### PR TITLE
feat: add experimental word pronunciation via on-device TTS

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,10 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent>
+        <!-- Required on API 30+ so TextToSpeech can see and bind to the device's TTS engine. -->
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
     </queries>
     <application
         android:localeConfig="@xml/locales_config"

--- a/app/src/main/java/com/procrastilearn/app/data/local/prefs/PronunciationPreferencesStore.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/prefs/PronunciationPreferencesStore.kt
@@ -1,0 +1,27 @@
+package com.procrastilearn.app.data.local.prefs
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PronunciationPreferencesStore
+    @Inject
+    constructor(
+        studyPreferences: StudyPreferencesDataStore,
+    ) {
+        private val ds = studyPreferences.ds
+
+        private object K {
+            val PRONUNCIATION_ENABLED = booleanPreferencesKey("pronunciation_enabled")
+        }
+
+        fun readEnabled(): Flow<Boolean> = ds.data.map { p -> p[K.PRONUNCIATION_ENABLED] ?: false }
+
+        suspend fun setEnabled(enabled: Boolean) {
+            ds.edit { it[K.PRONUNCIATION_ENABLED] = enabled }
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/di/AppModule.kt
+++ b/app/src/main/java/com/procrastilearn/app/di/AppModule.kt
@@ -13,6 +13,8 @@ import com.procrastilearn.app.domain.parser.VocabularyParser
 import com.procrastilearn.app.domain.repository.AppPreferencesRepository
 import com.procrastilearn.app.domain.repository.PendingWordRepository
 import com.procrastilearn.app.domain.repository.VocabularyRepository
+import com.procrastilearn.app.tts.AndroidTtsSpeaker
+import com.procrastilearn.app.tts.Speaker
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -45,6 +47,10 @@ abstract class AppModule {
     @Binds
     @Singleton
     abstract fun bindPendingWordRepository(impl: PendingWordRepositoryImpl): PendingWordRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSpeaker(impl: AndroidTtsSpeaker): Speaker
 
     @Binds
     @IntoSet

--- a/app/src/main/java/com/procrastilearn/app/overlay/OverlayScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/overlay/OverlayScreen.kt
@@ -39,7 +39,12 @@ fun OverlayScreen(
         if (uiState.unlocked) onUnlock()
     }
 
-    OverlayScreen(uiState, viewModel::onToggleShowAnswer, viewModel::onDifficultySelected)
+    OverlayScreen(
+        uiState,
+        viewModel::onToggleShowAnswer,
+        viewModel::onDifficultySelected,
+        viewModel::speakCurrentWord,
+    )
 }
 
 @Suppress("MagicNumber")
@@ -49,6 +54,7 @@ internal fun OverlayScreen(
     uiState: OverlayUiState,
     onToggleShowAnswer: () -> Unit,
     onDifficultySelected: (Rating) -> Unit,
+    onSpeakWord: () -> Unit = {},
 ) {
     OverlayTheme {
         val backgroundGradient =
@@ -70,6 +76,8 @@ internal fun OverlayScreen(
                 state = uiState,
                 onToggleShowAnswer = onToggleShowAnswer,
                 onDifficultySelected = onDifficultySelected,
+                pronunciationEnabled = uiState.pronunciationEnabled,
+                onSpeakWord = onSpeakWord,
             )
         }
     }

--- a/app/src/main/java/com/procrastilearn/app/overlay/OverlayUiState.kt
+++ b/app/src/main/java/com/procrastilearn/app/overlay/OverlayUiState.kt
@@ -7,4 +7,5 @@ data class OverlayUiState(
     val showAnswer: Boolean = false,
     val unlocked: Boolean = false,
     val isLoading: Boolean = false,
+    val pronunciationEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/procrastilearn/app/overlay/OverlayViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/overlay/OverlayViewModel.kt
@@ -3,10 +3,12 @@ package com.procrastilearn.app.overlay
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.data.repository.NoAvailableItemsException
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
+import com.procrastilearn.app.tts.Speaker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.openspacedrepetition.Rating
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,6 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,9 +25,24 @@ class OverlayViewModel
     constructor(
         private val getNextVocabularyItem: GetNextVocabularyItemUseCase,
         private val saveDifficultyRating: SaveDifficultyRatingUseCase,
+        private val pronunciationPreferencesStore: PronunciationPreferencesStore,
+        private val speaker: Speaker,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(OverlayUiState())
         val uiState: StateFlow<OverlayUiState> = _uiState.asStateFlow()
+
+        init {
+            viewModelScope.launch {
+                pronunciationPreferencesStore.readEnabled().collect { enabled ->
+                    _uiState.update { it.copy(pronunciationEnabled = enabled) }
+                }
+            }
+        }
+
+        fun speakCurrentWord() {
+            val word = _uiState.value.vocabularyItem?.word ?: return
+            speaker.speak(word, Locale.ENGLISH)
+        }
 
         fun onOverlayOpened() {
             // Call this when overlay is opened/shown

--- a/app/src/main/java/com/procrastilearn/app/overlay/components/LearningCard.kt
+++ b/app/src/main/java/com/procrastilearn/app/overlay/components/LearningCard.kt
@@ -26,6 +26,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -48,7 +51,7 @@ import com.procrastilearn.app.overlay.OverlayUiState
 import com.procrastilearn.app.overlay.theme.OverlayThemeTokens
 import io.github.openspacedrepetition.Rating
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 fun LearningCard(
     state: OverlayUiState,
@@ -56,6 +59,8 @@ fun LearningCard(
     onDifficultySelected: (Rating) -> Unit,
     showTranslationButtonHeight: androidx.compose.ui.unit.Dp = 52.dp,
     addNavigationBarsPadding: Boolean = true,
+    pronunciationEnabled: Boolean = false,
+    onSpeakWord: () -> Unit = {},
 ) {
     val titleAnnotated =
         buildAnnotatedString {
@@ -89,17 +94,31 @@ fun LearningCard(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // Title
-            Text(
-                text = titleAnnotated,
-                fontSize = 30.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = OverlayThemeTokens.colors.titleColor,
-                textAlign = TextAlign.Center,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
                 modifier =
                     Modifier
                         .padding(top = 6.dp, bottom = 10.dp)
                         .fillMaxWidth(),
-            )
+            ) {
+                Text(
+                    text = titleAnnotated,
+                    fontSize = 30.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = OverlayThemeTokens.colors.titleColor,
+                    textAlign = TextAlign.Center,
+                )
+                if (pronunciationEnabled) {
+                    IconButton(onClick = onSpeakWord) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_volume_up),
+                            contentDescription = stringResource(R.string.learning_speak_word),
+                            tint = OverlayThemeTokens.colors.titleColor,
+                        )
+                    }
+                }
+            }
             // Translation area (middle). Scrollable when shown.
             val scrollState = rememberScrollState()
             LaunchedEffect(state.vocabularyItem?.id, state.showAnswer) {

--- a/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
+++ b/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.data.repository.NoAvailableItemsException
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.repository.AppPreferencesRepository
@@ -28,6 +29,7 @@ import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
 import com.procrastilearn.app.overlay.OverlayScreen
 import com.procrastilearn.app.overlay.OverlayViewModel
+import com.procrastilearn.app.tts.Speaker
 import com.procrastilearn.app.utils.ServiceLifecycleOwner
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.CoroutineScope
@@ -73,6 +75,8 @@ class OverlayAccessibilityService : AccessibilityService() {
     internal lateinit var getNextVocabularyItemUseCase: GetNextVocabularyItemUseCase
     internal lateinit var getSaveDifficultyRatingUseCase: SaveDifficultyRatingUseCase
     internal lateinit var dayCountersStore: DayCountersStore
+    internal lateinit var pronunciationPreferencesStore: PronunciationPreferencesStore
+    internal lateinit var speaker: Speaker
 
     private fun initializeDependenciesIfNeeded() {
         if (!::appPreferencesRepository.isInitialized) {
@@ -89,6 +93,12 @@ class OverlayAccessibilityService : AccessibilityService() {
         }
         if (!::dayCountersStore.isInitialized) {
             dayCountersStore = serviceEntryPoint.dayCountersStore()
+        }
+        if (!::pronunciationPreferencesStore.isInitialized) {
+            pronunciationPreferencesStore = serviceEntryPoint.pronunciationPreferencesStore()
+        }
+        if (!::speaker.isInitialized) {
+            speaker = serviceEntryPoint.speaker()
         }
     }
 
@@ -214,6 +224,8 @@ class OverlayAccessibilityService : AccessibilityService() {
                     ServiceViewModelFactory(
                         getNextVocabularyItemUseCase,
                         getSaveDifficultyRatingUseCase,
+                        pronunciationPreferencesStore,
+                        speaker,
                     ),
                 ).get(OverlayViewModel::class.java)
             // Seed the already-loaded word so the first composition renders it immediately,
@@ -459,6 +471,9 @@ class OverlayAccessibilityService : AccessibilityService() {
         Log.d("OverlayService", "Service destroying")
         hideOverlay()
         stopIntervalTimer()
+        if (::speaker.isInitialized) {
+            speaker.shutdown()
+        }
         serviceScope.cancel()
         super.onDestroy()
     }

--- a/app/src/main/java/com/procrastilearn/app/service/ServiceEntryPoint.kt
+++ b/app/src/main/java/com/procrastilearn/app/service/ServiceEntryPoint.kt
@@ -1,11 +1,13 @@
 package com.procrastilearn.app.service
 
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.domain.repository.AppPreferencesRepository
 import com.procrastilearn.app.domain.repository.VocabularyRepository
 import com.procrastilearn.app.domain.usecase.CheckVocabularyAvailabilityUseCase
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
+import com.procrastilearn.app.tts.Speaker
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
@@ -30,4 +32,8 @@ interface ServiceEntryPoint {
     fun checkVocabularyAvailabilityUseCase(): CheckVocabularyAvailabilityUseCase
 
     fun dayCountersStore(): DayCountersStore
+
+    fun pronunciationPreferencesStore(): PronunciationPreferencesStore
+
+    fun speaker(): Speaker
 }

--- a/app/src/main/java/com/procrastilearn/app/service/ServiceViewModelFactory.kt
+++ b/app/src/main/java/com/procrastilearn/app/service/ServiceViewModelFactory.kt
@@ -2,13 +2,17 @@ package com.procrastilearn.app.service
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
 import com.procrastilearn.app.overlay.OverlayViewModel
+import com.procrastilearn.app.tts.Speaker
 
 class ServiceViewModelFactory(
     private val getNextVocabularyItemUseCase: GetNextVocabularyItemUseCase,
     private val saveDifficultyRatingUseCase: SaveDifficultyRatingUseCase,
+    private val pronunciationPreferencesStore: PronunciationPreferencesStore,
+    private val speaker: Speaker,
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T =
@@ -17,6 +21,8 @@ class ServiceViewModelFactory(
                 OverlayViewModel(
                     getNextVocabularyItem = getNextVocabularyItemUseCase,
                     saveDifficultyRating = saveDifficultyRatingUseCase,
+                    pronunciationPreferencesStore = pronunciationPreferencesStore,
+                    speaker = speaker,
                 ) as T
             }
             else -> throw IllegalArgumentException("Unknown ViewModel class")

--- a/app/src/main/java/com/procrastilearn/app/tts/AndroidTtsSpeaker.kt
+++ b/app/src/main/java/com/procrastilearn/app/tts/AndroidTtsSpeaker.kt
@@ -1,0 +1,131 @@
+package com.procrastilearn.app.tts
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.Locale
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Wraps a single, lazily-created [TextToSpeech] engine binding. All public methods are expected
+ * to be called from the main thread (matches viewModelScope's default dispatcher), so the
+ * internal state isn't guarded beyond that confinement.
+ */
+@Singleton
+class AndroidTtsSpeaker
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) : Speaker {
+        private companion object {
+            const val TAG = "AndroidTtsSpeaker"
+            const val IDLE_TIMEOUT_MS = 60_000L
+        }
+
+        @VisibleForTesting
+        internal var engineFactory: (Context, TextToSpeech.OnInitListener) -> TextToSpeech =
+            { ctx, listener -> TextToSpeech(ctx, listener) }
+
+        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+        private var engine: TextToSpeech? = null
+        private var isReady = false
+        private var pendingUtterance: PendingUtterance? = null
+        private var idleShutdownJob: Job? = null
+
+        private data class PendingUtterance(
+            val text: String,
+            val locale: Locale,
+        )
+
+        override fun speak(
+            text: String,
+            locale: Locale,
+        ) {
+            armIdleShutdown()
+
+            val currentEngine = engine
+            when {
+                currentEngine == null -> {
+                    pendingUtterance = PendingUtterance(text, locale)
+                    initEngine()
+                }
+                !isReady -> pendingUtterance = PendingUtterance(text, locale)
+                else -> speakNow(currentEngine, text, locale)
+            }
+        }
+
+        private fun initEngine() {
+            if (engine != null) return
+            engine =
+                engineFactory(context) { status ->
+                    scope.launch { onInitResult(status) }
+                }
+        }
+
+        private fun onInitResult(status: Int) {
+            val currentEngine = engine
+            if (status != TextToSpeech.SUCCESS || currentEngine == null) {
+                Log.w(TAG, "TextToSpeech init failed with status=$status")
+                isReady = false
+                pendingUtterance = null
+                // Reset so the next speak() retries initialization instead of silently
+                // queuing utterances that would never be flushed.
+                currentEngine?.shutdown()
+                engine = null
+                return
+            }
+
+            isReady = true
+            pendingUtterance?.let { pending ->
+                pendingUtterance = null
+                speakNow(currentEngine, pending.text, pending.locale)
+            }
+        }
+
+        private fun speakNow(
+            engine: TextToSpeech,
+            text: String,
+            locale: Locale,
+        ) {
+            val languageResult = engine.setLanguage(locale)
+            if (languageResult == TextToSpeech.LANG_MISSING_DATA ||
+                languageResult == TextToSpeech.LANG_NOT_SUPPORTED
+            ) {
+                Log.w(TAG, "Locale $locale not supported by TTS engine, result=$languageResult")
+                return
+            }
+            engine.speak(text, TextToSpeech.QUEUE_FLUSH, null, UUID.randomUUID().toString())
+        }
+
+        private fun armIdleShutdown() {
+            idleShutdownJob?.cancel()
+            idleShutdownJob =
+                scope.launch {
+                    delay(IDLE_TIMEOUT_MS)
+                    shutdown()
+                }
+        }
+
+        override fun shutdown() {
+            idleShutdownJob?.cancel()
+            idleShutdownJob = null
+            pendingUtterance = null
+            isReady = false
+            engine?.let {
+                it.stop()
+                it.shutdown()
+            }
+            engine = null
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/tts/Speaker.kt
+++ b/app/src/main/java/com/procrastilearn/app/tts/Speaker.kt
@@ -1,0 +1,12 @@
+package com.procrastilearn.app.tts
+
+import java.util.Locale
+
+interface Speaker {
+    fun speak(
+        text: String,
+        locale: Locale,
+    )
+
+    fun shutdown()
+}

--- a/app/src/main/java/com/procrastilearn/app/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.procrastilearn.app.data.local.mapper.toEntity
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
 import com.procrastilearn.app.data.local.prefs.OpenAiPreferencesStore
 import com.procrastilearn.app.data.local.prefs.OpenAiPromptDefaults
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.domain.model.MixMode
 import com.procrastilearn.app.domain.model.VocabularyExportItem
 import com.procrastilearn.app.domain.model.VocabularyItem
@@ -41,9 +42,11 @@ data class SettingsUiState(
     val openAiApiKey: String? = null,
     val openAiPrompt: String = OpenAiPromptDefaults.translationPrompt,
     val openAiReversePrompt: String = OpenAiPromptDefaults.reverseTranslationPrompt,
+    val pronunciationEnabled: Boolean = false,
 )
 
 @HiltViewModel
+@Suppress("LongParameterList")
 class SettingsViewModel
     @Inject
     constructor(
@@ -53,6 +56,7 @@ class SettingsViewModel
         private val vocabularyRepository: VocabularyRepository,
         private val parsers: Set<@JvmSuppressWildcards VocabularyParser>,
         private val ioDispatcher: CoroutineDispatcher,
+        private val pronunciationPreferencesStore: PronunciationPreferencesStore,
     ) : ViewModel() {
         val uiState: StateFlow<SettingsUiState> =
             kotlinx.coroutines.flow
@@ -61,7 +65,8 @@ class SettingsViewModel
                     openAiStore.readOpenAiApiKey(),
                     openAiStore.readOpenAiPrompt(),
                     openAiStore.readOpenAiReversePrompt(),
-                ) { policy, apiKey, prompt, reversePrompt ->
+                    pronunciationPreferencesStore.readEnabled(),
+                ) { policy, apiKey, prompt, reversePrompt, pronunciationEnabled ->
                     SettingsUiState(
                         mixMode = policy.mixMode,
                         newPerDay = policy.newPerDay,
@@ -70,6 +75,7 @@ class SettingsViewModel
                         openAiApiKey = apiKey,
                         openAiPrompt = prompt,
                         openAiReversePrompt = reversePrompt,
+                        pronunciationEnabled = pronunciationEnabled,
                     )
                 }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState())
 
@@ -124,6 +130,10 @@ class SettingsViewModel
 
         fun onOpenAiReversePromptChange(value: String) {
             viewModelScope.launch { openAiStore.setOpenAiReversePrompt(value) }
+        }
+
+        fun onPronunciationEnabledChange(enabled: Boolean) {
+            viewModelScope.launch { pronunciationPreferencesStore.setEnabled(enabled) }
         }
 
         /**

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoScreen.kt
@@ -38,7 +38,12 @@ import io.github.openspacedrepetition.Rating
 @Composable
 fun DojoScreen(viewModel: DojoViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsState()
-    DojoScreen(uiState, viewModel::onToggleShowAnswer, viewModel::onDifficultySelected)
+    DojoScreen(
+        uiState,
+        viewModel::onToggleShowAnswer,
+        viewModel::onDifficultySelected,
+        viewModel::speakCurrentWord,
+    )
 }
 
 @VisibleForTesting
@@ -47,6 +52,7 @@ internal fun DojoScreen(
     uiState: DojoUiState,
     onToggleShowAnswer: () -> Unit,
     onDifficultySelected: (Rating) -> Unit,
+    onSpeakWord: () -> Unit = {},
 ) {
     MyApplicationTheme {
         Surface(
@@ -97,6 +103,8 @@ internal fun DojoScreen(
                                     onDifficultySelected = onDifficultySelected,
                                     showTranslationButtonHeight = 56.dp,
                                     addNavigationBarsPadding = false,
+                                    pronunciationEnabled = uiState.pronunciationEnabled,
+                                    onSpeakWord = onSpeakWord,
                                 )
                             }
                         }

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoUiState.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoUiState.kt
@@ -10,6 +10,7 @@ data class DojoUiState(
     // Stats state
     val newQuotaRemaining: Int = 0,
     val pendingReviewCount: Int = 0,
+    val pronunciationEnabled: Boolean = false,
 ) {
     val hasNoWords: Boolean get() = vocabularyItem == null && !isLoading
 }

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.data.repository.NoAvailableItemsException
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
+import com.procrastilearn.app.tts.Speaker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.openspacedrepetition.Rating
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,6 +19,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,6 +30,8 @@ class DojoViewModel
         private val saveDifficultyRating: SaveDifficultyRatingUseCase,
         private val vocabularyDao: VocabularyDao,
         private val dayCountersStore: DayCountersStore,
+        private val pronunciationPreferencesStore: PronunciationPreferencesStore,
+        private val speaker: Speaker,
     ) : ViewModel() {
         private val flashcardState = MutableStateFlow(FlashcardState())
 
@@ -40,7 +45,8 @@ class DojoViewModel
                 dayCountersStore.read(),
                 dayCountersStore.readPolicy(),
                 reviewsDueCount,
-            ) { flashcard, counters, policy, pendingReviews ->
+                pronunciationPreferencesStore.readEnabled(),
+            ) { flashcard, counters, policy, pendingReviews, pronunciationEnabled ->
                 // Calculate stats reactively
                 val newQuotaRemaining =
                     (policy.newPerDay + counters.extraNewToday - counters.newShown).coerceAtLeast(0)
@@ -55,6 +61,7 @@ class DojoViewModel
                     isLoading = flashcard.isLoading,
                     newQuotaRemaining = newQuotaRemaining,
                     pendingReviewCount = pendingReviewCount,
+                    pronunciationEnabled = pronunciationEnabled,
                 )
             }.stateIn(viewModelScope, SharingStarted.Eagerly, DojoUiState(isLoading = true))
 
@@ -77,6 +84,11 @@ class DojoViewModel
 
         fun onToggleShowAnswer() {
             flashcardState.value = flashcardState.value.copy(showAnswer = !flashcardState.value.showAnswer)
+        }
+
+        fun speakCurrentWord() {
+            val word = flashcardState.value.vocabularyItem?.word ?: return
+            speaker.speak(word, Locale.ENGLISH)
         }
 
         fun onDifficultySelected(rating: Rating) {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
@@ -59,6 +59,7 @@ import com.procrastilearn.app.ui.screens.settings.components.OpenAiApiKeySetting
 import com.procrastilearn.app.ui.screens.settings.components.OpenAiPromptSettingsItem
 import com.procrastilearn.app.ui.screens.settings.components.OpenAiReversePromptSettingsItem
 import com.procrastilearn.app.ui.screens.settings.components.OverlayPermissionItem
+import com.procrastilearn.app.ui.screens.settings.components.PronunciationSettingsItem
 import com.procrastilearn.app.ui.screens.settings.components.ReviewPerDaySettingsItem
 import com.procrastilearn.app.ui.screens.settings.components.ShowOverlayIntervalSettingsItem
 import com.procrastilearn.app.ui.screens.settings.components.StringInputDialog
@@ -162,6 +163,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
             openAiApiKey = state.openAiApiKey,
             openAiPrompt = state.openAiPrompt,
             openAiReversePrompt = state.openAiReversePrompt,
+            pronunciationEnabled = state.pronunciationEnabled,
             onOverlayClick = { openOverlaySettings(ctx) },
             onA11yClick = { openAccessibilitySettings(ctx) },
             onMixModeChange = viewModel::onMixModeChange,
@@ -173,6 +175,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
             onOpenAiApiKeyChange = viewModel::onOpenAiApiKeyChange,
             onOpenAiPromptChange = viewModel::onOpenAiPromptChange,
             onOpenAiReversePromptChange = viewModel::onOpenAiReversePromptChange,
+            onPronunciationEnabledChange = viewModel::onPronunciationEnabledChange,
             onExportClick = {
                 val name = "vocabulary-export-${LocalDate.now()}.json"
                 exportLauncher.launch(name)
@@ -212,6 +215,7 @@ internal fun SettingsContent(
     openAiApiKey: String?,
     openAiPrompt: String,
     openAiReversePrompt: String,
+    pronunciationEnabled: Boolean = false,
     onOverlayClick: () -> Unit,
     onA11yClick: () -> Unit,
     onMixModeChange: (MixMode) -> Unit,
@@ -223,6 +227,7 @@ internal fun SettingsContent(
     onOpenAiApiKeyChange: (String) -> Unit,
     onOpenAiPromptChange: (String) -> Unit,
     onOpenAiReversePromptChange: (String) -> Unit,
+    onPronunciationEnabledChange: (Boolean) -> Unit = {},
     onExportClick: () -> Unit,
     importOptions: List<VocabularyImportOption> = emptyList(),
     onImportOptionSelected: (VocabularyImportOption) -> Unit = {},
@@ -288,6 +293,13 @@ internal fun SettingsContent(
             OpenAiReversePromptSettingsItem(
                 prompt = openAiReversePrompt,
                 onClick = { dialogState = DialogState.OpenAiReversePrompt },
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            PronunciationSettingsItem(
+                isEnabled = pronunciationEnabled,
+                onToggle = onPronunciationEnabledChange,
             )
             Divider(
                 modifier = Modifier.padding(vertical = 8.dp),

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/PronunciationSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/PronunciationSettingsItem.kt
@@ -1,0 +1,59 @@
+package com.procrastilearn.app.ui.screens.settings.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.unit.dp
+import com.procrastilearn.app.R
+
+@Composable
+fun PronunciationSettingsItem(
+    isEnabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_pronunciation_title)) },
+        supportingContent = {
+            Text(
+                stringResource(R.string.settings_pronunciation_desc),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        trailingContent = {
+            Checkbox(
+                checked = isEnabled,
+                onCheckedChange = null,
+                modifier =
+                    Modifier
+                        .testTag("pronunciation_settings_checkbox")
+                        .semantics {
+                            role = Role.Checkbox
+                            this[SemanticsProperties.ToggleableState] =
+                                if (isEnabled) {
+                                    ToggleableState.On
+                                } else {
+                                    ToggleableState.Off
+                                }
+                        },
+            )
+        },
+        modifier =
+            Modifier
+                .clickable { onToggle(!isEnabled) }
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+                .fillMaxWidth(),
+    )
+}

--- a/app/src/main/res/drawable/ic_volume_up.xml
+++ b/app/src/main/res/drawable/ic_volume_up.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,9v6h4l5,5V4L7,9H3z M16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02z M14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z" />
+</vector>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,6 +37,7 @@
         <string name="learning_no_translation">Перевод не загружен</string>
         <string name="learning_show_translation">Показать перевод</string>
         <string name="learning_question">Насколько хорошо вы знали это?</string>
+        <string name="learning_speak_word">Произнести слово</string>
 
         <!-- Ratings -->
         <string name="rating_again">Снова</string>
@@ -124,6 +125,10 @@
         <string name="settings_study_mode_mixed_desc">Смешивать новые и повторения</string>
         <string name="settings_study_mode_reviews_first_desc">Показывать все повторения перед новыми карточками</string>
         <string name="settings_study_mode_new_first_desc">Показывать новые карточки перед повторениями</string>
+
+        <!-- Pronunciation -->
+        <string name="settings_pronunciation_title">Включить произношение (Экспериментально)</string>
+        <string name="settings_pronunciation_desc">Добавляет значок динамика рядом со словом, чтобы услышать его произношение</string>
 
         <!-- Daily limits -->
         <string name="settings_add_cards_for_today_title">Добавить карточки на сегодня</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="learning_no_translation">No translation loaded</string>
     <string name="learning_show_translation">Show translation</string>
     <string name="learning_question">How well did you know this?</string>
+    <string name="learning_speak_word">Pronounce word</string>
 
     <!-- Ratings -->
     <string name="rating_again">Again</string>
@@ -130,6 +131,10 @@
     <string name="settings_study_mode_mixed_desc">Mix new and review cards</string>
     <string name="settings_study_mode_reviews_first_desc">Show all reviews before new cards</string>
     <string name="settings_study_mode_new_first_desc">Show new cards before reviews</string>
+
+    <!-- Pronunciation -->
+    <string name="settings_pronunciation_title">Enable pronunciation (Experimental)</string>
+    <string name="settings_pronunciation_desc">Adds a speaker icon next to the word to hear it pronounced</string>
 
     <!-- Daily limits -->
     <string name="settings_add_cards_for_today_title">Add Cards For Today</string>

--- a/app/src/test/java/com/procrastilearn/app/data/local/prefs/PronunciationPreferencesStoreTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/prefs/PronunciationPreferencesStoreTest.kt
@@ -1,0 +1,54 @@
+package com.procrastilearn.app.data.local.prefs
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class PronunciationPreferencesStoreTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var store: PronunciationPreferencesStore
+
+    @Before
+    fun setUp() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val filesRoot = temporaryFolder.newFolder("datastore-root")
+        val dataStoreContext =
+            object : ContextWrapper(baseContext) {
+                override fun getFilesDir(): File = filesRoot
+
+                override fun getApplicationContext(): Context = this
+            }
+        store = PronunciationPreferencesStore(StudyPreferencesDataStore(dataStoreContext))
+    }
+
+    @Test
+    fun `defaults to disabled when preference missing`() =
+        runTest {
+            assertThat(store.readEnabled().first()).isFalse()
+        }
+
+    @Test
+    fun `enabling and disabling persists`() =
+        runTest {
+            store.setEnabled(true)
+            assertThat(store.readEnabled().first()).isTrue()
+
+            store.setEnabled(false)
+            assertThat(store.readEnabled().first()).isFalse()
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/overlay/OverlayScreenTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/overlay/OverlayScreenTest.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
@@ -195,5 +197,76 @@ class OverlayScreenTest {
 
         composeTestRule.onNodeWithText(noWordText).assertIsDisplayed()
         composeTestRule.onNodeWithText(noTranslationText, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `speaker icon hidden when pronunciation is disabled`() {
+        composeTestRule.setContent {
+            OverlayScreen(
+                uiState =
+                    OverlayUiState(
+                        vocabularyItem = sampleVocabularyItem,
+                        showAnswer = false,
+                        pronunciationEnabled = false,
+                    ),
+                onToggleShowAnswer = {},
+                onDifficultySelected = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        val speakContentDescription = context.getString(R.string.learning_speak_word)
+        composeTestRule
+            .onAllNodesWithContentDescription(speakContentDescription)
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `speaker icon shown when pronunciation is enabled`() {
+        composeTestRule.setContent {
+            OverlayScreen(
+                uiState =
+                    OverlayUiState(
+                        vocabularyItem = sampleVocabularyItem,
+                        showAnswer = false,
+                        pronunciationEnabled = true,
+                    ),
+                onToggleShowAnswer = {},
+                onDifficultySelected = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        val speakContentDescription = context.getString(R.string.learning_speak_word)
+        composeTestRule
+            .onNodeWithContentDescription(speakContentDescription)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `clicking speaker icon invokes onSpeakWord`() {
+        var spoken = false
+
+        composeTestRule.setContent {
+            OverlayScreen(
+                uiState =
+                    OverlayUiState(
+                        vocabularyItem = sampleVocabularyItem,
+                        showAnswer = false,
+                        pronunciationEnabled = true,
+                    ),
+                onToggleShowAnswer = {},
+                onDifficultySelected = {},
+                onSpeakWord = { spoken = true },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        val speakContentDescription = context.getString(R.string.learning_speak_word)
+        composeTestRule.onNodeWithContentDescription(speakContentDescription).performClick()
+
+        composeTestRule.runOnIdle {
+            assertThat(spoken).isTrue()
+        }
     }
 }

--- a/app/src/test/java/com/procrastilearn/app/overlay/OverlayViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/overlay/OverlayViewModelTest.kt
@@ -2,10 +2,12 @@ package com.procrastilearn.app.overlay
 
 import android.util.Log
 import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.data.repository.NoAvailableItemsException
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
+import com.procrastilearn.app.tts.Speaker
 import com.procrastilearn.app.utils.MainDispatcherRule
 import io.github.openspacedrepetition.Rating
 import io.mockk.clearAllMocks
@@ -15,7 +17,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -23,6 +27,7 @@ import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OverlayViewModelTest {
@@ -31,6 +36,9 @@ class OverlayViewModelTest {
 
     private lateinit var getNextVocabularyItem: GetNextVocabularyItemUseCase
     private lateinit var saveDifficultyRating: SaveDifficultyRatingUseCase
+    private lateinit var pronunciationPreferencesStore: PronunciationPreferencesStore
+    private lateinit var speaker: Speaker
+    private lateinit var pronunciationEnabledFlow: MutableStateFlow<Boolean>
 
     @Before
     fun setUp() {
@@ -38,6 +46,10 @@ class OverlayViewModelTest {
         every { Log.i(any(), any()) } returns 0
         getNextVocabularyItem = mockk()
         saveDifficultyRating = mockk()
+        pronunciationPreferencesStore = mockk()
+        speaker = mockk(relaxed = true)
+        pronunciationEnabledFlow = MutableStateFlow(false)
+        every { pronunciationPreferencesStore.readEnabled() } returns pronunciationEnabledFlow
     }
 
     @After
@@ -46,7 +58,13 @@ class OverlayViewModelTest {
         unmockkStatic(Log::class)
     }
 
-    private fun buildViewModel(): OverlayViewModel = OverlayViewModel(getNextVocabularyItem, saveDifficultyRating)
+    private fun buildViewModel(): OverlayViewModel =
+        OverlayViewModel(
+            getNextVocabularyItem,
+            saveDifficultyRating,
+            pronunciationPreferencesStore,
+            speaker,
+        )
 
     @Test
     fun `onOverlayOpened loads next item and resets reveal state`() =
@@ -190,4 +208,41 @@ class OverlayViewModelTest {
             assertThat(state.showAnswer).isFalse()
             assertThat(state.vocabularyItem).isEqualTo(item)
         }
+
+    @Test
+    fun `pronunciationEnabled reflects the preference store`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.pronunciationEnabled).isFalse()
+
+            pronunciationEnabledFlow.value = true
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.pronunciationEnabled).isTrue()
+        }
+
+    @Test
+    fun `speakCurrentWord delegates to speaker with the current word in English`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 42, word = "Haus", translation = "House", isNew = true)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+
+            val viewModel = buildViewModel()
+            viewModel.onOverlayOpened()
+            advanceUntilIdle()
+
+            viewModel.speakCurrentWord()
+
+            verify(exactly = 1) { speaker.speak("Haus", Locale.ENGLISH) }
+        }
+
+    @Test
+    fun `speakCurrentWord is a no-op when no word is loaded`() {
+        val viewModel = buildViewModel()
+
+        viewModel.speakCurrentWord()
+
+        verify(exactly = 0) { speaker.speak(any(), any()) }
+    }
 }

--- a/app/src/test/java/com/procrastilearn/app/tts/AndroidTtsSpeakerTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/tts/AndroidTtsSpeakerTest.kt
@@ -1,0 +1,282 @@
+package com.procrastilearn.app.tts
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.util.Log
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.utils.MainDispatcherRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * [kotlinx.coroutines.test.TestCoroutineScheduler.advanceUntilIdle] fast-forwards through *any*
+ * pending delay, including the speaker's 60s idle-shutdown timer - so these tests use
+ * [runCurrent] to flush only the zero-delay init-callback dispatch, and reserve explicit
+ * [advanceTimeBy] for the tests that actually exercise the idle timeout.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AndroidTtsSpeakerTest {
+    private companion object {
+        const val IDLE_TIMEOUT_MS = 60_000L
+    }
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val context: Context = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.w(any(), any<String>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    private fun buildSpeaker(
+        engine: TextToSpeech,
+        onListenerCaptured: (TextToSpeech.OnInitListener) -> Unit,
+    ): AndroidTtsSpeaker {
+        val speaker = AndroidTtsSpeaker(context)
+        speaker.engineFactory = { _, listener ->
+            onListenerCaptured(listener)
+            engine
+        }
+        return speaker
+    }
+
+    private fun readyEngine(): TextToSpeech {
+        val engine = mockk<TextToSpeech>(relaxed = true)
+        every { engine.setLanguage(any()) } returns TextToSpeech.LANG_AVAILABLE
+        return engine
+    }
+
+    @Test
+    fun `speak before init completes queues the utterance`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val engine = readyEngine()
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = buildSpeaker(engine) { listener = it }
+
+            speaker.speak("hello", Locale.ENGLISH)
+            runCurrent()
+
+            verify(exactly = 0) { engine.speak(any(), any(), any(), any()) }
+
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            verify(exactly = 1) { engine.setLanguage(Locale.ENGLISH) }
+            verify(exactly = 1) { engine.speak("hello", TextToSpeech.QUEUE_FLUSH, null, any()) }
+        }
+
+    @Test
+    fun `speak only flushes the most recent pending utterance`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val engine = readyEngine()
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = buildSpeaker(engine) { listener = it }
+
+            speaker.speak("first", Locale.ENGLISH)
+            speaker.speak("second", Locale.ENGLISH)
+            runCurrent()
+
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            verify(exactly = 0) { engine.speak("first", any(), any(), any()) }
+            verify(exactly = 1) { engine.speak("second", TextToSpeech.QUEUE_FLUSH, null, any()) }
+        }
+
+    @Test
+    fun `speak on an already-ready engine speaks immediately without re-init`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val engine = readyEngine()
+            var listener: TextToSpeech.OnInitListener? = null
+            var factoryCalls = 0
+            val speaker = AndroidTtsSpeaker(context)
+            speaker.engineFactory = { _, l ->
+                factoryCalls++
+                listener = l
+                engine
+            }
+
+            speaker.speak("warm-up", Locale.ENGLISH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            speaker.speak("second call", Locale.ENGLISH)
+            runCurrent()
+
+            assertThat(factoryCalls).isEqualTo(1)
+            verify(exactly = 1) { engine.speak("second call", TextToSpeech.QUEUE_FLUSH, null, any()) }
+        }
+
+    @Test
+    fun `init failure drops the pending utterance and retries engine creation on next speak`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            var factoryCalls = 0
+            val failingEngine = mockk<TextToSpeech>(relaxed = true)
+            val workingEngine = readyEngine()
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = AndroidTtsSpeaker(context)
+            speaker.engineFactory = { _, l ->
+                factoryCalls++
+                listener = l
+                if (factoryCalls == 1) failingEngine else workingEngine
+            }
+
+            speaker.speak("hello", Locale.ENGLISH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.ERROR)
+            runCurrent()
+
+            verify(exactly = 0) { failingEngine.speak(any(), any(), any(), any()) }
+
+            // A later tap should retry initialization rather than staying stuck forever.
+            speaker.speak("hello again", Locale.ENGLISH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            assertThat(factoryCalls).isEqualTo(2)
+            verify(exactly = 1) { workingEngine.speak("hello again", TextToSpeech.QUEUE_FLUSH, null, any()) }
+        }
+
+    @Test
+    fun `unsupported locale does not invoke engine speak`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val engine = mockk<TextToSpeech>(relaxed = true)
+            every { engine.setLanguage(any()) } returns TextToSpeech.LANG_NOT_SUPPORTED
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = buildSpeaker(engine) { listener = it }
+
+            speaker.speak("bonjour", Locale.FRENCH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            verify(exactly = 1) { engine.setLanguage(Locale.FRENCH) }
+            verify(exactly = 0) { engine.speak(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `missing language data does not invoke engine speak`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val engine = mockk<TextToSpeech>(relaxed = true)
+            every { engine.setLanguage(any()) } returns TextToSpeech.LANG_MISSING_DATA
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = buildSpeaker(engine) { listener = it }
+
+            speaker.speak("bonjour", Locale.FRENCH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            verify(exactly = 0) { engine.speak(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `idle timeout shuts down the engine automatically`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val engine = readyEngine()
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = buildSpeaker(engine) { listener = it }
+
+            speaker.speak("hello", Locale.ENGLISH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            advanceTimeBy(IDLE_TIMEOUT_MS + 1_000L)
+            runCurrent()
+
+            verify(exactly = 1) { engine.stop() }
+            verify(exactly = 1) { engine.shutdown() }
+        }
+
+    @Test
+    fun `repeated speak calls reset the idle timer`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val engine = readyEngine()
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = buildSpeaker(engine) { listener = it }
+
+            speaker.speak("hello", Locale.ENGLISH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            // Tap again just before the idle window would expire.
+            advanceTimeBy(IDLE_TIMEOUT_MS - 1_000L)
+            speaker.speak("hello", Locale.ENGLISH)
+            runCurrent()
+
+            // Original deadline has passed, but the timer was reset - engine must still be alive.
+            advanceTimeBy(2_000L)
+            runCurrent()
+            verify(exactly = 0) { engine.shutdown() }
+
+            // Now let the reset timer actually expire.
+            advanceTimeBy(IDLE_TIMEOUT_MS)
+            runCurrent()
+            verify(exactly = 1) { engine.shutdown() }
+        }
+
+    @Test
+    fun `explicit shutdown releases the engine and next speak re-initializes`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            var factoryCalls = 0
+            val firstEngine = readyEngine()
+            val secondEngine = readyEngine()
+            var listener: TextToSpeech.OnInitListener? = null
+            val speaker = AndroidTtsSpeaker(context)
+            speaker.engineFactory = { _, l ->
+                factoryCalls++
+                listener = l
+                if (factoryCalls == 1) firstEngine else secondEngine
+            }
+
+            speaker.speak("hello", Locale.ENGLISH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            speaker.shutdown()
+
+            verify(exactly = 1) { firstEngine.stop() }
+            verify(exactly = 1) { firstEngine.shutdown() }
+
+            speaker.speak("hello again", Locale.ENGLISH)
+            runCurrent()
+            listener?.onInit(TextToSpeech.SUCCESS)
+            runCurrent()
+
+            assertThat(factoryCalls).isEqualTo(2)
+            verify(exactly = 1) { secondEngine.speak("hello again", TextToSpeech.QUEUE_FLUSH, null, any()) }
+        }
+
+    @Test
+    fun `shutdown is safe to call before any speak`() {
+        val speaker = AndroidTtsSpeaker(context)
+
+        speaker.shutdown()
+        speaker.shutdown()
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/SettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import com.procrastilearn.app.data.local.entity.VocabularyEntity
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
 import com.procrastilearn.app.data.local.prefs.OpenAiPreferencesStore
 import com.procrastilearn.app.data.local.prefs.OpenAiPromptDefaults
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.domain.model.LearningPreferencesConfig
 import com.procrastilearn.app.domain.model.MixMode
 import com.procrastilearn.app.domain.model.VocabularyExportItem
@@ -51,10 +52,12 @@ class SettingsViewModelTest {
     private lateinit var openAiStore: OpenAiPreferencesStore
     private lateinit var vocabularyDao: VocabularyDao
     private lateinit var vocabularyRepository: VocabularyRepository
+    private lateinit var pronunciationPreferencesStore: PronunciationPreferencesStore
     private lateinit var policyFlow: MutableStateFlow<LearningPreferencesConfig>
     private lateinit var apiKeyFlow: MutableStateFlow<String?>
     private lateinit var promptFlow: MutableStateFlow<String>
     private lateinit var reversePromptFlow: MutableStateFlow<String>
+    private lateinit var pronunciationEnabledFlow: MutableStateFlow<Boolean>
     private val defaultParser: VocabularyParser =
         object : VocabularyParser {
             override val id: String = "apkg"
@@ -73,6 +76,7 @@ class SettingsViewModelTest {
         openAiStore = mockk(relaxed = true)
         vocabularyDao = mockk()
         vocabularyRepository = mockk(relaxed = true)
+        pronunciationPreferencesStore = mockk(relaxed = true)
         policyFlow =
             MutableStateFlow(
                 LearningPreferencesConfig(
@@ -85,11 +89,13 @@ class SettingsViewModelTest {
         apiKeyFlow = MutableStateFlow(null)
         promptFlow = MutableStateFlow(OpenAiPromptDefaults.translationPrompt)
         reversePromptFlow = MutableStateFlow(OpenAiPromptDefaults.reverseTranslationPrompt)
+        pronunciationEnabledFlow = MutableStateFlow(false)
 
         every { dayCountersStore.readPolicy() } returns policyFlow
         every { openAiStore.readOpenAiApiKey() } returns apiKeyFlow
         every { openAiStore.readOpenAiPrompt() } returns promptFlow
         every { openAiStore.readOpenAiReversePrompt() } returns reversePromptFlow
+        every { pronunciationPreferencesStore.readEnabled() } returns pronunciationEnabledFlow
     }
 
     @After
@@ -105,6 +111,7 @@ class SettingsViewModelTest {
             vocabularyRepository = vocabularyRepository,
             parsers = parsers,
             ioDispatcher = mainDispatcherRule.testDispatcher,
+            pronunciationPreferencesStore = pronunciationPreferencesStore,
         )
 
     @Test
@@ -137,6 +144,7 @@ class SettingsViewModelTest {
                 assertThat(hydrated.openAiApiKey).isNull()
                 assertThat(hydrated.openAiPrompt).isEqualTo(OpenAiPromptDefaults.translationPrompt)
                 assertThat(hydrated.openAiReversePrompt).isEqualTo(OpenAiPromptDefaults.reverseTranslationPrompt)
+                assertThat(hydrated.pronunciationEnabled).isFalse()
 
                 policyFlow.value =
                     policyFlow.value.copy(
@@ -148,6 +156,7 @@ class SettingsViewModelTest {
                 apiKeyFlow.value = "abc"
                 promptFlow.value = "custom prompt"
                 reversePromptFlow.value = "custom reverse prompt"
+                pronunciationEnabledFlow.value = true
 
                 val updated = awaitItem()
                 assertThat(updated.mixMode).isEqualTo(MixMode.NEW_FIRST)
@@ -157,6 +166,7 @@ class SettingsViewModelTest {
                 assertThat(updated.openAiApiKey).isEqualTo("abc")
                 assertThat(updated.openAiPrompt).isEqualTo("custom prompt")
                 assertThat(updated.openAiReversePrompt).isEqualTo("custom reverse prompt")
+                assertThat(updated.pronunciationEnabled).isTrue()
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -272,6 +282,18 @@ class SettingsViewModelTest {
             advanceUntilIdle()
 
             coVerify { openAiStore.setOpenAiReversePrompt("prompt") }
+        }
+
+    @Test
+    fun `onPronunciationEnabledChange delegates to store`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            coEvery { pronunciationPreferencesStore.setEnabled(any()) } returns Unit
+
+            viewModel.onPronunciationEnabledChange(true)
+            advanceUntilIdle()
+
+            coVerify { pronunciationPreferencesStore.setEnabled(true) }
         }
 
     @Test

--- a/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoScreenTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoScreenTest.kt
@@ -1,0 +1,100 @@
+package com.procrastilearn.app.ui.dojo
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.R
+import com.procrastilearn.app.domain.model.VocabularyItem
+import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    sdk = [33],
+    manifest = Config.NONE,
+)
+class DojoScreenTest {
+    private val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val rules: TestRule =
+        RuleChain
+            .outerRule(ComponentActivityRegistrationRule())
+            .around(composeTestRule)
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val sampleVocabularyItem =
+        VocabularyItem(
+            id = 1L,
+            word = "Haus",
+            translation = "House",
+            isNew = false,
+        )
+
+    @Test
+    fun `speaker icon hidden when pronunciation is disabled`() {
+        composeTestRule.setContent {
+            DojoScreen(
+                uiState =
+                    DojoUiState(
+                        vocabularyItem = sampleVocabularyItem,
+                        showAnswer = false,
+                        isLoading = false,
+                        pronunciationEnabled = false,
+                    ),
+                onToggleShowAnswer = {},
+                onDifficultySelected = {},
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        val speakContentDescription = context.getString(R.string.learning_speak_word)
+        composeTestRule
+            .onAllNodesWithContentDescription(speakContentDescription)
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `speaker icon shown and wired when pronunciation is enabled`() {
+        var spoken = false
+
+        composeTestRule.setContent {
+            DojoScreen(
+                uiState =
+                    DojoUiState(
+                        vocabularyItem = sampleVocabularyItem,
+                        showAnswer = false,
+                        isLoading = false,
+                        pronunciationEnabled = true,
+                    ),
+                onToggleShowAnswer = {},
+                onDifficultySelected = {},
+                onSpeakWord = { spoken = true },
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        val speakContentDescription = context.getString(R.string.learning_speak_word)
+        composeTestRule
+            .onNodeWithContentDescription(speakContentDescription)
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule.runOnIdle {
+            assertThat(spoken).isTrue()
+        }
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
@@ -4,12 +4,14 @@ import com.google.common.truth.Truth.assertThat
 import com.procrastilearn.app.data.counter.DayCounters
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
+import com.procrastilearn.app.data.local.prefs.PronunciationPreferencesStore
 import com.procrastilearn.app.data.repository.NoAvailableItemsException
 import com.procrastilearn.app.domain.model.LearningPreferencesConfig
 import com.procrastilearn.app.domain.model.MixMode
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
+import com.procrastilearn.app.tts.Speaker
 import com.procrastilearn.app.utils.MainDispatcherRule
 import io.github.openspacedrepetition.Rating
 import io.mockk.clearAllMocks
@@ -17,6 +19,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -25,6 +28,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DojoViewModelTest {
@@ -35,10 +39,13 @@ class DojoViewModelTest {
     private lateinit var saveDifficultyRating: SaveDifficultyRatingUseCase
     private lateinit var vocabularyDao: VocabularyDao
     private lateinit var dayCountersStore: DayCountersStore
+    private lateinit var pronunciationPreferencesStore: PronunciationPreferencesStore
+    private lateinit var speaker: Speaker
 
     private lateinit var countersFlow: MutableStateFlow<DayCounters>
     private lateinit var policyFlow: MutableStateFlow<LearningPreferencesConfig>
     private lateinit var dueCountFlow: MutableStateFlow<Int>
+    private lateinit var pronunciationEnabledFlow: MutableStateFlow<Boolean>
 
     @Before
     fun setUp() {
@@ -46,6 +53,8 @@ class DojoViewModelTest {
         saveDifficultyRating = mockk()
         vocabularyDao = mockk()
         dayCountersStore = mockk()
+        pronunciationPreferencesStore = mockk()
+        speaker = mockk(relaxed = true)
 
         // Default flows
         countersFlow =
@@ -67,11 +76,13 @@ class DojoViewModelTest {
                 ),
             )
         dueCountFlow = MutableStateFlow(10)
+        pronunciationEnabledFlow = MutableStateFlow(false)
 
         every { dayCountersStore.read() } returns countersFlow
         every { dayCountersStore.readPolicy() } returns policyFlow
         coEvery { vocabularyDao.countReviewsDue(any()) } returns 10
         every { vocabularyDao.observeReviewsDueCount(any()) } returns dueCountFlow
+        every { pronunciationPreferencesStore.readEnabled() } returns pronunciationEnabledFlow
     }
 
     @After
@@ -85,6 +96,8 @@ class DojoViewModelTest {
             saveDifficultyRating,
             vocabularyDao,
             dayCountersStore,
+            pronunciationPreferencesStore,
+            speaker,
         )
 
     @Test
@@ -468,5 +481,48 @@ class DojoViewModelTest {
 
             // showAnswer should be reset
             assertThat(viewModel.uiState.value.showAnswer).isFalse()
+        }
+
+    @Test
+    fun `pronunciationEnabled reflects the preference store`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.pronunciationEnabled).isFalse()
+
+            pronunciationEnabledFlow.value = true
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.pronunciationEnabled).isTrue()
+        }
+
+    @Test
+    fun `speakCurrentWord delegates to speaker with the current word in English`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "serendipity", translation = "случайность", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.speakCurrentWord()
+
+            verify(exactly = 1) { speaker.speak("serendipity", Locale.ENGLISH) }
+        }
+
+    @Test
+    fun `speakCurrentWord is a no-op when no word is loaded`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            coEvery { getNextVocabularyItem.invoke() } returns Result.failure(NoAvailableItemsException())
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.speakCurrentWord()
+
+            verify(exactly = 0) { speaker.speak(any(), any()) }
         }
 }

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/settings/components/PronunciationSettingsItemTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/settings/components/PronunciationSettingsItemTest.kt
@@ -1,0 +1,117 @@
+package com.procrastilearn.app.ui.screens.settings.components
+
+import android.content.Context
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.procrastilearn.app.R
+import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
+import com.procrastilearn.app.ui.theme.MyApplicationTheme
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    sdk = [33],
+    manifest = Config.NONE,
+    qualifiers = "xlarge",
+)
+class PronunciationSettingsItemTest {
+    private val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val rules: TestRule =
+        RuleChain
+            .outerRule(ComponentActivityRegistrationRule())
+            .around(composeTestRule)
+
+    private lateinit var onToggle: (Boolean) -> Unit
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        onToggle = mockk(relaxed = true)
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `shows title and description`() {
+        setContent(isEnabled = false)
+
+        composeTestRule
+            .onNodeWithText(string(R.string.settings_pronunciation_title))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.settings_pronunciation_desc), substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `checkbox reflects disabled state`() {
+        setContent(isEnabled = false)
+
+        composeTestRule
+            .onNodeWithTag("pronunciation_settings_checkbox", useUnmergedTree = true)
+            .assertIsOff()
+    }
+
+    @Test
+    fun `checkbox reflects enabled state`() {
+        setContent(isEnabled = true)
+
+        composeTestRule
+            .onNodeWithTag("pronunciation_settings_checkbox", useUnmergedTree = true)
+            .assertIsOn()
+    }
+
+    @Test
+    fun `row click toggles from disabled to enabled`() {
+        setContent(isEnabled = false)
+
+        composeTestRule
+            .onNodeWithText(string(R.string.settings_pronunciation_title))
+            .assertHasClickAction()
+            .performClick()
+
+        verify(exactly = 1) { onToggle(true) }
+    }
+
+    @Test
+    fun `row click toggles from enabled to disabled`() {
+        setContent(isEnabled = true)
+
+        composeTestRule
+            .onNodeWithText(string(R.string.settings_pronunciation_title))
+            .performClick()
+
+        verify(exactly = 1) { onToggle(false) }
+    }
+
+    private fun setContent(isEnabled: Boolean) {
+        composeTestRule.setContent {
+            MyApplicationTheme {
+                PronunciationSettingsItem(
+                    isEnabled = isEnabled,
+                    onToggle = onToggle,
+                )
+            }
+        }
+    }
+
+    private fun string(resId: Int): String = context.getString(resId)
+}


### PR DESCRIPTION
## Summary
- Adds a speaker icon next to the vocabulary **word** (not the translation) on both the blocking overlay and the Dojo screen. Tapping it pronounces the word in English using Android's built-in, on-device `TextToSpeech` engine — no new runtime permissions needed.
- The feature is **off by default**, gated behind a new "Enable pronunciation (Experimental)" toggle in Settings.
- `AndroidTtsSpeaker` wraps a single lazily-created `TextToSpeech` binding, with a cancelable idle-timeout `shutdown()` (~60s) so the engine binding isn't held indefinitely, plus a backstop `shutdown()` in `OverlayAccessibilityService.onDestroy()`.
- `Speaker.speak(text, locale)` takes the locale explicitly from day one (hardcoded to `Locale.ENGLISH` for now), so a future per-word `lang` property can be wired in later with only a call-site change — no changes needed to the TTS layer, the settings toggle, or `LearningCard`.
- Adds a `<queries>` entry to `AndroidManifest.xml` so the app can see the device's TTS engine on API 30+ (package-visibility requirement, not a runtime permission).

## Test plan
- [x] `./gradlew testDebugUnitTest` — full suite passes, including new coverage for `PronunciationPreferencesStore`, `AndroidTtsSpeaker` (init/pending-utterance queueing, idle-timeout, retry-after-failure, unsupported-locale handling), `DojoViewModel`/`OverlayViewModel` pronunciation wiring, `SettingsViewModel` toggle persistence, and Compose UI tests for the speaker icon's visibility/wiring in `DojoScreen`/`OverlayScreen`/`PronunciationSettingsItem`.
- [x] `./gradlew ktlintCheck detekt lintDebug` — all clean.
- [x] `./gradlew assembleDebug` — builds successfully.
- [ ] Manual on-device check: toggle the setting on/off in Settings and confirm the speaker icon appears/disappears and pronounces the word on both the overlay and Dojo screens.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jvti4532NHepPzziv6yyvX)_