### PR TITLE
Add "ProcrastiLearn this" text-selection action

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,11 +30,18 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.MyApplication">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- Adds "ProcrastiLearn this" to the text-selection context menu in other apps. -->
+            <intent-filter android:label="@string/process_text_action">
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/procrastilearn/app/MainActivity.kt
+++ b/app/src/main/java/com/procrastilearn/app/MainActivity.kt
@@ -27,14 +27,17 @@ import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.lifecycleScope
+import com.procrastilearn.app.data.text.ProcessTextEventBus
 import com.procrastilearn.app.ui.components.OverlayPermissionDialog
 import com.procrastilearn.app.ui.components.ProminentA11yDisclosureScreen
 import com.procrastilearn.app.ui.theme.MyApplicationTheme
 import com.procrastilearn.app.ui.views.MainScreen
+import com.procrastilearn.app.utils.extractProcessText
 import com.procrastilearn.app.utils.isPermissionsGranted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 private val Context.dataStore by preferencesDataStore("app_prefs")
 private val KEY_ACCESSIBILITY_SKIPPED = booleanPreferencesKey("accessibility_skipped")
@@ -42,10 +45,14 @@ private val KEY_OVERLAY_SKIPPED = booleanPreferencesKey("overlay_skipped")
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject
+    lateinit var processTextEventBus: ProcessTextEventBus
+
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        handleProcessTextIntent(intent)
 
         setContent {
             MyApplicationTheme {
@@ -158,6 +165,16 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleProcessTextIntent(intent)
+    }
+
+    private fun handleProcessTextIntent(intent: Intent?) {
+        extractProcessText(intent)?.let { processTextEventBus.submit(it) }
     }
 
     private fun openAccessibilitySettings() {

--- a/app/src/main/java/com/procrastilearn/app/data/text/ProcessTextEventBus.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/text/ProcessTextEventBus.kt
@@ -7,9 +7,9 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Bridges an incoming ACTION_PROCESS_TEXT intent (from the "ProcrastiLearn this" text-selection
- * action) from [com.procrastilearn.app.MainActivity] to the Add-Word screen, since nav routes
- * take no arguments and the receiving ViewModel may not exist yet when the intent arrives.
+ * Bridges an incoming ACTION_PROCESS_TEXT intent from [com.procrastilearn.app.MainActivity]
+ * to the Add-Word screen, since nav routes take no arguments and the receiving ViewModel
+ * may not exist yet when the intent arrives.
  */
 @Singleton
 class ProcessTextEventBus

--- a/app/src/main/java/com/procrastilearn/app/data/text/ProcessTextEventBus.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/text/ProcessTextEventBus.kt
@@ -1,0 +1,28 @@
+package com.procrastilearn.app.data.text
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Bridges an incoming ACTION_PROCESS_TEXT intent (from the "ProcrastiLearn this" text-selection
+ * action) from [com.procrastilearn.app.MainActivity] to the Add-Word screen, since nav routes
+ * take no arguments and the receiving ViewModel may not exist yet when the intent arrives.
+ */
+@Singleton
+class ProcessTextEventBus
+    @Inject
+    constructor() {
+        private val _events = MutableStateFlow<String?>(null)
+        val events: StateFlow<String?> = _events.asStateFlow()
+
+        fun submit(text: String) {
+            _events.value = text
+        }
+
+        fun consume() {
+            _events.value = null
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.procrastilearn.app.data.connectivity.NetworkConnectivityObserver
 import com.procrastilearn.app.data.local.prefs.OpenAiPreferencesStore
+import com.procrastilearn.app.data.text.ProcessTextEventBus
 import com.procrastilearn.app.domain.model.AiTranslationDirection
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.AddVocabularyItemUseCase
@@ -19,11 +20,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class AddWordViewModel @Inject
     constructor(
         private val addVocabularyItemUseCase: AddVocabularyItemUseCase,
@@ -35,6 +37,7 @@ class AddWordViewModel @Inject
         private val observePendingWordsUseCase: ObservePendingWordsUseCase,
         private val deletePendingWordUseCase: DeletePendingWordUseCase,
         private val connectivityObserver: NetworkConnectivityObserver,
+        private val processTextEventBus: ProcessTextEventBus = ProcessTextEventBus(),
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(AddWordUiState())
         private var pendingOverride: PendingOverrideSubmission? = null
@@ -72,6 +75,42 @@ class AddWordViewModel @Inject
                             pendingWords = pendingWords.map { PendingWordUi(id = it.id, word = it.word) },
                         )
                 }
+            }
+
+            viewModelScope.launch {
+                processTextEventBus.events.collectLatest { text ->
+                    if (!text.isNullOrBlank()) {
+                        prefillFromProcessText(text)
+                        processTextEventBus.consume()
+                    }
+                }
+            }
+        }
+
+        private suspend fun prefillFromProcessText(rawText: String) {
+            val word = rawText.trim()
+            if (word.isBlank()) return
+
+            val hasKey = !openAiStore.readOpenAiApiKey().first().isNullOrBlank()
+            val useAi = openAiStore.readUseAiForTranslation().first()
+
+            _uiState.value =
+                _uiState.value.copy(
+                    word = word,
+                    translation = "",
+                    wordError = null,
+                    translationError = null,
+                    openAiAvailable = hasKey,
+                    useAiForTranslation = useAi,
+                    previewContent = null,
+                    isPreviewVisible = false,
+                    errorMessage = null,
+                    successMessage = null,
+                    isSuccess = false,
+                )
+
+            if (hasKey && useAi && _uiState.value.isOnline) {
+                onPreviewClick()
             }
         }
 

--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList")
 class AddWordViewModel @Inject
     constructor(
         private val addVocabularyItemUseCase: AddVocabularyItemUseCase,
@@ -80,37 +80,29 @@ class AddWordViewModel @Inject
             viewModelScope.launch {
                 processTextEventBus.events.collectLatest { text ->
                     if (!text.isNullOrBlank()) {
-                        prefillFromProcessText(text)
+                        val prefill = resolveProcessTextPrefill(openAiStore, text)
+                        if (prefill != null) {
+                            _uiState.value =
+                                _uiState.value.copy(
+                                    word = prefill.word,
+                                    translation = "",
+                                    wordError = null,
+                                    translationError = null,
+                                    openAiAvailable = prefill.hasKey,
+                                    useAiForTranslation = prefill.useAi,
+                                    previewContent = null,
+                                    isPreviewVisible = false,
+                                    errorMessage = null,
+                                    successMessage = null,
+                                    isSuccess = false,
+                                )
+                            if (prefill.hasKey && prefill.useAi && _uiState.value.isOnline) {
+                                onPreviewClick()
+                            }
+                        }
                         processTextEventBus.consume()
                     }
                 }
-            }
-        }
-
-        private suspend fun prefillFromProcessText(rawText: String) {
-            val word = rawText.trim()
-            if (word.isBlank()) return
-
-            val hasKey = !openAiStore.readOpenAiApiKey().first().isNullOrBlank()
-            val useAi = openAiStore.readUseAiForTranslation().first()
-
-            _uiState.value =
-                _uiState.value.copy(
-                    word = word,
-                    translation = "",
-                    wordError = null,
-                    translationError = null,
-                    openAiAvailable = hasKey,
-                    useAiForTranslation = useAi,
-                    previewContent = null,
-                    isPreviewVisible = false,
-                    errorMessage = null,
-                    successMessage = null,
-                    isSuccess = false,
-                )
-
-            if (hasKey && useAi && _uiState.value.isOnline) {
-                onPreviewClick()
             }
         }
 
@@ -586,4 +578,22 @@ enum class AddWordLoadingAction {
     ADD,
     PREVIEW,
     PREVIEW_CONFIRM,
+}
+
+internal data class ProcessTextPrefill(
+    val word: String,
+    val hasKey: Boolean,
+    val useAi: Boolean,
+)
+
+internal suspend fun resolveProcessTextPrefill(
+    openAiStore: OpenAiPreferencesStore,
+    rawText: String,
+): ProcessTextPrefill? {
+    val word = rawText.trim()
+    if (word.isBlank()) return null
+
+    val hasKey = !openAiStore.readOpenAiApiKey().first().isNullOrBlank()
+    val useAi = openAiStore.readUseAiForTranslation().first()
+    return ProcessTextPrefill(word, hasKey, useAi)
 }

--- a/app/src/main/java/com/procrastilearn/app/ui/views/MainScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/views/MainScreen.kt
@@ -3,7 +3,12 @@ package com.procrastilearn.app.ui.views
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -16,8 +21,21 @@ import com.procrastilearn.app.ui.screens.WordListScreen
 import com.procrastilearn.app.ui.screens.settings.SettingsScreen
 
 @Composable
-fun MainScreen() {
+fun MainScreen(mainViewModel: MainViewModel = hiltViewModel()) {
     val navController = rememberNavController()
+
+    val processTextEvent by mainViewModel.processTextEvents.collectAsStateWithLifecycle()
+    LaunchedEffect(processTextEvent) {
+        if (processTextEvent != null) {
+            navController.navigate(Screen.AddWord.route) {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = true
+            }
+        }
+    }
 
     Scaffold(
         bottomBar = {

--- a/app/src/main/java/com/procrastilearn/app/ui/views/MainViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/views/MainViewModel.kt
@@ -1,0 +1,16 @@
+package com.procrastilearn.app.ui.views
+
+import androidx.lifecycle.ViewModel
+import com.procrastilearn.app.data.text.ProcessTextEventBus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel
+    @Inject
+    constructor(
+        processTextEventBus: ProcessTextEventBus,
+    ) : ViewModel() {
+        val processTextEvents: StateFlow<String?> = processTextEventBus.events
+    }

--- a/app/src/main/java/com/procrastilearn/app/utils/ProcessTextIntent.kt
+++ b/app/src/main/java/com/procrastilearn/app/utils/ProcessTextIntent.kt
@@ -1,0 +1,13 @@
+package com.procrastilearn.app.utils
+
+import android.content.Intent
+
+/**
+ * Extracts the selected text from an ACTION_PROCESS_TEXT intent (the "ProcrastiLearn this"
+ * text-selection action), or null if the intent doesn't carry one.
+ */
+fun extractProcessText(intent: Intent?): String? {
+    if (intent?.action != Intent.ACTION_PROCESS_TEXT) return null
+    val selectedText = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)?.toString()
+    return selectedText?.takeIf { it.isNotBlank() }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -26,6 +26,9 @@
         <string name="word_list_delete">@string/action_delete</string>
         <string name="add_word_view_list">@string/action_view_list</string>
 
+        <!-- ─── Text selection context menu ─────────────────────────────────────── -->
+        <string name="process_text_action">Добавить в ProcrastiLearn</string>
+
         <!-- ─── Navigation ──────────────────────────────────────────────────────── -->
         <string name="nav_apps">Приложения</string>
         <string name="nav_add_word">Добавить слово</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="word_list_delete">@string/action_delete</string>
     <string name="add_word_view_list">@string/action_view_list</string>
 
+    <!-- ─── Text selection context menu ─────────────────────────────────────── -->
+    <string name="process_text_action">ProcrastiLearn this</string>
+
     <!-- ─── Navigation ──────────────────────────────────────────────────────── -->
     <string name="nav_apps">Apps</string>
     <string name="nav_add_word">Add Word</string>

--- a/app/src/test/java/com/procrastilearn/app/data/text/ProcessTextEventBusTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/text/ProcessTextEventBusTest.kt
@@ -1,0 +1,59 @@
+package com.procrastilearn.app.data.text
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProcessTextEventBusTest {
+    @Test
+    fun `starts with no pending event`() =
+        runTest {
+            val bus = ProcessTextEventBus()
+
+            assertThat(bus.events.value).isNull()
+        }
+
+    @Test
+    fun `submit publishes the text`() =
+        runTest {
+            val bus = ProcessTextEventBus()
+
+            bus.submit("Haus")
+
+            assertThat(bus.events.value).isEqualTo("Haus")
+        }
+
+    @Test
+    fun `consume clears the pending event`() =
+        runTest {
+            val bus = ProcessTextEventBus()
+            bus.submit("Haus")
+
+            bus.consume()
+
+            assertThat(bus.events.value).isNull()
+        }
+
+    @Test
+    fun `submit overwrites a previously pending event`() =
+        runTest {
+            val bus = ProcessTextEventBus()
+            bus.submit("Haus")
+
+            bus.submit("Katze")
+
+            assertThat(bus.events.value).isEqualTo("Katze")
+        }
+
+    @Test
+    fun `consume without a pending event is a no-op`() =
+        runTest {
+            val bus = ProcessTextEventBus()
+
+            bus.consume()
+
+            assertThat(bus.events.value).isNull()
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt
@@ -1,0 +1,267 @@
+package com.procrastilearn.app.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.connectivity.NetworkConnectivityObserver
+import com.procrastilearn.app.data.local.prefs.OpenAiPreferencesStore
+import com.procrastilearn.app.data.text.ProcessTextEventBus
+import com.procrastilearn.app.data.translation.AiTranslationProvider
+import com.procrastilearn.app.data.translation.AiTranslationRequest
+import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.usecase.AddVocabularyItemUseCase
+import com.procrastilearn.app.domain.usecase.DeletePendingWordUseCase
+import com.procrastilearn.app.domain.usecase.GenerateAiTranslationUseCase
+import com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase
+import com.procrastilearn.app.domain.usecase.ObservePendingWordsUseCase
+import com.procrastilearn.app.domain.usecase.OverrideVocabularyItemUseCase
+import com.procrastilearn.app.domain.usecase.QueuePendingWordUseCase
+import com.procrastilearn.app.utils.MainDispatcherRule
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Covers the "ProcrastiLearn this" text-selection prefill flow, kept in its own file so
+ * [AddWordViewModelTest] doesn't grow past detekt's LargeClass threshold.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddWordViewModelProcessTextTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var addVocabularyItemUseCase: AddVocabularyItemUseCase
+    private lateinit var getVocabularyItemByWordUseCase: GetVocabularyItemByWordUseCase
+    private lateinit var overrideVocabularyItemUseCase: OverrideVocabularyItemUseCase
+    private lateinit var queuePendingWordUseCase: QueuePendingWordUseCase
+    private lateinit var observePendingWordsUseCase: ObservePendingWordsUseCase
+    private lateinit var deletePendingWordUseCase: DeletePendingWordUseCase
+    private lateinit var connectivityObserver: NetworkConnectivityObserver
+    private lateinit var openAiStore: OpenAiPreferencesStore
+    private lateinit var generateAiTranslationUseCase: GenerateAiTranslationUseCase
+    private lateinit var openAiKeyFlow: MutableStateFlow<String?>
+    private lateinit var useAiFlow: MutableStateFlow<Boolean>
+    private lateinit var directionFlow: MutableStateFlow<AiTranslationDirection>
+    private lateinit var onlineFlow: MutableStateFlow<Boolean>
+    private lateinit var pendingWordsFlow: MutableStateFlow<List<PendingWord>>
+    private lateinit var aiTranslationProvider: FakeAiTranslationProvider
+    private lateinit var processTextEventBus: ProcessTextEventBus
+
+    @Before
+    fun setUp() {
+        addVocabularyItemUseCase = mockk()
+        getVocabularyItemByWordUseCase = mockk()
+        overrideVocabularyItemUseCase = mockk()
+        queuePendingWordUseCase = mockk()
+        observePendingWordsUseCase = mockk()
+        deletePendingWordUseCase = mockk()
+        connectivityObserver = mockk()
+        openAiStore = mockk(relaxed = true)
+        openAiKeyFlow = MutableStateFlow(null)
+        useAiFlow = MutableStateFlow(false)
+        directionFlow = MutableStateFlow(AiTranslationDirection.EN_TO_RU)
+        onlineFlow = MutableStateFlow(true)
+        pendingWordsFlow = MutableStateFlow(emptyList())
+        aiTranslationProvider = FakeAiTranslationProvider()
+        generateAiTranslationUseCase =
+            GenerateAiTranslationUseCase(aiTranslationProvider, openAiStore, mainDispatcherRule.testDispatcher)
+        processTextEventBus = ProcessTextEventBus()
+
+        every { openAiStore.readOpenAiApiKey() } returns openAiKeyFlow
+        every { openAiStore.readUseAiForTranslation() } returns useAiFlow
+        every { openAiStore.readOpenAiPrompt() } returns MutableStateFlow("system prompt")
+        every { openAiStore.readOpenAiReversePrompt() } returns MutableStateFlow("reverse system prompt")
+        every { openAiStore.readAiTranslationDirection() } returns directionFlow
+        coEvery { getVocabularyItemByWordUseCase.invoke(any()) } returns null
+        every { connectivityObserver.observe() } returns onlineFlow
+        every { observePendingWordsUseCase.invoke() } returns pendingWordsFlow
+        coEvery { queuePendingWordUseCase.invoke(any(), any()) } just Runs
+        coEvery { deletePendingWordUseCase.invoke(any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    private fun buildViewModel(): AddWordViewModel =
+        AddWordViewModel(
+            addVocabularyItemUseCase,
+            getVocabularyItemByWordUseCase,
+            overrideVocabularyItemUseCase,
+            openAiStore,
+            generateAiTranslationUseCase,
+            queuePendingWordUseCase,
+            observePendingWordsUseCase,
+            deletePendingWordUseCase,
+            connectivityObserver,
+            processTextEventBus,
+        )
+
+    @Test
+    fun `process text event with AI active prefills word and triggers preview`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            openAiKeyFlow.value = "abc"
+            useAiFlow.value = true
+            aiTranslationProvider.nextTranslation = "House"
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            processTextEventBus.submit("Haus")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.word).isEqualTo("Haus")
+            assertThat(state.isPreviewVisible).isTrue()
+            assertThat(state.previewContent?.word).isEqualTo("Haus")
+            assertThat(state.previewContent?.translation).isEqualTo("House")
+            assertThat(aiTranslationProvider.requests).hasSize(1)
+        }
+
+    @Test
+    fun `process text event with AI disabled prefills word and leaves translation empty`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            processTextEventBus.submit("Haus")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.word).isEqualTo("Haus")
+            assertThat(state.translation).isEmpty()
+            assertThat(state.isPreviewVisible).isFalse()
+            assertThat(state.previewContent).isNull()
+            assertThat(aiTranslationProvider.requests).isEmpty()
+        }
+
+    @Test
+    fun `process text event with AI toggle on but no api key does not trigger preview`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            useAiFlow.value = true
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            processTextEventBus.submit("Haus")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.word).isEqualTo("Haus")
+            assertThat(state.translation).isEmpty()
+            assertThat(state.isPreviewVisible).isFalse()
+            assertThat(aiTranslationProvider.requests).isEmpty()
+        }
+
+    @Test
+    fun `process text event while offline in AI mode prefills without triggering preview`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            openAiKeyFlow.value = "abc"
+            useAiFlow.value = true
+            onlineFlow.value = false
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            processTextEventBus.submit("Haus")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.word).isEqualTo("Haus")
+            assertThat(state.translation).isEmpty()
+            assertThat(state.isPreviewVisible).isFalse()
+            assertThat(aiTranslationProvider.requests).isEmpty()
+        }
+
+    @Test
+    fun `process text event trims whitespace from selected text`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            processTextEventBus.submit("  Haus  \n")
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.word).isEqualTo("Haus")
+        }
+
+    @Test
+    fun `process text event with blank text is ignored`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            viewModel.onWordChange("existing")
+            advanceUntilIdle()
+
+            processTextEventBus.submit("   ")
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.word).isEqualTo("existing")
+        }
+
+    @Test
+    fun `process text event is consumed from the bus after handling`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            buildViewModel()
+            advanceUntilIdle()
+
+            processTextEventBus.submit("Haus")
+            advanceUntilIdle()
+
+            assertThat(processTextEventBus.events.value).isNull()
+        }
+
+    @Test
+    fun `process text event overwrites a previously prefilled word and preview state`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            openAiKeyFlow.value = "abc"
+            useAiFlow.value = true
+            aiTranslationProvider.nextTranslation = "House"
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            processTextEventBus.submit("Haus")
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.isPreviewVisible).isTrue()
+
+            aiTranslationProvider.nextTranslation = "Cat"
+            processTextEventBus.submit("Katze")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.word).isEqualTo("Katze")
+            assertThat(state.previewContent?.word).isEqualTo("Katze")
+            assertThat(state.previewContent?.translation).isEqualTo("Cat")
+        }
+
+    @Test
+    fun `process text event received before AI preferences load still applies once they arrive`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+
+            processTextEventBus.submit("Haus")
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.word).isEqualTo("Haus")
+            assertThat(viewModel.uiState.value.isPreviewVisible).isFalse()
+        }
+
+    private class FakeAiTranslationProvider : AiTranslationProvider {
+        var nextTranslation: String = "House"
+        var nextError: Throwable? = null
+        val requests = mutableListOf<AiTranslationRequest>()
+
+        override suspend fun translate(request: AiTranslationRequest): String {
+            requests += request
+            nextError?.let { throw it }
+            return nextTranslation
+        }
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt
@@ -31,10 +31,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-/**
- * Covers the "ProcrastiLearn this" text-selection prefill flow, kept in its own file so
- * [AddWordViewModelTest] doesn't grow past detekt's LargeClass threshold.
- */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AddWordViewModelProcessTextTest {
     @get:Rule

--- a/app/src/test/java/com/procrastilearn/app/ui/ProcessTextPrefillResolverTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/ProcessTextPrefillResolverTest.kt
@@ -10,10 +10,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
-/**
- * Unit tests for the [resolveProcessTextPrefill] helper extracted out of [AddWordViewModel],
- * covering it directly rather than only through the ViewModel's behavior.
- */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProcessTextPrefillResolverTest {
     private lateinit var openAiStore: OpenAiPreferencesStore

--- a/app/src/test/java/com/procrastilearn/app/ui/ProcessTextPrefillResolverTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/ProcessTextPrefillResolverTest.kt
@@ -1,0 +1,106 @@
+package com.procrastilearn.app.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.prefs.OpenAiPreferencesStore
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for the [resolveProcessTextPrefill] helper extracted out of [AddWordViewModel],
+ * covering it directly rather than only through the ViewModel's behavior.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProcessTextPrefillResolverTest {
+    private lateinit var openAiStore: OpenAiPreferencesStore
+    private lateinit var openAiKeyFlow: MutableStateFlow<String?>
+    private lateinit var useAiFlow: MutableStateFlow<Boolean>
+
+    @Before
+    fun setUp() {
+        openAiStore = mockk()
+        openAiKeyFlow = MutableStateFlow(null)
+        useAiFlow = MutableStateFlow(false)
+        every { openAiStore.readOpenAiApiKey() } returns openAiKeyFlow
+        every { openAiStore.readUseAiForTranslation() } returns useAiFlow
+    }
+
+    @Test
+    fun `returns null for blank text`() =
+        runTest {
+            val result = resolveProcessTextPrefill(openAiStore, "   ")
+
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `returns null for empty text`() =
+        runTest {
+            val result = resolveProcessTextPrefill(openAiStore, "")
+
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `trims surrounding whitespace from the word`() =
+        runTest {
+            val result = resolveProcessTextPrefill(openAiStore, "  Haus  \n")
+
+            assertThat(result?.word).isEqualTo("Haus")
+        }
+
+    @Test
+    fun `reports hasKey false when api key is missing`() =
+        runTest {
+            openAiKeyFlow.value = null
+
+            val result = resolveProcessTextPrefill(openAiStore, "Haus")
+
+            assertThat(result?.hasKey).isFalse()
+        }
+
+    @Test
+    fun `reports hasKey false when api key is blank`() =
+        runTest {
+            openAiKeyFlow.value = "   "
+
+            val result = resolveProcessTextPrefill(openAiStore, "Haus")
+
+            assertThat(result?.hasKey).isFalse()
+        }
+
+    @Test
+    fun `reports hasKey true when api key is present`() =
+        runTest {
+            openAiKeyFlow.value = "abc123"
+
+            val result = resolveProcessTextPrefill(openAiStore, "Haus")
+
+            assertThat(result?.hasKey).isTrue()
+        }
+
+    @Test
+    fun `reports useAi from the preference store`() =
+        runTest {
+            useAiFlow.value = true
+
+            val result = resolveProcessTextPrefill(openAiStore, "Haus")
+
+            assertThat(result?.useAi).isTrue()
+        }
+
+    @Test
+    fun `combines word key and toggle state into the result`() =
+        runTest {
+            openAiKeyFlow.value = "abc123"
+            useAiFlow.value = true
+
+            val result = resolveProcessTextPrefill(openAiStore, "Katze")
+
+            assertThat(result).isEqualTo(ProcessTextPrefill(word = "Katze", hasKey = true, useAi = true))
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/views/MainViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/views/MainViewModelTest.kt
@@ -1,0 +1,28 @@
+package com.procrastilearn.app.ui.views
+
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.text.ProcessTextEventBus
+import com.procrastilearn.app.utils.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `exposes the event bus text as process text events`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val bus = ProcessTextEventBus()
+            val viewModel = MainViewModel(bus)
+
+            assertThat(viewModel.processTextEvents.value).isNull()
+
+            bus.submit("Haus")
+
+            assertThat(viewModel.processTextEvents.value).isEqualTo("Haus")
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/utils/ProcessTextIntentTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/utils/ProcessTextIntentTest.kt
@@ -1,0 +1,52 @@
+package com.procrastilearn.app.utils
+
+import android.content.Intent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ProcessTextIntentTest {
+    @Test
+    fun `returns the selected text for a PROCESS_TEXT intent`() {
+        val intent =
+            Intent(Intent.ACTION_PROCESS_TEXT).apply {
+                putExtra(Intent.EXTRA_PROCESS_TEXT, "Haus")
+            }
+
+        assertThat(extractProcessText(intent)).isEqualTo("Haus")
+    }
+
+    @Test
+    fun `returns null when the intent action is not PROCESS_TEXT`() {
+        val intent =
+            Intent(Intent.ACTION_MAIN).apply {
+                putExtra(Intent.EXTRA_PROCESS_TEXT, "Haus")
+            }
+
+        assertThat(extractProcessText(intent)).isNull()
+    }
+
+    @Test
+    fun `returns null when the intent is null`() {
+        assertThat(extractProcessText(null)).isNull()
+    }
+
+    @Test
+    fun `returns null when the extra is missing`() {
+        val intent = Intent(Intent.ACTION_PROCESS_TEXT)
+
+        assertThat(extractProcessText(intent)).isNull()
+    }
+
+    @Test
+    fun `returns null when the extra is blank`() {
+        val intent =
+            Intent(Intent.ACTION_PROCESS_TEXT).apply {
+                putExtra(Intent.EXTRA_PROCESS_TEXT, "   ")
+            }
+
+        assertThat(extractProcessText(intent)).isNull()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `ACTION_PROCESS_TEXT` intent-filter to `MainActivity`, labeled **"ProcrastiLearn this"**, so it appears in the text-selection context menu of any app
- Selecting it opens the app on the Add Word screen with the selected text prefilled as the word
- If AI translation is active (toggle on, API key saved, device online), the existing AI preview flow is automatically triggered so the user just confirms; otherwise the translation field is left blank for manual entry
- Offline-with-AI-enabled naturally falls back to the existing "add later" queue behavior — no special-casing needed

## Implementation
- `ProcessTextEventBus` (new `@Singleton`) bridges the incoming intent from `MainActivity` to `AddWordViewModel`, since nav routes take no arguments and the ViewModel may not exist yet when the intent arrives
- `MainActivity` parses `EXTRA_PROCESS_TEXT` in both `onCreate` and `onNewIntent` (activity is now `launchMode="singleTop"`) via a small pure helper (`extractProcessText`) kept outside the Activity for testability
- `MainScreen`/new `MainViewModel` navigate to the Add Word tab when an event arrives
- `AddWordViewModel` prefills the word and reuses the existing `onPreviewClick()` preview flow when AI is active

## Test plan
- [x] `./gradlew testDebugUnitTest` — all tests pass (new tests cover: AI active → prefill + preview; AI disabled → prefill only; AI on but no key; offline; whitespace trimming; blank text ignored; bus consumption; event re-entrancy; intent-parsing edge cases)
- [x] `./gradlew ktlintCheck detekt lintDebug`
- [x] `./gradlew assembleDebug`
- [ ] Manual: select text in another app → confirm "ProcrastiLearn this" appears in the toolbar → tap it → verify prefill/preview behavior on a device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mui1Rcwqpb9tzzD28RFjdp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mui1Rcwqpb9tzzD28RFjdp)_