### PR TITLE
feat: queue and retry AI translations that fail while online

### DIFF
--- a/app/schemas/com.procrastilearn.app.data.local.database.AppDatabase/3.json
+++ b/app/schemas/com.procrastilearn.app.data.local.database.AppDatabase/3.json
@@ -1,0 +1,178 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "cd2620f216766cbf26e002fa136741f2",
+    "entities": [
+      {
+        "tableName": "vocabulary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `word` TEXT NOT NULL COLLATE NOCASE, `translation` TEXT NOT NULL COLLATE NOCASE, `createdAt` INTEGER NOT NULL, `lastShownAt` INTEGER, `correctCount` INTEGER NOT NULL, `incorrectCount` INTEGER NOT NULL, `fsrsCardJson` TEXT NOT NULL, `fsrsDueAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translation",
+            "columnName": "translation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastShownAt",
+            "columnName": "lastShownAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "correctCount",
+            "columnName": "correctCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incorrectCount",
+            "columnName": "incorrectCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fsrsCardJson",
+            "columnName": "fsrsCardJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fsrsDueAt",
+            "columnName": "fsrsDueAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_vocabulary_fsrsDueAt",
+            "unique": false,
+            "columnNames": [
+              "fsrsDueAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vocabulary_fsrsDueAt` ON `${TABLE_NAME}` (`fsrsDueAt`)"
+          },
+          {
+            "name": "index_vocabulary_correctCount_incorrectCount",
+            "unique": false,
+            "columnNames": [
+              "correctCount",
+              "incorrectCount"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vocabulary_correctCount_incorrectCount` ON `${TABLE_NAME}` (`correctCount`, `incorrectCount`)"
+          },
+          {
+            "name": "index_vocabulary_word",
+            "unique": true,
+            "columnNames": [
+              "word"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_vocabulary_word` ON `${TABLE_NAME}` (`word`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pending_words",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `word` TEXT NOT NULL COLLATE NOCASE, `direction` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `status` TEXT NOT NULL, `retryCount` INTEGER NOT NULL, `nextAttemptAt` INTEGER NOT NULL, `lastError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextAttemptAt",
+            "columnName": "nextAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_words_word",
+            "unique": true,
+            "columnNames": [
+              "word"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pending_words_word` ON `${TABLE_NAME}` (`word`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cd2620f216766cbf26e002fa136741f2')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/procrastilearn/app/data/local/database/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/data/local/database/AppDatabaseMigrationTest.kt
@@ -51,6 +51,45 @@ class AppDatabaseMigrationTest {
         }
     }
 
+    @Test
+    fun migrate2To3AddsRetryColumnsWithDefaultsAndKeepsExistingRows() {
+        helper.createDatabase(TEST_DB, 2).apply {
+            execSQL(
+                """
+                INSERT INTO pending_words (word, direction, createdAt) VALUES ('Haus', 'EN_TO_RU', 0)
+                """.trimIndent(),
+            )
+            close()
+        }
+
+        val migrated = helper.runMigrationsAndValidate(TEST_DB, 3, true, MIGRATION_2_3)
+
+        migrated.query("SELECT word, status, retryCount, nextAttemptAt, lastError FROM pending_words").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Haus", cursor.getString(0))
+            assertEquals("PENDING", cursor.getString(1))
+            assertEquals(0, cursor.getInt(2))
+            assertEquals(0L, cursor.getLong(3))
+            assertTrue(cursor.isNull(4))
+        }
+
+        migrated.execSQL(
+            """
+            INSERT INTO pending_words (word, direction, createdAt, status, retryCount, nextAttemptAt, lastError)
+            VALUES ('Auto', 'EN_TO_RU', 0, 'FAILED', 5, 12345, '401: unauthorized')
+            """.trimIndent(),
+        )
+        migrated.query(
+            "SELECT status, retryCount, nextAttemptAt, lastError FROM pending_words WHERE word = 'Auto'",
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("FAILED", cursor.getString(0))
+            assertEquals(5, cursor.getInt(1))
+            assertEquals(12345L, cursor.getLong(2))
+            assertEquals("401: unauthorized", cursor.getString(3))
+        }
+    }
+
     private companion object {
         const val TEST_DB = "migration-test"
     }

--- a/app/src/main/java/com/procrastilearn/app/data/local/dao/PendingWordDao.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/dao/PendingWordDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import com.procrastilearn.app.data.local.entity.PendingWordEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -18,6 +19,18 @@ interface PendingWordDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPendingWord(item: PendingWordEntity): Long
+
+    @Update
+    suspend fun updatePendingWord(item: PendingWordEntity)
+
+    @Query(
+        """
+        UPDATE pending_words
+        SET status = 'PENDING', retryCount = 0, nextAttemptAt = 0, lastError = NULL
+        WHERE id = :id
+        """,
+    )
+    suspend fun resetPendingWordForRetry(id: Long)
 
     @Delete
     suspend fun deletePendingWord(item: PendingWordEntity)

--- a/app/src/main/java/com/procrastilearn/app/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/database/AppDatabase.kt
@@ -9,7 +9,7 @@ import com.procrastilearn.app.data.local.entity.VocabularyEntity
 
 @Database(
     entities = [VocabularyEntity::class, PendingWordEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/procrastilearn/app/data/local/database/Migrations.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/database/Migrations.kt
@@ -21,3 +21,13 @@ val MIGRATION_1_2 =
             )
         }
     }
+
+val MIGRATION_2_3 =
+    object : Migration(2, 3) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE pending_words ADD COLUMN status TEXT NOT NULL DEFAULT 'PENDING'")
+            db.execSQL("ALTER TABLE pending_words ADD COLUMN retryCount INTEGER NOT NULL DEFAULT 0")
+            db.execSQL("ALTER TABLE pending_words ADD COLUMN nextAttemptAt INTEGER NOT NULL DEFAULT 0")
+            db.execSQL("ALTER TABLE pending_words ADD COLUMN lastError TEXT DEFAULT NULL")
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/data/local/entity/PendingWordEntity.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/entity/PendingWordEntity.kt
@@ -14,4 +14,8 @@ data class PendingWordEntity(
     @ColumnInfo(collate = ColumnInfo.NOCASE) val word: String,
     val direction: String,
     val createdAt: Long = System.currentTimeMillis(),
+    val status: String = "PENDING",
+    val retryCount: Int = 0,
+    val nextAttemptAt: Long = 0,
+    val lastError: String? = null,
 )

--- a/app/src/main/java/com/procrastilearn/app/data/local/mapper/PendingWordMapper.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/mapper/PendingWordMapper.kt
@@ -3,6 +3,7 @@ package com.procrastilearn.app.data.local.mapper
 import com.procrastilearn.app.data.local.entity.PendingWordEntity
 import com.procrastilearn.app.domain.model.AiTranslationDirection
 import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
 
 fun PendingWordEntity.toDomain(): PendingWord =
     PendingWord(
@@ -12,6 +13,12 @@ fun PendingWordEntity.toDomain(): PendingWord =
             runCatching { AiTranslationDirection.valueOf(direction) }
                 .getOrDefault(AiTranslationDirection.EN_TO_RU),
         createdAt = createdAt,
+        status =
+            runCatching { PendingWordStatus.valueOf(status) }
+                .getOrDefault(PendingWordStatus.PENDING),
+        retryCount = retryCount,
+        nextAttemptAt = nextAttemptAt,
+        lastError = lastError,
     )
 
 fun PendingWord.toEntity(): PendingWordEntity =
@@ -20,4 +27,8 @@ fun PendingWord.toEntity(): PendingWordEntity =
         word = word,
         direction = direction.name,
         createdAt = createdAt,
+        status = status.name,
+        retryCount = retryCount,
+        nextAttemptAt = nextAttemptAt,
+        lastError = lastError,
     )

--- a/app/src/main/java/com/procrastilearn/app/data/repository/PendingWordRepositoryImpl.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/repository/PendingWordRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.procrastilearn.app.data.local.mapper.toDomain
 import com.procrastilearn.app.data.local.mapper.toEntity
 import com.procrastilearn.app.domain.model.AiTranslationDirection
 import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.domain.repository.PendingWordRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -32,10 +33,28 @@ class PendingWordRepositoryImpl
         override suspend fun queuePendingWord(
             word: String,
             direction: AiTranslationDirection,
+            status: PendingWordStatus,
+            lastError: String?,
         ): Unit =
             withContext(io) {
-                val entity = PendingWord(word = word, direction = direction).toEntity()
+                val entity =
+                    PendingWord(
+                        word = word,
+                        direction = direction,
+                        status = status,
+                        lastError = lastError,
+                    ).toEntity()
                 pendingWordDao.insertPendingWord(entity)
+            }
+
+        override suspend fun updatePendingWord(pendingWord: PendingWord): Unit =
+            withContext(io) {
+                pendingWordDao.updatePendingWord(pendingWord.toEntity())
+            }
+
+        override suspend fun retryPendingWord(id: Long): Unit =
+            withContext(io) {
+                pendingWordDao.resetPendingWordForRetry(id)
             }
 
         override suspend fun deletePendingWord(pendingWord: PendingWord): Unit =

--- a/app/src/main/java/com/procrastilearn/app/data/sync/PendingWordSyncManager.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/sync/PendingWordSyncManager.kt
@@ -1,56 +1,85 @@
 package com.procrastilearn.app.data.sync
 
 import com.procrastilearn.app.data.connectivity.NetworkConnectivityObserver
+import com.procrastilearn.app.data.translation.ErrorClassification
+import com.procrastilearn.app.data.translation.TranslationErrorClassifier
 import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.domain.repository.PendingWordRepository
 import com.procrastilearn.app.domain.usecase.AddVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.GenerateAiTranslationUseCase
 import com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * App-wide singleton that retries AI translation for words queued while offline
- * (see [com.procrastilearn.app.domain.usecase.QueuePendingWordUseCase]) whenever
- * connectivity is restored, for as long as the app process is alive.
+ * App-wide singleton that retries AI translation for queued words (see
+ * [com.procrastilearn.app.domain.usecase.QueuePendingWordUseCase]) - both words queued while
+ * offline and words queued after an online AI request failed - for as long as the app process
+ * is alive.
+ *
+ * While online and the queue is non-empty, it polls on [POLL_INTERVAL_MS] and immediately
+ * whenever the queue or connectivity changes (e.g. a new word is queued or the user taps
+ * manual retry). Each pass only processes items whose [PendingWord.nextAttemptAt] has elapsed,
+ * so transient failures back off exponentially instead of being hammered on every poll.
+ * Permanent failures, and transient failures that exhaust [MAX_ATTEMPTS], are marked
+ * [PendingWordStatus.FAILED] and are no longer auto-retried until the user retries manually.
  */
 @Singleton
 class PendingWordSyncManager
     @Inject
+    @Suppress("LongParameterList")
     constructor(
         private val connectivityObserver: NetworkConnectivityObserver,
         private val pendingWordRepository: PendingWordRepository,
         private val generateAiTranslationUseCase: GenerateAiTranslationUseCase,
         private val addVocabularyItemUseCase: AddVocabularyItemUseCase,
         private val getVocabularyItemByWordUseCase: GetVocabularyItemByWordUseCase,
+        private val errorClassifier: TranslationErrorClassifier,
+        private val timeProvider: TimeProvider,
+        dispatcher: CoroutineDispatcher,
     ) {
-        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        private val scope = CoroutineScope(SupervisorJob() + dispatcher)
         private var started = false
 
         fun start() {
             if (started) return
             started = true
             scope.launch {
-                connectivityObserver.observe()
-                    .filter { online -> online }
-                    .collect { syncPendingWords() }
+                combine(
+                    pendingWordRepository.observePendingWords(),
+                    connectivityObserver.observe(),
+                ) { pendingWords, online -> online && pendingWords.isNotEmpty() }
+                    .collectLatest { shouldSync -> if (shouldSync) pollUntilCancelled() }
+            }
+        }
+
+        private suspend fun pollUntilCancelled() {
+            while (true) {
+                syncPendingWords()
+                delay(POLL_INTERVAL_MS)
             }
         }
 
         suspend fun syncPendingWords() {
-            val pending = pendingWordRepository.getAllPendingWordsSnapshot()
-            for (item in pending) {
+            val now = timeProvider.now()
+            val eligible =
+                pendingWordRepository.getAllPendingWordsSnapshot()
+                    .filter { it.status == PendingWordStatus.PENDING && it.nextAttemptAt <= now }
+            for (item in eligible) {
                 processPendingWord(item)
             }
         }
 
-        @Suppress("TooGenericExceptionCaught", "SwallowedException")
+        @Suppress("TooGenericExceptionCaught")
         private suspend fun processPendingWord(item: PendingWord) {
             try {
                 val existing = getVocabularyItemByWordUseCase(item.word)
@@ -60,17 +89,63 @@ class PendingWordSyncManager
                 }
 
                 val translation = generateAiTranslationUseCase(item.word, item.direction).trim()
-                if (translation.isBlank()) return
+                if (translation.isBlank()) {
+                    reschedule(item, ErrorClassification.Transient(EMPTY_TRANSLATION_ERROR))
+                    return
+                }
 
                 val result = addVocabularyItemUseCase(word = item.word, translation = translation)
                 if (result.isSuccess) {
                     pendingWordRepository.deletePendingWord(item)
+                } else {
+                    reschedule(item, errorClassifier.classify(result.exceptionOrNull()))
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                // Leave it pending; it will be retried on the next reconnect. No user is
-                // present to be notified, so we deliberately stay silent here.
+                reschedule(item, errorClassifier.classify(e))
             }
+        }
+
+        private suspend fun reschedule(
+            item: PendingWord,
+            classification: ErrorClassification,
+        ) {
+            val updated =
+                when (classification) {
+                    is ErrorClassification.Permanent ->
+                        item.copy(status = PendingWordStatus.FAILED, lastError = classification.message)
+
+                    is ErrorClassification.Transient -> {
+                        val attempt = item.retryCount + 1
+                        if (attempt >= MAX_ATTEMPTS) {
+                            item.copy(
+                                status = PendingWordStatus.FAILED,
+                                retryCount = attempt,
+                                lastError = classification.message,
+                            )
+                        } else {
+                            item.copy(
+                                retryCount = attempt,
+                                nextAttemptAt = timeProvider.now() + backoffDelayMillis(attempt),
+                                lastError = classification.message,
+                            )
+                        }
+                    }
+                }
+            pendingWordRepository.updatePendingWord(updated)
+        }
+
+        private fun backoffDelayMillis(attempt: Int): Long {
+            val multiplier = 1L shl (attempt - 1)
+            return (BASE_BACKOFF_MS * multiplier).coerceAtMost(MAX_BACKOFF_MS)
+        }
+
+        companion object {
+            private const val EMPTY_TRANSLATION_ERROR = "AI returned an empty translation"
+            internal const val MAX_ATTEMPTS = 5
+            internal const val BASE_BACKOFF_MS = 30_000L
+            internal const val MAX_BACKOFF_MS = 3_600_000L
+            internal const val POLL_INTERVAL_MS = 30_000L
         }
     }

--- a/app/src/main/java/com/procrastilearn/app/data/sync/TimeProvider.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/sync/TimeProvider.kt
@@ -1,0 +1,5 @@
+package com.procrastilearn.app.data.sync
+
+fun interface TimeProvider {
+    fun now(): Long
+}

--- a/app/src/main/java/com/procrastilearn/app/data/translation/ErrorClassification.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/translation/ErrorClassification.kt
@@ -1,0 +1,9 @@
+package com.procrastilearn.app.data.translation
+
+sealed interface ErrorClassification {
+    val message: String
+
+    data class Permanent(override val message: String) : ErrorClassification
+
+    data class Transient(override val message: String) : ErrorClassification
+}

--- a/app/src/main/java/com/procrastilearn/app/data/translation/TranslationErrorClassifier.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/translation/TranslationErrorClassifier.kt
@@ -1,0 +1,32 @@
+package com.procrastilearn.app.data.translation
+
+import com.openai.errors.OpenAIIoException
+import com.openai.errors.OpenAIServiceException
+import javax.inject.Inject
+
+/**
+ * Distinguishes translation failures a retry can plausibly fix (network blips, timeouts,
+ * rate limits, server errors) from ones that will keep failing until the user intervenes
+ * (bad API key, malformed request). Unknown failures default to transient since retries
+ * are attempt-capped, so treating them as retryable first is the safer default.
+ */
+class TranslationErrorClassifier
+    @Inject
+    constructor() {
+        fun classify(error: Throwable?): ErrorClassification {
+            val message = error?.message ?: DEFAULT_MESSAGE
+            return when {
+                error is OpenAIServiceException && error.statusCode() in PERMANENT_STATUS_CODES ->
+                    ErrorClassification.Permanent(message)
+                error is IllegalArgumentException -> ErrorClassification.Permanent(message)
+                error is OpenAIServiceException -> ErrorClassification.Transient(message)
+                error is OpenAIIoException -> ErrorClassification.Transient(message)
+                else -> ErrorClassification.Transient(message)
+            }
+        }
+
+        private companion object {
+            const val DEFAULT_MESSAGE = "Unknown error"
+            val PERMANENT_STATUS_CODES = setOf(400, 401, 403, 404, 422)
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/di/AppModule.kt
+++ b/app/src/main/java/com/procrastilearn/app/di/AppModule.kt
@@ -7,6 +7,7 @@ import com.procrastilearn.app.data.parser.json.JsonVocabularyParser
 import com.procrastilearn.app.data.repository.AppPreferencesRepositoryImpl
 import com.procrastilearn.app.data.repository.PendingWordRepositoryImpl
 import com.procrastilearn.app.data.repository.VocabularyRepositoryImpl
+import com.procrastilearn.app.data.sync.TimeProvider
 import com.procrastilearn.app.data.translation.AiTranslationProvider
 import com.procrastilearn.app.data.translation.OpenAiTranslationProvider
 import com.procrastilearn.app.domain.parser.VocabularyParser
@@ -58,5 +59,9 @@ abstract class AppModule {
         @Provides
         @Singleton
         fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+        @Provides
+        @Singleton
+        fun provideTimeProvider(): TimeProvider = TimeProvider { System.currentTimeMillis() }
     }
 }

--- a/app/src/main/java/com/procrastilearn/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/procrastilearn/app/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import com.procrastilearn.app.data.local.dao.PendingWordDao
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.database.AppDatabase
 import com.procrastilearn.app.data.local.database.MIGRATION_1_2
+import com.procrastilearn.app.data.local.database.MIGRATION_2_3
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -26,7 +27,7 @@ object DatabaseModule {
                 context,
                 AppDatabase::class.java,
                 "app_database",
-            ).addMigrations(MIGRATION_1_2)
+            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3)
             .build()
 
     @Provides

--- a/app/src/main/java/com/procrastilearn/app/domain/model/PendingWord.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/model/PendingWord.kt
@@ -5,4 +5,8 @@ data class PendingWord(
     val word: String,
     val direction: AiTranslationDirection,
     val createdAt: Long = System.currentTimeMillis(),
+    val status: PendingWordStatus = PendingWordStatus.PENDING,
+    val retryCount: Int = 0,
+    val nextAttemptAt: Long = 0,
+    val lastError: String? = null,
 )

--- a/app/src/main/java/com/procrastilearn/app/domain/model/PendingWordStatus.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/model/PendingWordStatus.kt
@@ -1,0 +1,6 @@
+package com.procrastilearn.app.domain.model
+
+enum class PendingWordStatus {
+    PENDING,
+    FAILED,
+}

--- a/app/src/main/java/com/procrastilearn/app/domain/repository/PendingWordRepository.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/repository/PendingWordRepository.kt
@@ -2,6 +2,7 @@ package com.procrastilearn.app.domain.repository
 
 import com.procrastilearn.app.domain.model.AiTranslationDirection
 import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import kotlinx.coroutines.flow.Flow
 
 interface PendingWordRepository {
@@ -12,7 +13,13 @@ interface PendingWordRepository {
     suspend fun queuePendingWord(
         word: String,
         direction: AiTranslationDirection,
+        status: PendingWordStatus = PendingWordStatus.PENDING,
+        lastError: String? = null,
     )
+
+    suspend fun updatePendingWord(pendingWord: PendingWord)
+
+    suspend fun retryPendingWord(id: Long)
 
     suspend fun deletePendingWord(pendingWord: PendingWord)
 

--- a/app/src/main/java/com/procrastilearn/app/domain/usecase/QueuePendingWordUseCase.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/usecase/QueuePendingWordUseCase.kt
@@ -1,6 +1,7 @@
 package com.procrastilearn.app.domain.usecase
 
 import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.domain.repository.PendingWordRepository
 import javax.inject.Inject
 
@@ -12,9 +13,11 @@ class QueuePendingWordUseCase
         suspend operator fun invoke(
             word: String,
             direction: AiTranslationDirection,
+            status: PendingWordStatus = PendingWordStatus.PENDING,
+            lastError: String? = null,
         ) {
             val trimmed = word.trim()
             require(trimmed.isNotBlank()) { "Word cannot be blank" }
-            repository.queuePendingWord(trimmed, direction)
+            repository.queuePendingWord(trimmed, direction, status, lastError)
         }
     }

--- a/app/src/main/java/com/procrastilearn/app/domain/usecase/RetryPendingWordUseCase.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/usecase/RetryPendingWordUseCase.kt
@@ -1,0 +1,14 @@
+package com.procrastilearn.app.domain.usecase
+
+import com.procrastilearn.app.domain.repository.PendingWordRepository
+import javax.inject.Inject
+
+class RetryPendingWordUseCase
+    @Inject
+    constructor(
+        private val repository: PendingWordRepository,
+    ) {
+        suspend operator fun invoke(id: Long) {
+            repository.retryPendingWord(id)
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.procrastilearn.app.data.connectivity.NetworkConnectivityObserver
 import com.procrastilearn.app.data.local.prefs.OpenAiPreferencesStore
+import com.procrastilearn.app.data.translation.ErrorClassification
+import com.procrastilearn.app.data.translation.TranslationErrorClassifier
 import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.AddVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.DeletePendingWordUseCase
@@ -13,6 +16,7 @@ import com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase
 import com.procrastilearn.app.domain.usecase.ObservePendingWordsUseCase
 import com.procrastilearn.app.domain.usecase.OverrideVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.QueuePendingWordUseCase
+import com.procrastilearn.app.domain.usecase.RetryPendingWordUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,7 +27,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class AddWordViewModel @Inject
     constructor(
         private val addVocabularyItemUseCase: AddVocabularyItemUseCase,
@@ -34,7 +38,9 @@ class AddWordViewModel @Inject
         private val queuePendingWordUseCase: QueuePendingWordUseCase,
         private val observePendingWordsUseCase: ObservePendingWordsUseCase,
         private val deletePendingWordUseCase: DeletePendingWordUseCase,
+        private val retryPendingWordUseCase: RetryPendingWordUseCase,
         private val connectivityObserver: NetworkConnectivityObserver,
+        private val translationErrorClassifier: TranslationErrorClassifier,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(AddWordUiState())
         private var pendingOverride: PendingOverrideSubmission? = null
@@ -69,7 +75,15 @@ class AddWordViewModel @Inject
                 observePendingWordsUseCase().collectLatest { pendingWords ->
                     _uiState.value =
                         _uiState.value.copy(
-                            pendingWords = pendingWords.map { PendingWordUi(id = it.id, word = it.word) },
+                            pendingWords =
+                                pendingWords.map {
+                                    PendingWordUi(
+                                        id = it.id,
+                                        word = it.word,
+                                        status = it.status,
+                                        lastError = it.lastError,
+                                    )
+                                },
                         )
                 }
             }
@@ -120,8 +134,12 @@ class AddWordViewModel @Inject
                         isExistingWordDialogLoading = false,
                     )
 
-                val finalTranslation = resolveTranslationForAdd(currentState)
+                if (currentState.aiModeActive) {
+                    submitWithAiTranslation(currentState)
+                    return@launch
+                }
 
+                val finalTranslation = currentState.translation
                 if (finalTranslation.isBlank()) {
                     _uiState.value =
                         _uiState.value.copy(
@@ -140,25 +158,38 @@ class AddWordViewModel @Inject
             }
         }
 
-        private suspend fun resolveTranslationForAdd(currentState: AddWordUiState): String {
-            val aiTranslation: String? =
-                if (currentState.aiModeActive) {
-                    runCatching {
-                        generateAiTranslationUseCase(
-                            currentState.word,
-                            currentState.translationDirection,
-                        )
-                    }.getOrNull()
-                } else {
-                    null
+        private suspend fun submitWithAiTranslation(currentState: AddWordUiState) {
+            val word = currentState.word.trim()
+            val outcome =
+                runCatching {
+                    generateAiTranslationUseCase(word, currentState.translationDirection)
                 }
 
-            return if (!aiTranslation.isNullOrBlank()) {
-                _uiState.value = _uiState.value.copy(translation = aiTranslation)
-                aiTranslation
-            } else {
-                currentState.translation
+            val translation = outcome.getOrNull()?.trim()
+            if (!translation.isNullOrBlank()) {
+                _uiState.value = _uiState.value.copy(translation = translation)
+                handleWordSubmission(word = word, translation = translation, fromPreview = false)
+                return
             }
+
+            val error = outcome.exceptionOrNull() ?: IllegalStateException(EMPTY_AI_TRANSLATION_ERROR)
+            queueAfterAiFailure(word, currentState.translationDirection, error)
+        }
+
+        private suspend fun queueAfterAiFailure(
+            word: String,
+            direction: AiTranslationDirection,
+            error: Throwable,
+        ) {
+            val classification = translationErrorClassifier.classify(error)
+            val status =
+                if (classification is ErrorClassification.Permanent) {
+                    PendingWordStatus.FAILED
+                } else {
+                    PendingWordStatus.PENDING
+                }
+            queuePendingWordUseCase(word, direction, status, classification.message)
+            applyQueuedState(AI_ERROR_QUEUED_MESSAGE)
         }
 
         private fun queuePendingWord(
@@ -167,23 +198,31 @@ class AddWordViewModel @Inject
         ) {
             viewModelScope.launch {
                 queuePendingWordUseCase(word, direction)
-                _uiState.value =
-                    _uiState.value.copy(
-                        word = "",
-                        translation = "",
-                        wordError = null,
-                        translationError = null,
-                        errorMessage = null,
-                        isLoading = false,
-                        loadingAction = null,
-                        isSuccess = true,
-                        successMessage = PENDING_QUEUED_MESSAGE,
-                    )
+                applyQueuedState(PENDING_QUEUED_MESSAGE)
             }
+        }
+
+        private fun applyQueuedState(message: String) {
+            _uiState.value =
+                _uiState.value.copy(
+                    word = "",
+                    translation = "",
+                    wordError = null,
+                    translationError = null,
+                    errorMessage = null,
+                    isLoading = false,
+                    loadingAction = null,
+                    isSuccess = true,
+                    successMessage = message,
+                )
         }
 
         fun onDeletePendingWord(id: Long) {
             viewModelScope.launch { deletePendingWordUseCase(id) }
+        }
+
+        fun onRetryPendingWord(id: Long) {
+            viewModelScope.launch { retryPendingWordUseCase(id) }
         }
 
         fun resetSuccess() {
@@ -484,6 +523,9 @@ class AddWordViewModel @Inject
             private const val DEFAULT_ADD_SUCCESS_MESSAGE = "Word added successfully!"
             private const val OVERRIDE_SUCCESS_MESSAGE = "Word updated and progress reset!"
             private const val PENDING_QUEUED_MESSAGE = "Saved. Translation will be generated once you're back online."
+            private const val AI_ERROR_QUEUED_MESSAGE =
+                "Couldn't reach AI. Saved - translation will be generated automatically."
+            private const val EMPTY_AI_TRANSLATION_ERROR = "AI returned an empty translation"
         }
 
         fun onPreviewConfirmAdd() {
@@ -541,6 +583,8 @@ data class AddWordPreviewContent(
 data class PendingWordUi(
     val id: Long,
     val word: String,
+    val status: PendingWordStatus = PendingWordStatus.PENDING,
+    val lastError: String? = null,
 )
 
 enum class AddWordLoadingAction {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/AddWordScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/AddWordScreen.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.procrastilearn.app.ui.screens
 
 import androidx.compose.animation.AnimatedVisibility
@@ -36,6 +38,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -55,6 +58,7 @@ import com.procrastilearn.app.ui.AddWordPreviewContent
 import com.procrastilearn.app.ui.AddWordViewModel
 import com.procrastilearn.app.ui.PendingWordUi
 import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import kotlinx.coroutines.delay
 
 @Suppress("MagicNumber")
@@ -97,6 +101,7 @@ fun AddWordScreen(
         isAddLaterMode = uiState.isAddLaterMode,
         pendingWords = uiState.pendingWords,
         onDeletePendingWord = viewModel::onDeletePendingWord,
+        onRetryPendingWord = viewModel::onRetryPendingWord,
         onWordChange = viewModel::onWordChange,
         onTranslationChange = viewModel::onTranslationChange,
         onUseAiToggle = viewModel::onUseAiToggle,
@@ -136,6 +141,7 @@ internal fun AddWordContent(
     isAddLaterMode: Boolean,
     pendingWords: List<PendingWordUi>,
     onDeletePendingWord: (Long) -> Unit,
+    onRetryPendingWord: (Long) -> Unit,
     onWordChange: (String) -> Unit,
     onTranslationChange: (String) -> Unit,
     onUseAiToggle: (Boolean) -> Unit,
@@ -234,6 +240,7 @@ internal fun AddWordContent(
                 PendingWordsSection(
                     pendingWords = pendingWords,
                     onDeletePendingWord = onDeletePendingWord,
+                    onRetryPendingWord = onRetryPendingWord,
                     modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
                 )
             }
@@ -580,6 +587,7 @@ private fun ErrorMessageCard(errorMessage: String?) {
 internal fun PendingWordsSection(
     pendingWords: List<PendingWordUi>,
     onDeletePendingWord: (Long) -> Unit,
+    onRetryPendingWord: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -599,31 +607,68 @@ internal fun PendingWordsSection(
         ) {
             Column(modifier = Modifier.fillMaxWidth()) {
                 pendingWords.forEachIndexed { index, pendingWord ->
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = pendingWord.word,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.weight(1f),
-                        )
-                        IconButton(onClick = { onDeletePendingWord(pendingWord.id) }) {
-                            Icon(
-                                imageVector = Icons.Default.Delete,
-                                contentDescription = stringResource(R.string.add_word_pending_delete),
-                                tint = MaterialTheme.colorScheme.error,
-                            )
-                        }
-                    }
+                    PendingWordRow(
+                        pendingWord = pendingWord,
+                        onDeletePendingWord = onDeletePendingWord,
+                        onRetryPendingWord = onRetryPendingWord,
+                    )
                     if (index != pendingWords.lastIndex) {
                         HorizontalDivider()
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PendingWordRow(
+    pendingWord: PendingWordUi,
+    onDeletePendingWord: (Long) -> Unit,
+    onRetryPendingWord: (Long) -> Unit,
+) {
+    val isFailed = pendingWord.status == PendingWordStatus.FAILED
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = pendingWord.word,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text =
+                    stringResource(
+                        if (isFailed) {
+                            R.string.add_word_pending_status_failed
+                        } else {
+                            R.string.add_word_pending_status_waiting
+                        },
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                color =
+                    if (isFailed) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+            )
+        }
+        if (isFailed) {
+            TextButton(onClick = { onRetryPendingWord(pendingWord.id) }) {
+                Text(text = stringResource(R.string.add_word_pending_retry))
+            }
+        }
+        IconButton(onClick = { onDeletePendingWord(pendingWord.id) }) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = stringResource(R.string.add_word_pending_delete),
+                tint = MaterialTheme.colorScheme.error,
+            )
         }
     }
 }

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/AddWordScreenPreviews.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/AddWordScreenPreviews.kt
@@ -3,6 +3,7 @@ package com.procrastilearn.app.ui.screens
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.ui.AddWordPreviewContent
 import com.procrastilearn.app.ui.PendingWordUi
 import com.procrastilearn.app.ui.theme.MyApplicationTheme
@@ -38,6 +39,7 @@ private fun AddWordContentPreviewAiEnabled() {
             isAddLaterMode = false,
             pendingWords = emptyList(),
             onDeletePendingWord = {},
+            onRetryPendingWord = {},
             onWordChange = {},
             onTranslationChange = {},
             onUseAiToggle = {},
@@ -81,9 +83,10 @@ private fun AddWordContentPreviewOffline() {
                 listOf(
                     PendingWordUi(id = 1, word = "Haus"),
                     PendingWordUi(id = 2, word = "Auto"),
-                    PendingWordUi(id = 3, word = "Fenster"),
+                    PendingWordUi(id = 3, word = "Fenster", status = PendingWordStatus.FAILED, lastError = "401"),
                 ),
             onDeletePendingWord = {},
+            onRetryPendingWord = {},
             onWordChange = {},
             onTranslationChange = {},
             onUseAiToggle = {},
@@ -106,9 +109,10 @@ private fun PendingWordsSectionPreview() {
             pendingWords =
                 listOf(
                     PendingWordUi(id = 1, word = "Haus"),
-                    PendingWordUi(id = 2, word = "Auto"),
+                    PendingWordUi(id = 2, word = "Auto", status = PendingWordStatus.FAILED, lastError = "401"),
                 ),
             onDeletePendingWord = {},
+            onRetryPendingWord = {},
         )
     }
 }
@@ -162,6 +166,7 @@ private fun AddWordContentPreview() {
             isAddLaterMode = false,
             pendingWords = emptyList(),
             onDeletePendingWord = {},
+            onRetryPendingWord = {},
             onWordChange = {},
             onTranslationChange = {},
             onUseAiToggle = {},

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -230,6 +230,9 @@
         <string name="add_word_button_add_later">Добавить позже</string>
         <string name="add_word_pending_title">Ожидающие переводы</string>
         <string name="add_word_pending_delete">Удалить ожидающее слово</string>
+        <string name="add_word_pending_status_waiting">Ожидает повтора…</string>
+        <string name="add_word_pending_status_failed">Не удалось перевести</string>
+        <string name="add_word_pending_retry">Повторить</string>
 
         <!-- ─── Accessibility content descriptions (for icons) ──────────────────── -->
         <string name="cd_add_word">Добавить слово</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,9 @@
     <string name="add_word_button_add_later">Add later</string>
     <string name="add_word_pending_title">Pending translations</string>
     <string name="add_word_pending_delete">Remove pending word</string>
+    <string name="add_word_pending_status_waiting">Waiting to retry…</string>
+    <string name="add_word_pending_status_failed">Couldn\'t translate</string>
+    <string name="add_word_pending_retry">Retry</string>
 
     <!-- ─── Vocabulary list ─────────────────────────────────────────────────── -->
     <string name="word_list_title">My Vocabulary</string>

--- a/app/src/test/java/com/procrastilearn/app/data/local/mapper/PendingWordMapperTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/mapper/PendingWordMapperTest.kt
@@ -1,0 +1,98 @@
+package com.procrastilearn.app.data.local.mapper
+
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.entity.PendingWordEntity
+import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
+import org.junit.Test
+
+class PendingWordMapperTest {
+    @Test
+    fun `toDomain maps retry state fields`() {
+        val entity =
+            PendingWordEntity(
+                id = 3,
+                word = "Haus",
+                direction = "EN_TO_RU",
+                createdAt = 111L,
+                status = "FAILED",
+                retryCount = 4,
+                nextAttemptAt = 999L,
+                lastError = "401: unauthorized",
+            )
+
+        val result = entity.toDomain()
+
+        assertThat(result.id).isEqualTo(3)
+        assertThat(result.status).isEqualTo(PendingWordStatus.FAILED)
+        assertThat(result.retryCount).isEqualTo(4)
+        assertThat(result.nextAttemptAt).isEqualTo(999L)
+        assertThat(result.lastError).isEqualTo("401: unauthorized")
+    }
+
+    @Test
+    fun `toDomain falls back to pending for an unrecognized status string`() {
+        val entity =
+            PendingWordEntity(
+                word = "Haus",
+                direction = "EN_TO_RU",
+                status = "SOMETHING_UNKNOWN",
+            )
+
+        val result = entity.toDomain()
+
+        assertThat(result.status).isEqualTo(PendingWordStatus.PENDING)
+    }
+
+    @Test
+    fun `toDomain defaults to fresh retry state when columns are at their defaults`() {
+        val entity = PendingWordEntity(word = "Haus", direction = "EN_TO_RU")
+
+        val result = entity.toDomain()
+
+        assertThat(result.status).isEqualTo(PendingWordStatus.PENDING)
+        assertThat(result.retryCount).isEqualTo(0)
+        assertThat(result.nextAttemptAt).isEqualTo(0L)
+        assertThat(result.lastError).isNull()
+    }
+
+    @Test
+    fun `toEntity maps retry state fields`() {
+        val domain =
+            PendingWord(
+                id = 8,
+                word = "Auto",
+                direction = AiTranslationDirection.RU_TO_EN,
+                status = PendingWordStatus.FAILED,
+                retryCount = 2,
+                nextAttemptAt = 555L,
+                lastError = "timeout",
+            )
+
+        val result = domain.toEntity()
+
+        assertThat(result.status).isEqualTo("FAILED")
+        assertThat(result.retryCount).isEqualTo(2)
+        assertThat(result.nextAttemptAt).isEqualTo(555L)
+        assertThat(result.lastError).isEqualTo("timeout")
+    }
+
+    @Test
+    fun `round trip through entity preserves retry state`() {
+        val original =
+            PendingWord(
+                id = 1,
+                word = "Haus",
+                direction = AiTranslationDirection.EN_TO_RU,
+                status = PendingWordStatus.FAILED,
+                retryCount = 3,
+                nextAttemptAt = 4242L,
+                lastError = "boom",
+            )
+
+        val result = original.toEntity().toDomain()
+
+        assertThat(result).isEqualTo(original)
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/data/repository/PendingWordRepositoryImplTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/PendingWordRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import com.procrastilearn.app.data.local.dao.PendingWordDao
 import com.procrastilearn.app.data.local.database.AppDatabase
 import com.procrastilearn.app.domain.model.AiTranslationDirection
 import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -62,6 +63,103 @@ class PendingWordRepositoryImplTest {
             val snapshot = repository.getAllPendingWordsSnapshot()
             assertThat(snapshot).hasSize(1)
             assertThat(snapshot.first().direction).isEqualTo(AiTranslationDirection.RU_TO_EN)
+        }
+
+    @Test
+    fun `queuePendingWord with explicit failed status persists status and lastError`() =
+        runTest {
+            repository.queuePendingWord(
+                "Haus",
+                AiTranslationDirection.EN_TO_RU,
+                PendingWordStatus.FAILED,
+                "401: unauthorized",
+            )
+
+            val stored = repository.getAllPendingWordsSnapshot().first()
+            assertThat(stored.status).isEqualTo(PendingWordStatus.FAILED)
+            assertThat(stored.lastError).isEqualTo("401: unauthorized")
+        }
+
+    @Test
+    fun `queuePendingWord replacing an existing word resets retry state to fresh pending`() =
+        runTest {
+            repository.queuePendingWord(
+                "Haus",
+                AiTranslationDirection.EN_TO_RU,
+                PendingWordStatus.FAILED,
+                "401: unauthorized",
+            )
+            val failed = repository.getAllPendingWordsSnapshot().first()
+            repository.updatePendingWord(failed.copy(retryCount = 3, nextAttemptAt = 999_999L))
+
+            repository.queuePendingWord("Haus", AiTranslationDirection.EN_TO_RU)
+
+            val stored = repository.getAllPendingWordsSnapshot().first()
+            assertThat(stored.status).isEqualTo(PendingWordStatus.PENDING)
+            assertThat(stored.retryCount).isEqualTo(0)
+            assertThat(stored.nextAttemptAt).isEqualTo(0)
+            assertThat(stored.lastError).isNull()
+        }
+
+    @Test
+    fun `updatePendingWord persists retry state changes`() =
+        runTest {
+            repository.queuePendingWord("Haus", AiTranslationDirection.EN_TO_RU)
+            val stored = repository.getAllPendingWordsSnapshot().first()
+
+            repository.updatePendingWord(
+                stored.copy(retryCount = 2, nextAttemptAt = 123_456L, lastError = "timeout"),
+            )
+
+            val updated = repository.getAllPendingWordsSnapshot().first()
+            assertThat(updated.retryCount).isEqualTo(2)
+            assertThat(updated.nextAttemptAt).isEqualTo(123_456L)
+            assertThat(updated.lastError).isEqualTo("timeout")
+            assertThat(updated.status).isEqualTo(PendingWordStatus.PENDING)
+        }
+
+    @Test
+    fun `updatePendingWord can mark an item as failed`() =
+        runTest {
+            repository.queuePendingWord("Haus", AiTranslationDirection.EN_TO_RU)
+            val stored = repository.getAllPendingWordsSnapshot().first()
+
+            repository.updatePendingWord(stored.copy(status = PendingWordStatus.FAILED, lastError = "boom"))
+
+            val updated = repository.getAllPendingWordsSnapshot().first()
+            assertThat(updated.status).isEqualTo(PendingWordStatus.FAILED)
+            assertThat(updated.lastError).isEqualTo("boom")
+        }
+
+    @Test
+    fun `retryPendingWord resets a failed item back to pending`() =
+        runTest {
+            repository.queuePendingWord(
+                "Haus",
+                AiTranslationDirection.EN_TO_RU,
+                PendingWordStatus.FAILED,
+                "401: unauthorized",
+            )
+            val failed = repository.getAllPendingWordsSnapshot().first()
+            repository.updatePendingWord(failed.copy(retryCount = 5, nextAttemptAt = 999_999L))
+
+            repository.retryPendingWord(failed.id)
+
+            val retried = repository.getAllPendingWordsSnapshot().first()
+            assertThat(retried.status).isEqualTo(PendingWordStatus.PENDING)
+            assertThat(retried.retryCount).isEqualTo(0)
+            assertThat(retried.nextAttemptAt).isEqualTo(0)
+            assertThat(retried.lastError).isNull()
+        }
+
+    @Test
+    fun `retryPendingWord for an unknown id is a no-op`() =
+        runTest {
+            repository.queuePendingWord("Haus", AiTranslationDirection.EN_TO_RU)
+
+            repository.retryPendingWord(999L)
+
+            assertThat(repository.getAllPendingWordsSnapshot()).hasSize(1)
         }
 
     @Test

--- a/app/src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt
@@ -1,8 +1,10 @@
 package com.procrastilearn.app.data.sync
 
 import com.procrastilearn.app.data.connectivity.NetworkConnectivityObserver
+import com.procrastilearn.app.data.translation.TranslationErrorClassifier
 import com.procrastilearn.app.domain.model.AiTranslationDirection
 import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.repository.PendingWordRepository
 import com.procrastilearn.app.domain.usecase.AddVocabularyItemUseCase
@@ -11,22 +13,36 @@ import com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class PendingWordSyncManagerTest {
     private val connectivityObserver: NetworkConnectivityObserver = mockk()
     private val pendingWordRepository: PendingWordRepository = mockk()
     private val generateAiTranslationUseCase: GenerateAiTranslationUseCase = mockk()
     private val addVocabularyItemUseCase: AddVocabularyItemUseCase = mockk()
     private val getVocabularyItemByWordUseCase: GetVocabularyItemByWordUseCase = mockk()
+    private val errorClassifier = TranslationErrorClassifier()
+    private val timeProvider = FakeTimeProvider(BASE_TIME)
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var onlineFlow: MutableStateFlow<Boolean>
+    private lateinit var pendingWordsFlow: MutableStateFlow<List<PendingWord>>
     private lateinit var manager: PendingWordSyncManager
 
     @Before
     fun setUp() {
+        onlineFlow = MutableStateFlow(true)
+        pendingWordsFlow = MutableStateFlow(emptyList())
+        every { connectivityObserver.observe() } returns onlineFlow
+        every { pendingWordRepository.observePendingWords() } returns pendingWordsFlow
         manager =
             PendingWordSyncManager(
                 connectivityObserver,
@@ -34,8 +50,13 @@ class PendingWordSyncManagerTest {
                 generateAiTranslationUseCase,
                 addVocabularyItemUseCase,
                 getVocabularyItemByWordUseCase,
+                errorClassifier,
+                timeProvider,
+                testDispatcher,
             )
     }
+
+    // --- syncPendingWords: eligibility filtering ---
 
     @Test
     fun `syncPendingWords generates translation, adds the word and clears the pending entry`() =
@@ -70,21 +91,161 @@ class PendingWordSyncManagerTest {
         }
 
     @Test
-    fun `syncPendingWords leaves the word pending when translation generation fails`() =
+    fun `syncPendingWords skips items whose backoff has not elapsed yet`() =
+        runTest {
+            val notYetEligible =
+                PendingWord(
+                    id = 1,
+                    word = "Haus",
+                    direction = AiTranslationDirection.EN_TO_RU,
+                    nextAttemptAt = BASE_TIME + 1,
+                )
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(notYetEligible)
+
+            manager.syncPendingWords()
+
+            coVerify(exactly = 0) { getVocabularyItemByWordUseCase.invoke(any()) }
+            coVerify(exactly = 0) { generateAiTranslationUseCase.invoke(any(), any()) }
+        }
+
+    @Test
+    fun `syncPendingWords processes items exactly at their nextAttemptAt boundary`() =
+        runTest {
+            val eligible =
+                PendingWord(
+                    id = 1,
+                    word = "Haus",
+                    direction = AiTranslationDirection.EN_TO_RU,
+                    nextAttemptAt = BASE_TIME,
+                )
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(eligible)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } returns "House"
+            coEvery { addVocabularyItemUseCase.invoke("Haus", "House") } returns Result.success(Unit)
+            coEvery { pendingWordRepository.deletePendingWord(eligible) } just Runs
+
+            manager.syncPendingWords()
+
+            coVerify(exactly = 1) { generateAiTranslationUseCase.invoke("Haus", any()) }
+        }
+
+    @Test
+    fun `syncPendingWords never auto-retries an item already marked failed`() =
+        runTest {
+            val failed =
+                PendingWord(
+                    id = 1,
+                    word = "Haus",
+                    direction = AiTranslationDirection.EN_TO_RU,
+                    status = PendingWordStatus.FAILED,
+                )
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(failed)
+
+            manager.syncPendingWords()
+
+            coVerify(exactly = 0) { getVocabularyItemByWordUseCase.invoke(any()) }
+            coVerify(exactly = 0) { generateAiTranslationUseCase.invoke(any(), any()) }
+        }
+
+    // --- syncPendingWords: failure classification and rescheduling ---
+
+    @Test
+    fun `syncPendingWords marks the item failed immediately on a permanent error`() =
         runTest {
             val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
             coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
             coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
-            coEvery { generateAiTranslationUseCase.invoke(any(), any()) } throws IllegalStateException("network blip")
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } throws
+                IllegalArgumentException("Missing OpenAI API key")
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
 
             manager.syncPendingWords()
 
             coVerify(exactly = 0) { addVocabularyItemUseCase.invoke(any(), any()) }
             coVerify(exactly = 0) { pendingWordRepository.deletePendingWord(any()) }
+            coVerify(exactly = 1) {
+                pendingWordRepository.updatePendingWord(
+                    match {
+                        it.status == PendingWordStatus.FAILED &&
+                            it.retryCount == 0 &&
+                            it.lastError == "Missing OpenAI API key"
+                    },
+                )
+            }
         }
 
     @Test
-    fun `syncPendingWords leaves the word pending when adding it fails`() =
+    fun `syncPendingWords reschedules with exponential backoff on a transient error`() =
+        runTest {
+            val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } throws IllegalStateException("network blip")
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
+
+            manager.syncPendingWords()
+
+            coVerify(exactly = 1) {
+                pendingWordRepository.updatePendingWord(
+                    match {
+                        it.status == PendingWordStatus.PENDING &&
+                            it.retryCount == 1 &&
+                            it.nextAttemptAt == BASE_TIME + PendingWordSyncManager.BASE_BACKOFF_MS &&
+                            it.lastError == "network blip"
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun `syncPendingWords doubles the backoff on successive transient failures`() =
+        runTest {
+            val pending =
+                PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU, retryCount = 1)
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } throws IllegalStateException("blip")
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
+
+            manager.syncPendingWords()
+
+            coVerify(exactly = 1) {
+                pendingWordRepository.updatePendingWord(
+                    match {
+                        it.retryCount == 2 && it.nextAttemptAt == BASE_TIME + 2 * PendingWordSyncManager.BASE_BACKOFF_MS
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun `syncPendingWords marks the item failed once max attempts are exhausted`() =
+        runTest {
+            val pending =
+                PendingWord(
+                    id = 1,
+                    word = "Haus",
+                    direction = AiTranslationDirection.EN_TO_RU,
+                    retryCount = PendingWordSyncManager.MAX_ATTEMPTS - 1,
+                )
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } throws IllegalStateException("blip")
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
+
+            manager.syncPendingWords()
+
+            coVerify(exactly = 1) {
+                pendingWordRepository.updatePendingWord(
+                    match {
+                        it.status == PendingWordStatus.FAILED && it.retryCount == PendingWordSyncManager.MAX_ATTEMPTS
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun `syncPendingWords reschedules as transient when adding the vocabulary item fails`() =
         runTest {
             val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
             coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
@@ -92,24 +253,32 @@ class PendingWordSyncManagerTest {
             coEvery { generateAiTranslationUseCase.invoke("Haus", AiTranslationDirection.EN_TO_RU) } returns "House"
             coEvery { addVocabularyItemUseCase.invoke("Haus", "House") } returns
                 Result.failure(IllegalStateException("db busy"))
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
 
             manager.syncPendingWords()
 
             coVerify(exactly = 0) { pendingWordRepository.deletePendingWord(any()) }
+            coVerify(exactly = 1) {
+                pendingWordRepository.updatePendingWord(match { it.status == PendingWordStatus.PENDING })
+            }
         }
 
     @Test
-    fun `syncPendingWords leaves the word pending when the generated translation is blank`() =
+    fun `syncPendingWords reschedules as transient when the generated translation is blank`() =
         runTest {
             val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
             coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
             coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
             coEvery { generateAiTranslationUseCase.invoke("Haus", AiTranslationDirection.EN_TO_RU) } returns "   "
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
 
             manager.syncPendingWords()
 
             coVerify(exactly = 0) { addVocabularyItemUseCase.invoke(any(), any()) }
             coVerify(exactly = 0) { pendingWordRepository.deletePendingWord(any()) }
+            coVerify(exactly = 1) {
+                pendingWordRepository.updatePendingWord(match { it.status == PendingWordStatus.PENDING })
+            }
         }
 
     @Test
@@ -124,10 +293,164 @@ class PendingWordSyncManagerTest {
             coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } returns "House"
             coEvery { addVocabularyItemUseCase.invoke("Haus", "House") } returns Result.success(Unit)
             coEvery { pendingWordRepository.deletePendingWord(succeeding) } just Runs
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
 
             manager.syncPendingWords()
 
             coVerify(exactly = 1) { pendingWordRepository.deletePendingWord(succeeding) }
             coVerify(exactly = 0) { pendingWordRepository.deletePendingWord(failing) }
+            coVerify(exactly = 1) { pendingWordRepository.updatePendingWord(match { it.id == 1L }) }
         }
+
+    // --- start(): polling behavior ---
+    //
+    // These tests give the manager its own TestCoroutineScheduler, deliberately NOT shared with
+    // runTest's scheduler, and drive it directly via testDispatcher.scheduler. manager.start()
+    // launches an infinite polling loop (by design, for as long as the app process is alive);
+    // if it shared runTest's scheduler, runTest's implicit end-of-test drain would try to
+    // exhaust that infinite loop and hang/OOM. Driving a separate scheduler by hand avoids that
+    // entirely and still gives full deterministic control over virtual time.
+
+    @Test
+    fun `start syncs immediately when already online with pending words`() =
+        runTest {
+            val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
+            pendingWordsFlow.value = listOf(pending)
+            onlineFlow.value = true
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } returns "House"
+            coEvery { addVocabularyItemUseCase.invoke("Haus", "House") } returns Result.success(Unit)
+            coEvery { pendingWordRepository.deletePendingWord(pending) } just Runs
+
+            manager.start()
+            testDispatcher.scheduler.runCurrent()
+
+            coVerify(exactly = 1) { addVocabularyItemUseCase.invoke("Haus", "House") }
+        }
+
+    @Test
+    fun `start polls again after the interval while still online with pending items`() =
+        runTest {
+            val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
+            pendingWordsFlow.value = listOf(pending)
+            onlineFlow.value = true
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } throws IllegalStateException("boom")
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
+
+            manager.start()
+            testDispatcher.scheduler.runCurrent()
+            coVerify(exactly = 1) { generateAiTranslationUseCase.invoke("Haus", any()) }
+
+            testDispatcher.scheduler.advanceTimeBy(PendingWordSyncManager.POLL_INTERVAL_MS)
+            testDispatcher.scheduler.runCurrent()
+
+            coVerify(exactly = 2) { generateAiTranslationUseCase.invoke("Haus", any()) }
+        }
+
+    @Test
+    fun `start does not sync while offline`() =
+        runTest {
+            val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
+            pendingWordsFlow.value = listOf(pending)
+            onlineFlow.value = false
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+
+            manager.start()
+            testDispatcher.scheduler.runCurrent()
+
+            coVerify(exactly = 0) { generateAiTranslationUseCase.invoke(any(), any()) }
+        }
+
+    @Test
+    fun `start does not poll when there are no pending words`() =
+        runTest {
+            pendingWordsFlow.value = emptyList()
+            onlineFlow.value = true
+
+            manager.start()
+            testDispatcher.scheduler.runCurrent()
+
+            coVerify(exactly = 0) { pendingWordRepository.getAllPendingWordsSnapshot() }
+        }
+
+    @Test
+    fun `start is idempotent when called twice`() =
+        runTest {
+            val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } returns "House"
+            coEvery { addVocabularyItemUseCase.invoke("Haus", "House") } returns Result.success(Unit)
+            coEvery { pendingWordRepository.deletePendingWord(pending) } just Runs
+
+            manager.start()
+            manager.start()
+            pendingWordsFlow.value = listOf(pending)
+            onlineFlow.value = true
+            testDispatcher.scheduler.runCurrent()
+
+            coVerify(exactly = 1) { addVocabularyItemUseCase.invoke("Haus", "House") }
+        }
+
+    @Test
+    fun `start resyncs promptly when the pending list changes without waiting for the poll interval`() =
+        runTest {
+            val first = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
+            val second = PendingWord(id = 2, word = "Auto", direction = AiTranslationDirection.EN_TO_RU)
+            pendingWordsFlow.value = listOf(first)
+            onlineFlow.value = true
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(first)
+            coEvery { getVocabularyItemByWordUseCase.invoke(any()) } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } throws IllegalStateException("boom")
+            coEvery { generateAiTranslationUseCase.invoke("Auto", any()) } returns "Car"
+            coEvery { addVocabularyItemUseCase.invoke("Auto", "Car") } returns Result.success(Unit)
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
+            coEvery { pendingWordRepository.deletePendingWord(second) } just Runs
+
+            manager.start()
+            testDispatcher.scheduler.runCurrent()
+            coVerify(exactly = 1) { generateAiTranslationUseCase.invoke("Haus", any()) }
+
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(first, second)
+            pendingWordsFlow.value = listOf(first, second)
+            testDispatcher.scheduler.advanceTimeBy(1_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            coVerify(exactly = 1) { addVocabularyItemUseCase.invoke("Auto", "Car") }
+        }
+
+    @Test
+    fun `start stops polling once connectivity drops`() =
+        runTest {
+            val pending = PendingWord(id = 1, word = "Haus", direction = AiTranslationDirection.EN_TO_RU)
+            pendingWordsFlow.value = listOf(pending)
+            onlineFlow.value = true
+            coEvery { pendingWordRepository.getAllPendingWordsSnapshot() } returns listOf(pending)
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+            coEvery { generateAiTranslationUseCase.invoke("Haus", any()) } throws IllegalStateException("boom")
+            coEvery { pendingWordRepository.updatePendingWord(any()) } just Runs
+
+            manager.start()
+            testDispatcher.scheduler.runCurrent()
+            coVerify(exactly = 1) { generateAiTranslationUseCase.invoke("Haus", any()) }
+
+            onlineFlow.value = false
+            testDispatcher.scheduler.advanceTimeBy(PendingWordSyncManager.POLL_INTERVAL_MS * 3)
+            testDispatcher.scheduler.runCurrent()
+
+            coVerify(exactly = 1) { generateAiTranslationUseCase.invoke("Haus", any()) }
+        }
+
+    private class FakeTimeProvider(
+        var currentTime: Long,
+    ) : TimeProvider {
+        override fun now(): Long = currentTime
+    }
+
+    private companion object {
+        const val BASE_TIME = 1_000_000L
+    }
 }

--- a/app/src/test/java/com/procrastilearn/app/data/translation/TranslationErrorClassifierTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/translation/TranslationErrorClassifierTest.kt
@@ -1,0 +1,137 @@
+package com.procrastilearn.app.data.translation
+
+import com.google.common.truth.Truth.assertThat
+import com.openai.errors.OpenAIIoException
+import com.openai.errors.OpenAIServiceException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+
+class TranslationErrorClassifierTest {
+    private val classifier = TranslationErrorClassifier()
+
+    @Test
+    fun `classifies 401 unauthorized as permanent`() {
+        val error = serviceException(statusCode = 401, message = "401: unauthorized")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isEqualTo(ErrorClassification.Permanent("401: unauthorized"))
+    }
+
+    @Test
+    fun `classifies 400 bad request as permanent`() {
+        val error = serviceException(statusCode = 400, message = "400: bad request")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isInstanceOf(ErrorClassification.Permanent::class.java)
+    }
+
+    @Test
+    fun `classifies 403 permission denied as permanent`() {
+        val error = serviceException(statusCode = 403, message = "403: forbidden")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isInstanceOf(ErrorClassification.Permanent::class.java)
+    }
+
+    @Test
+    fun `classifies 404 not found as permanent`() {
+        val error = serviceException(statusCode = 404, message = "404: not found")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isInstanceOf(ErrorClassification.Permanent::class.java)
+    }
+
+    @Test
+    fun `classifies 422 unprocessable entity as permanent`() {
+        val error = serviceException(statusCode = 422, message = "422: unprocessable")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isInstanceOf(ErrorClassification.Permanent::class.java)
+    }
+
+    @Test
+    fun `classifies 429 rate limit as transient`() {
+        val error = serviceException(statusCode = 429, message = "429: rate limited")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isEqualTo(ErrorClassification.Transient("429: rate limited"))
+    }
+
+    @Test
+    fun `classifies 500 internal server error as transient`() {
+        val error = serviceException(statusCode = 500, message = "500: server error")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isInstanceOf(ErrorClassification.Transient::class.java)
+    }
+
+    @Test
+    fun `classifies 503 as transient`() {
+        val error = serviceException(statusCode = 503, message = "503: unavailable")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isInstanceOf(ErrorClassification.Transient::class.java)
+    }
+
+    @Test
+    fun `classifies network io failures as transient`() {
+        val error = OpenAIIoException("connection timed out")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isEqualTo(ErrorClassification.Transient("connection timed out"))
+    }
+
+    @Test
+    fun `classifies blank api key as permanent`() {
+        val error = IllegalArgumentException("Missing OpenAI API key")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isEqualTo(ErrorClassification.Permanent("Missing OpenAI API key"))
+    }
+
+    @Test
+    fun `classifies unknown exceptions as transient by default`() {
+        val error = IllegalStateException("OpenAI returned an empty response")
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isEqualTo(ErrorClassification.Transient("OpenAI returned an empty response"))
+    }
+
+    @Test
+    fun `classifies a null error as transient with a default message`() {
+        val result = classifier.classify(null)
+
+        assertThat(result).isEqualTo(ErrorClassification.Transient("Unknown error"))
+    }
+
+    @Test
+    fun `falls back to default message when the exception message is null`() {
+        val error = serviceException(statusCode = 500, message = null)
+
+        val result = classifier.classify(error)
+
+        assertThat(result).isEqualTo(ErrorClassification.Transient("Unknown error"))
+    }
+
+    private fun serviceException(
+        statusCode: Int,
+        message: String?,
+    ): OpenAIServiceException {
+        val exception = mockk<OpenAIServiceException>()
+        every { exception.statusCode() } returns statusCode
+        every { exception.message } returns message
+        return exception
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/domain/usecase/QueuePendingWordUseCaseTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/domain/usecase/QueuePendingWordUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.procrastilearn.app.domain.usecase
 
 import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.domain.repository.PendingWordRepository
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -23,13 +24,32 @@ class QueuePendingWordUseCaseTest {
     }
 
     @Test
-    fun `invoke trims the word and delegates to repository`() =
+    fun `invoke trims the word and delegates to repository with default pending status`() =
         runTest {
-            coEvery { repository.queuePendingWord(any(), any()) } just Runs
+            coEvery { repository.queuePendingWord(any(), any(), any(), any()) } just Runs
 
             useCase(" Haus ", AiTranslationDirection.EN_TO_RU)
 
-            coVerify(exactly = 1) { repository.queuePendingWord("Haus", AiTranslationDirection.EN_TO_RU) }
+            coVerify(exactly = 1) {
+                repository.queuePendingWord("Haus", AiTranslationDirection.EN_TO_RU, PendingWordStatus.PENDING, null)
+            }
+        }
+
+    @Test
+    fun `invoke forwards an explicit failed status and error message`() =
+        runTest {
+            coEvery { repository.queuePendingWord(any(), any(), any(), any()) } just Runs
+
+            useCase("Haus", AiTranslationDirection.EN_TO_RU, PendingWordStatus.FAILED, "401: unauthorized")
+
+            coVerify(exactly = 1) {
+                repository.queuePendingWord(
+                    "Haus",
+                    AiTranslationDirection.EN_TO_RU,
+                    PendingWordStatus.FAILED,
+                    "401: unauthorized",
+                )
+            }
         }
 
     @Test
@@ -38,6 +58,6 @@ class QueuePendingWordUseCaseTest {
             runBlocking { useCase("   ", AiTranslationDirection.EN_TO_RU) }
         }
 
-        coVerify(exactly = 0) { repository.queuePendingWord(any(), any()) }
+        coVerify(exactly = 0) { repository.queuePendingWord(any(), any(), any(), any()) }
     }
 }

--- a/app/src/test/java/com/procrastilearn/app/domain/usecase/RetryPendingWordUseCaseTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/domain/usecase/RetryPendingWordUseCaseTest.kt
@@ -1,0 +1,31 @@
+package com.procrastilearn.app.domain.usecase
+
+import com.procrastilearn.app.domain.repository.PendingWordRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class RetryPendingWordUseCaseTest {
+    private val repository: PendingWordRepository = mockk()
+    private lateinit var useCase: RetryPendingWordUseCase
+
+    @Before
+    fun setUp() {
+        useCase = RetryPendingWordUseCase(repository)
+    }
+
+    @Test
+    fun `invoke delegates to repository with the given id`() =
+        runTest {
+            coEvery { repository.retryPendingWord(any()) } just Runs
+
+            useCase(42L)
+
+            coVerify(exactly = 1) { repository.retryPendingWord(42L) }
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt
@@ -5,8 +5,10 @@ import com.procrastilearn.app.data.connectivity.NetworkConnectivityObserver
 import com.procrastilearn.app.data.local.prefs.OpenAiPreferencesStore
 import com.procrastilearn.app.data.translation.AiTranslationProvider
 import com.procrastilearn.app.data.translation.AiTranslationRequest
+import com.procrastilearn.app.data.translation.TranslationErrorClassifier
 import com.procrastilearn.app.domain.model.AiTranslationDirection
 import com.procrastilearn.app.domain.model.PendingWord
+import com.procrastilearn.app.domain.model.PendingWordStatus
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.AddVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.DeletePendingWordUseCase
@@ -15,6 +17,7 @@ import com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase
 import com.procrastilearn.app.domain.usecase.ObservePendingWordsUseCase
 import com.procrastilearn.app.domain.usecase.OverrideVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.QueuePendingWordUseCase
+import com.procrastilearn.app.domain.usecase.RetryPendingWordUseCase
 import com.procrastilearn.app.utils.MainDispatcherRule
 import io.mockk.Runs
 import io.mockk.clearAllMocks
@@ -33,6 +36,7 @@ import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LargeClass")
 class AddWordViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
@@ -43,7 +47,9 @@ class AddWordViewModelTest {
     private lateinit var queuePendingWordUseCase: QueuePendingWordUseCase
     private lateinit var observePendingWordsUseCase: ObservePendingWordsUseCase
     private lateinit var deletePendingWordUseCase: DeletePendingWordUseCase
+    private lateinit var retryPendingWordUseCase: RetryPendingWordUseCase
     private lateinit var connectivityObserver: NetworkConnectivityObserver
+    private val translationErrorClassifier = TranslationErrorClassifier()
     private lateinit var openAiStore: OpenAiPreferencesStore
     private lateinit var generateAiTranslationUseCase: GenerateAiTranslationUseCase
     private lateinit var openAiKeyFlow: MutableStateFlow<String?>
@@ -63,6 +69,7 @@ class AddWordViewModelTest {
         queuePendingWordUseCase = mockk()
         observePendingWordsUseCase = mockk()
         deletePendingWordUseCase = mockk()
+        retryPendingWordUseCase = mockk()
         connectivityObserver = mockk()
         openAiStore = mockk(relaxed = true)
         openAiKeyFlow = MutableStateFlow(null)
@@ -87,8 +94,9 @@ class AddWordViewModelTest {
         coEvery { overrideVocabularyItemUseCase.invoke(any(), any(), any()) } returns Result.success(Unit)
         every { connectivityObserver.observe() } returns onlineFlow
         every { observePendingWordsUseCase.invoke() } returns pendingWordsFlow
-        coEvery { queuePendingWordUseCase.invoke(any(), any()) } just Runs
+        coEvery { queuePendingWordUseCase.invoke(any(), any(), any(), any()) } just Runs
         coEvery { deletePendingWordUseCase.invoke(any()) } just Runs
+        coEvery { retryPendingWordUseCase.invoke(any()) } just Runs
     }
 
     @After
@@ -106,7 +114,9 @@ class AddWordViewModelTest {
             queuePendingWordUseCase,
             observePendingWordsUseCase,
             deletePendingWordUseCase,
+            retryPendingWordUseCase,
             connectivityObserver,
+            translationErrorClassifier,
         )
 
     @Test
@@ -195,6 +205,41 @@ class AddWordViewModelTest {
             advanceUntilIdle()
 
             coVerify(exactly = 1) { deletePendingWordUseCase.invoke(9L) }
+        }
+
+    @Test
+    fun `onRetryPendingWord delegates to use case`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.onRetryPendingWord(9L)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { retryPendingWordUseCase.invoke(9L) }
+        }
+
+    @Test
+    fun `pendingWords reflects failed status and last error from use case emissions`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            pendingWordsFlow.value =
+                listOf(
+                    PendingWord(
+                        id = 6,
+                        word = "Haus",
+                        direction = AiTranslationDirection.EN_TO_RU,
+                        status = PendingWordStatus.FAILED,
+                        lastError = "401: unauthorized",
+                    ),
+                )
+            advanceUntilIdle()
+
+            val pendingWord = viewModel.uiState.value.pendingWords.single()
+            assertThat(pendingWord.status).isEqualTo(PendingWordStatus.FAILED)
+            assertThat(pendingWord.lastError).isEqualTo("401: unauthorized")
         }
 
     @Test
@@ -622,13 +667,13 @@ class AddWordViewModelTest {
         }
 
     @Test
-    fun `onAddClick falls back when AI translation fails`() =
+    fun `onAddClick queues the word as pending when AI translation fails with a transient error`() =
         runTest(mainDispatcherRule.testDispatcher) {
             openAiKeyFlow.value = "abc"
             useAiFlow.value = true
 
             val viewModel = buildViewModel()
-            aiTranslationProvider.nextError = IllegalStateException("nope")
+            aiTranslationProvider.nextError = IllegalStateException("network blip")
 
             advanceUntilIdle()
 
@@ -638,12 +683,71 @@ class AddWordViewModelTest {
             advanceUntilIdle()
 
             val state = viewModel.uiState.value
-            assertThat(state.translationError).isEqualTo("Please enter a translation")
+            assertThat(state.translationError).isNull()
             assertThat(state.errorMessage).isNull()
-            assertThat(state.isSuccess).isFalse()
+            assertThat(state.isSuccess).isTrue()
+            assertThat(state.successMessage).contains("Saved")
+            assertThat(state.word).isEmpty()
             coVerify(exactly = 0) { addVocabularyItemUseCase.invoke(any(), any()) }
+            coVerify(exactly = 1) {
+                queuePendingWordUseCase.invoke(
+                    "Haus",
+                    AiTranslationDirection.EN_TO_RU,
+                    PendingWordStatus.PENDING,
+                    "network blip",
+                )
+            }
             assertThat(aiTranslationProvider.requests).hasSize(1)
             assertThat(aiTranslationProvider.requests.single().userPrompt).contains("Haus")
+        }
+
+    @Test
+    fun `onAddClick queues the word as failed when AI translation fails with a permanent error`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            openAiKeyFlow.value = "abc"
+            useAiFlow.value = true
+
+            val viewModel = buildViewModel()
+            aiTranslationProvider.nextError = IllegalArgumentException("Missing OpenAI API key")
+
+            advanceUntilIdle()
+
+            viewModel.onWordChange("Haus")
+            viewModel.onAddClick()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.isSuccess).isTrue()
+            coVerify(exactly = 0) { addVocabularyItemUseCase.invoke(any(), any()) }
+            coVerify(exactly = 1) {
+                queuePendingWordUseCase.invoke(
+                    "Haus",
+                    AiTranslationDirection.EN_TO_RU,
+                    PendingWordStatus.FAILED,
+                    "Missing OpenAI API key",
+                )
+            }
+        }
+
+    @Test
+    fun `onAddClick queues the word when AI returns a blank translation`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            openAiKeyFlow.value = "abc"
+            useAiFlow.value = true
+
+            val viewModel = buildViewModel()
+            aiTranslationProvider.nextTranslation = "   "
+
+            advanceUntilIdle()
+
+            viewModel.onWordChange("Haus")
+            viewModel.onAddClick()
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { addVocabularyItemUseCase.invoke(any(), any()) }
+            coVerify(exactly = 1) {
+                queuePendingWordUseCase.invoke("Haus", AiTranslationDirection.EN_TO_RU, PendingWordStatus.PENDING, any())
+            }
         }
 
     @Test


### PR DESCRIPTION
## Summary

Extends the existing offline-word queue to also cover **online** AI-translation failures. Previously, when the app is online but the OpenAI request fails (timeout, 5xx, 429, bad API key, empty response), the word was silently dropped — nothing was queued or retried.

- **Error classification** (`TranslationErrorClassifier`): transient errors (timeouts, 5xx, 429, empty response) are retried with exponential backoff; permanent errors (401/400/403/404/422, bad API key) are marked `FAILED` immediately instead of retried pointlessly.
- **`PendingWordSyncManager`** now polls the queue while online (in addition to the existing offline→online reconnect trigger), retrying eligible items on backoff and capping transient retries at 5 attempts before marking `FAILED`.
- **`AddWordViewModel`**: a failed online AI translation now queues the word (classified as `PENDING` or `FAILED`) and informs the user, instead of showing a translation error.
- **Manual retry**: `FAILED` items are shown distinctly in the pending list with a Retry button (`RetryPendingWordUseCase`), which resets the item and lets the sync manager pick it up again.
- Schema: `pending_words` gains `status`, `retryCount`, `nextAttemptAt`, `lastError` columns (DB version 2 → 3, `MIGRATION_2_3`).

## Test plan

- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew detekt` — passes
- [x] `./gradlew testDebugUnitTest` — full suite passes, including new coverage: error classification (transient vs. permanent, all HTTP status codes), backoff scheduling and cap-then-fail behavior, manual retry, migration 2→3, and the updated `AddWordViewModel`/`AddWordScreen` flows
- [x] `./gradlew lintDebug` — passes (added Russian translations for new strings)
- [x] `./gradlew assembleDebug` — builds successfully
- [ ] `connectedDebugAndroidTest` (instrumented migration test) — not run; no device/emulator available in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018eUv3iTXrUQFYh4Gt1iry9)_