### PR TITLE
Add back navigation to WordList screen

### DIFF
--- a/app/src/androidTest/java/com/procrastilearn/app/navigation/BottomNavigationBarTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/navigation/BottomNavigationBarTest.kt
@@ -1,0 +1,105 @@
+package com.procrastilearn.app.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.procrastilearn.app.R
+import com.procrastilearn.app.ui.theme.MyApplicationTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BottomNavigationBarTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun clickingAddWordNavItemFromWordListNavigatesBackToAddWord() {
+        lateinit var navController: androidx.navigation.NavHostController
+
+        composeTestRule.setContent {
+            navController = rememberNavController()
+            MyApplicationTheme(dynamicColor = false) {
+                Scaffold(
+                    bottomBar = { BottomNavigationBar(navController = navController) },
+                ) { padding ->
+                    NavHost(
+                        navController = navController,
+                        startDestination = Screen.AddWord.route,
+                        modifier = Modifier.fillMaxSize().padding(padding),
+                    ) {
+                        composable(Screen.Apps.route) { Text(APPS_TEXT) }
+                        composable(Screen.AddWord.route) { Text(ADD_WORD_TEXT) }
+                        composable(Screen.WordList.route) { Text(WORD_LIST_TEXT) }
+                        composable(Screen.Dojo.route) { Text(DOJO_TEXT) }
+                        composable(Screen.Settings.route) { Text(SETTINGS_TEXT) }
+                    }
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            navController.navigate(Screen.WordList.route)
+        }
+        composeTestRule.onNodeWithText(WORD_LIST_TEXT).assertExists()
+
+        composeTestRule
+            .onNodeWithText(
+                composeTestRule.activity.getString(R.string.nav_add_word),
+            ).performClick()
+
+        composeTestRule.onNodeWithText(ADD_WORD_TEXT).assertExists()
+    }
+
+    @Test
+    fun clickingOtherNavItemsStillNavigatesNormally() {
+        lateinit var navController: androidx.navigation.NavHostController
+
+        composeTestRule.setContent {
+            navController = rememberNavController()
+            MyApplicationTheme(dynamicColor = false) {
+                Scaffold(
+                    bottomBar = { BottomNavigationBar(navController = navController) },
+                ) { padding ->
+                    NavHost(
+                        navController = navController,
+                        startDestination = Screen.AddWord.route,
+                        modifier = Modifier.fillMaxSize().padding(padding),
+                    ) {
+                        composable(Screen.Apps.route) { Text(APPS_TEXT) }
+                        composable(Screen.AddWord.route) { Text(ADD_WORD_TEXT) }
+                        composable(Screen.WordList.route) { Text(WORD_LIST_TEXT) }
+                        composable(Screen.Dojo.route) { Text(DOJO_TEXT) }
+                        composable(Screen.Settings.route) { Text(SETTINGS_TEXT) }
+                    }
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(
+                composeTestRule.activity.getString(R.string.nav_dojo),
+            ).performClick()
+
+        composeTestRule.onNodeWithText(DOJO_TEXT).assertExists()
+    }
+
+    private companion object {
+        const val APPS_TEXT = "apps_screen"
+        const val ADD_WORD_TEXT = "add_word_screen"
+        const val WORD_LIST_TEXT = "word_list_screen"
+        const val DOJO_TEXT = "dojo_screen"
+        const val SETTINGS_TEXT = "settings_screen"
+    }
+}

--- a/app/src/androidTest/java/com/procrastilearn/app/ui/screens/WordListScreenBackNavigationTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/ui/screens/WordListScreenBackNavigationTest.kt
@@ -1,0 +1,74 @@
+package com.procrastilearn.app.ui.screens
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.procrastilearn.app.R
+import com.procrastilearn.app.ui.theme.MyApplicationTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WordListScreenBackNavigationTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun backButtonIsDisplayedNextToTitle() {
+        composeTestRule.setContent {
+            MyApplicationTheme(dynamicColor = false) {
+                WordListContent(
+                    words = emptyList(),
+                    searchQuery = "",
+                    onSearchQueryChange = {},
+                    onDelete = {},
+                    onEdit = {},
+                    onReset = {},
+                    onNavigateBack = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(
+                composeTestRule.activity.getString(R.string.word_list_navigate_back),
+            ).assertExists()
+        composeTestRule
+            .onNodeWithText(
+                composeTestRule.activity.getString(R.string.word_list_title),
+            ).assertExists()
+    }
+
+    @Test
+    fun clickingBackButtonInvokesCallback() {
+        var backClicked = 0
+
+        composeTestRule.setContent {
+            MyApplicationTheme(dynamicColor = false) {
+                WordListContent(
+                    words = emptyList(),
+                    searchQuery = "",
+                    onSearchQueryChange = {},
+                    onDelete = {},
+                    onEdit = {},
+                    onReset = {},
+                    onNavigateBack = { backClicked++ },
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(
+                composeTestRule.activity.getString(R.string.word_list_navigate_back),
+            ).performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, backClicked)
+        }
+    }
+}

--- a/app/src/main/java/com/procrastilearn/app/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/procrastilearn/app/navigation/BottomNavigationBar.kt
@@ -59,12 +59,18 @@ fun BottomNavigationBar(navController: NavController) {
             NavigationBarItem(
                 selected = currentRoute == item.screen.route,
                 onClick = {
-                    navController.navigate(item.screen.route) {
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            saveState = true
+                    val poppedToDestination =
+                        item.screen == Screen.AddWord &&
+                            currentRoute == Screen.WordList.route &&
+                            navController.popBackStack(Screen.AddWord.route, inclusive = false)
+                    if (!poppedToDestination) {
+                        navController.navigate(item.screen.route) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
                         }
-                        launchSingleTop = true
-                        restoreState = true
                     }
                 },
                 icon = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -61,7 +62,10 @@ import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollba
 import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
 
 @Composable
-fun WordListScreen(viewModel: WordListViewModel = hiltViewModel()) {
+fun WordListScreen(
+    onNavigateBack: () -> Unit = {},
+    viewModel: WordListViewModel = hiltViewModel(),
+) {
     val words by viewModel.words.collectAsState()
     var searchQuery by rememberSaveable { mutableStateOf("") }
 
@@ -72,12 +76,13 @@ fun WordListScreen(viewModel: WordListViewModel = hiltViewModel()) {
         onDelete = viewModel::deleteWord,
         onEdit = viewModel::updateWord,
         onReset = viewModel::resetWordProgress,
+        onNavigateBack = onNavigateBack,
     )
 }
 
 @Composable
 @Suppress("LongMethod")
-private fun WordListContent(
+internal fun WordListContent(
     words: List<VocabularyItem>,
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,
@@ -85,6 +90,7 @@ private fun WordListContent(
     onEdit: (VocabularyItem) -> Unit,
     onReset: (VocabularyItem) -> Unit,
     modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit = {},
 ) {
     val normalizedQuery = searchQuery.trim()
     val displayedWords =
@@ -101,13 +107,24 @@ private fun WordListContent(
                 .padding(16.dp),
     ) {
         // Header
-        Text(
-            text = stringResource(R.string.word_list_title),
-            style = MaterialTheme.typography.headlineMedium,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.primary,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(bottom = 16.dp),
-        )
+        ) {
+            IconButton(onClick = onNavigateBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(R.string.word_list_navigate_back),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Text(
+                text = stringResource(R.string.word_list_title),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
 
         OutlinedTextField(
             value = searchQuery,

--- a/app/src/main/java/com/procrastilearn/app/ui/views/MainScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/views/MainScreen.kt
@@ -36,7 +36,7 @@ fun MainScreen() {
                 AddWordScreen(onNavigateToList = { navController.navigate(Screen.WordList.route) })
             }
             composable(Screen.WordList.route) {
-                WordListScreen()
+                WordListScreen(onNavigateBack = { navController.popBackStack() })
             }
             composable(Screen.Dojo.route) {
                 DojoScreen()

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -194,6 +194,7 @@
 
         <!-- ─── Vocabulary list ─────────────────────────────────────────────────── -->
         <string name="word_list_title">Мой словарь</string>
+        <string name="word_list_navigate_back">Назад к добавлению слова</string>
         <string name="word_list_empty">Вы ещё не добавили слов</string>
         <string name="word_list_delete_confirm_title">Удалить слово</string>
         <string name="word_list_delete_confirm_message">Удалить %1$s из списка?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
 
     <!-- ─── Vocabulary list ─────────────────────────────────────────────────── -->
     <string name="word_list_title">My Vocabulary</string>
+    <string name="word_list_navigate_back">Back to add word</string>
     <string name="word_list_empty">No words added yet</string>
     <string name="word_list_delete_confirm_title">Delete word</string>
     <string name="word_list_delete_confirm_message">


### PR DESCRIPTION
## Summary
Adds a back button to the WordList screen that navigates users back to the AddWord screen, improving navigation flow between these two main screens.

## Key Changes
- **WordListScreen**: Added `onNavigateBack` callback parameter and integrated a back button in the header
- **BottomNavigationBar**: Enhanced navigation logic to use `popBackStack()` when navigating from WordList back to AddWord, preserving the natural back-stack behavior
- **MainScreen**: Connected the back button callback to trigger `navController.popBackStack()`
- **Strings**: Added `word_list_navigate_back` resource for the back button's content description
- **Tests**: Added comprehensive instrumented tests:
  - `BottomNavigationBarTest`: Verifies that clicking AddWord from WordList uses back-stack navigation
  - `WordListScreenBackNavigationTest`: Validates back button presence and callback invocation

## Implementation Details
The back button uses Material Design's `ArrowBack` icon and is positioned next to the "My Vocabulary" title in a Row layout. The BottomNavigationBar now intelligently detects when the user is on WordList and attempts to navigate back to AddWord via `popBackStack()` before falling back to standard navigation, ensuring consistent back-stack behavior whether users navigate via the bottom bar or the screen's back button.

https://claude.ai/code/session_01WvKxBB14EGQRUBJ7tPDKkn