### PR TITLE
feat: add undo for last dojo/overlay rating

### DIFF
--- a/app/schemas/com.procrastilearn.app.data.local.database.AppDatabase/3.json
+++ b/app/schemas/com.procrastilearn.app.data.local.database.AppDatabase/3.json
@@ -1,0 +1,264 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "c555d1248578765c9de819e2fffc2662",
+    "entities": [
+      {
+        "tableName": "vocabulary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `word` TEXT NOT NULL COLLATE NOCASE, `translation` TEXT NOT NULL COLLATE NOCASE, `createdAt` INTEGER NOT NULL, `lastShownAt` INTEGER, `correctCount` INTEGER NOT NULL, `incorrectCount` INTEGER NOT NULL, `fsrsCardJson` TEXT NOT NULL, `fsrsDueAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translation",
+            "columnName": "translation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastShownAt",
+            "columnName": "lastShownAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "correctCount",
+            "columnName": "correctCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incorrectCount",
+            "columnName": "incorrectCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fsrsCardJson",
+            "columnName": "fsrsCardJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fsrsDueAt",
+            "columnName": "fsrsDueAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_vocabulary_fsrsDueAt",
+            "unique": false,
+            "columnNames": [
+              "fsrsDueAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vocabulary_fsrsDueAt` ON `${TABLE_NAME}` (`fsrsDueAt`)"
+          },
+          {
+            "name": "index_vocabulary_correctCount_incorrectCount",
+            "unique": false,
+            "columnNames": [
+              "correctCount",
+              "incorrectCount"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vocabulary_correctCount_incorrectCount` ON `${TABLE_NAME}` (`correctCount`, `incorrectCount`)"
+          },
+          {
+            "name": "index_vocabulary_word",
+            "unique": true,
+            "columnNames": [
+              "word"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_vocabulary_word` ON `${TABLE_NAME}` (`word`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pending_words",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `word` TEXT NOT NULL COLLATE NOCASE, `direction` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_words_word",
+            "unique": true,
+            "columnNames": [
+              "word"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pending_words_word` ON `${TABLE_NAME}` (`word`)"
+          }
+        ]
+      },
+      {
+        "tableName": "undo_snapshot",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `vocabId` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `snapshotDay` INTEGER NOT NULL, `ratingName` TEXT NOT NULL, `fsrsCardJson` TEXT NOT NULL, `fsrsDueAt` INTEGER NOT NULL, `lastShownAt` INTEGER, `correctCount` INTEGER NOT NULL, `incorrectCount` INTEGER NOT NULL, `newShown` INTEGER NOT NULL, `reviewShown` INTEGER NOT NULL, `reviewsSinceLastNew` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vocabId",
+            "columnName": "vocabId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snapshotDay",
+            "columnName": "snapshotDay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingName",
+            "columnName": "ratingName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fsrsCardJson",
+            "columnName": "fsrsCardJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fsrsDueAt",
+            "columnName": "fsrsDueAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastShownAt",
+            "columnName": "lastShownAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "correctCount",
+            "columnName": "correctCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incorrectCount",
+            "columnName": "incorrectCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newShown",
+            "columnName": "newShown",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewShown",
+            "columnName": "reviewShown",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewsSinceLastNew",
+            "columnName": "reviewsSinceLastNew",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_undo_snapshot_vocabId",
+            "unique": false,
+            "columnNames": [
+              "vocabId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_undo_snapshot_vocabId` ON `${TABLE_NAME}` (`vocabId`)"
+          },
+          {
+            "name": "index_undo_snapshot_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_undo_snapshot_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c555d1248578765c9de819e2fffc2662')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/procrastilearn/app/data/local/database/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/data/local/database/AppDatabaseMigrationTest.kt
@@ -51,6 +51,44 @@ class AppDatabaseMigrationTest {
         }
     }
 
+    @Test
+    fun migrate2To3AddsTheUndoSnapshotTableAndKeepsExistingVocabulary() {
+        helper.createDatabase(TEST_DB, 2).apply {
+            execSQL(
+                """
+                INSERT INTO vocabulary
+                    (word, translation, createdAt, correctCount, incorrectCount, fsrsCardJson, fsrsDueAt)
+                VALUES ('Baum', 'Tree', 0, 1, 0, '', 100)
+                """.trimIndent(),
+            )
+            close()
+        }
+
+        val migrated = helper.runMigrationsAndValidate(TEST_DB, 3, true, MIGRATION_1_2, MIGRATION_2_3)
+
+        migrated.query("SELECT word FROM vocabulary").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Baum", cursor.getString(0))
+        }
+        migrated.query("SELECT COUNT(*) FROM undo_snapshot").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        migrated.execSQL(
+            """
+            INSERT INTO undo_snapshot
+                (vocabId, createdAt, snapshotDay, ratingName, fsrsCardJson, fsrsDueAt,
+                 lastShownAt, correctCount, incorrectCount, newShown, reviewShown, reviewsSinceLastNew)
+            VALUES (1, 0, 20260117, 'GOOD', '', 0, NULL, 0, 0, 0, 0, 0)
+            """.trimIndent(),
+        )
+        migrated.query("SELECT ratingName, lastShownAt FROM undo_snapshot").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("GOOD", cursor.getString(0))
+            assertTrue(cursor.isNull(1))
+        }
+    }
+
     private companion object {
         const val TEST_DB = "migration-test"
     }

--- a/app/src/main/java/com/procrastilearn/app/data/local/dao/UndoSnapshotDao.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/dao/UndoSnapshotDao.kt
@@ -1,0 +1,39 @@
+package com.procrastilearn.app.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.procrastilearn.app.data.local.entity.UndoSnapshotEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UndoSnapshotDao {
+    @Insert
+    suspend fun insert(snapshot: UndoSnapshotEntity): Long
+
+    @Query("SELECT * FROM undo_snapshot ORDER BY id DESC LIMIT 1")
+    suspend fun peekLatest(): UndoSnapshotEntity?
+
+    @Query("SELECT COUNT(*) FROM undo_snapshot")
+    fun observeCount(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM undo_snapshot")
+    suspend fun count(): Int
+
+    @Query("DELETE FROM undo_snapshot WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("DELETE FROM undo_snapshot WHERE vocabId = :vocabId")
+    suspend fun deleteForVocab(vocabId: Long)
+
+    @Query(
+        """
+        DELETE FROM undo_snapshot
+        WHERE id NOT IN (SELECT id FROM undo_snapshot ORDER BY id DESC LIMIT :keep)
+        """,
+    )
+    suspend fun trimToLast(keep: Int)
+
+    @Query("DELETE FROM undo_snapshot")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
@@ -115,6 +115,29 @@ interface VocabularyDao {
         incIncorrect: Int,
     )
 
+    // Restore a card + count columns to an absolute prior state (undo)
+    @Suppress("LongParameterList")
+    @Query(
+        """
+        UPDATE vocabulary
+        SET
+            fsrsCardJson = :cardJson,
+            fsrsDueAt = :dueAt,
+            lastShownAt = :lastShownAt,
+            correctCount = :correctCount,
+            incorrectCount = :incorrectCount
+        WHERE id = :id
+    """,
+    )
+    suspend fun restoreFsrsState(
+        id: Long,
+        cardJson: String,
+        dueAt: Long,
+        lastShownAt: Long?,
+        correctCount: Int,
+        incorrectCount: Int,
+    )
+
     @Query(
         """
         SELECT * FROM vocabulary

--- a/app/src/main/java/com/procrastilearn/app/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/database/AppDatabase.kt
@@ -3,17 +3,21 @@ package com.procrastilearn.app.data.local.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.procrastilearn.app.data.local.dao.PendingWordDao
+import com.procrastilearn.app.data.local.dao.UndoSnapshotDao
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.entity.PendingWordEntity
+import com.procrastilearn.app.data.local.entity.UndoSnapshotEntity
 import com.procrastilearn.app.data.local.entity.VocabularyEntity
 
 @Database(
-    entities = [VocabularyEntity::class, PendingWordEntity::class],
-    version = 2,
+    entities = [VocabularyEntity::class, PendingWordEntity::class, UndoSnapshotEntity::class],
+    version = 3,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun vocabularyDao(): VocabularyDao
 
     abstract fun pendingWordDao(): PendingWordDao
+
+    abstract fun undoSnapshotDao(): UndoSnapshotDao
 }

--- a/app/src/main/java/com/procrastilearn/app/data/local/database/Migrations.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/database/Migrations.kt
@@ -21,3 +21,34 @@ val MIGRATION_1_2 =
             )
         }
     }
+
+val MIGRATION_2_3 =
+    object : Migration(2, 3) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `undo_snapshot` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `vocabId` INTEGER NOT NULL,
+                    `createdAt` INTEGER NOT NULL,
+                    `snapshotDay` INTEGER NOT NULL,
+                    `ratingName` TEXT NOT NULL,
+                    `fsrsCardJson` TEXT NOT NULL,
+                    `fsrsDueAt` INTEGER NOT NULL,
+                    `lastShownAt` INTEGER,
+                    `correctCount` INTEGER NOT NULL,
+                    `incorrectCount` INTEGER NOT NULL,
+                    `newShown` INTEGER NOT NULL,
+                    `reviewShown` INTEGER NOT NULL,
+                    `reviewsSinceLastNew` INTEGER NOT NULL
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                "CREATE INDEX IF NOT EXISTS `index_undo_snapshot_vocabId` ON `undo_snapshot` (`vocabId`)",
+            )
+            db.execSQL(
+                "CREATE INDEX IF NOT EXISTS `index_undo_snapshot_createdAt` ON `undo_snapshot` (`createdAt`)",
+            )
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/data/local/entity/UndoSnapshotEntity.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/entity/UndoSnapshotEntity.kt
@@ -1,0 +1,30 @@
+package com.procrastilearn.app.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "undo_snapshot",
+    indices = [
+        Index(value = ["vocabId"]),
+        Index(value = ["createdAt"]),
+    ],
+)
+data class UndoSnapshotEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val vocabId: Long,
+    val createdAt: Long,
+    val snapshotDay: Int,
+    val ratingName: String,
+    // Row state before the rating
+    val fsrsCardJson: String,
+    val fsrsDueAt: Long,
+    val lastShownAt: Long?,
+    val correctCount: Int,
+    val incorrectCount: Int,
+    // Day-counter state before the rating
+    val newShown: Int,
+    val reviewShown: Int,
+    val reviewsSinceLastNew: Int,
+)

--- a/app/src/main/java/com/procrastilearn/app/data/local/prefs/DayCountersStore.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/prefs/DayCountersStore.kt
@@ -70,6 +70,20 @@ class DayCountersStore
             }
         }
 
+        // Restore the three rating-derived counters to an absolute prior value (undo).
+        // Deliberately leaves EXTRA_NEW_TODAY and DAY untouched: a rating never changes them.
+        suspend fun restoreCounters(
+            newShown: Int,
+            reviewShown: Int,
+            reviewsSinceLastNew: Int,
+        ) {
+            ds.edit { p ->
+                p[K.NEW_SHOWN] = newShown
+                p[K.REVIEW_SHOWN] = reviewShown
+                p[K.REVIEWS_SINCE_NEW] = reviewsSinceLastNew
+            }
+        }
+
         suspend fun addExtraNewToday(amount: Int) {
             if (amount <= 0) return
             ds.edit { p ->

--- a/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
@@ -1,12 +1,17 @@
 package com.procrastilearn.app.data.repository
 
 import android.util.Log
+import androidx.room.withTransaction
+import com.procrastilearn.app.data.local.dao.UndoSnapshotDao
 import com.procrastilearn.app.data.local.dao.VocabularyDao
+import com.procrastilearn.app.data.local.database.AppDatabase
+import com.procrastilearn.app.data.local.entity.UndoSnapshotEntity
 import com.procrastilearn.app.data.local.entity.VocabularyEntity
 import com.procrastilearn.app.data.local.mapper.toDomain
 import com.procrastilearn.app.data.local.mapper.toEntity
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
 import com.procrastilearn.app.domain.model.MixMode
+import com.procrastilearn.app.domain.model.UndoResult
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.repository.VocabularyRepository
 import io.github.openspacedrepetition.Card
@@ -19,11 +24,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val UNDO_STACK_CAP = 3
 
 private fun todayStamp(): Int =
     LocalDate
@@ -40,9 +49,12 @@ class VocabularyRepositoryImpl
         private val vocabularyDao: VocabularyDao,
         private val scheduler: Scheduler,
         private val prefs: DayCountersStore,
+        private val undoSnapshotDao: UndoSnapshotDao,
+        private val appDatabase: AppDatabase,
     ) : VocabularyRepository {
         private val currentItem = MutableStateFlow<VocabularyItem?>(null)
         private val io = Dispatchers.IO
+        private val reviewMutex = Mutex()
 
         override suspend fun getVocabularyItemByWord(word: String): VocabularyItem? =
             withContext(io) {
@@ -68,12 +80,14 @@ class VocabularyRepositoryImpl
                             translation = item.translation,
                         )
                     vocabularyDao.updateVocabulary(updatedEntity)
+                    undoSnapshotDao.deleteForVocab(item.id)
                 }
             }
 
         override suspend fun deleteVocabularyItem(item: VocabularyItem) =
             withContext(io) {
                 vocabularyDao.deleteVocabulary(item.toEntity())
+                undoSnapshotDao.deleteForVocab(item.id)
             }
 
         override suspend fun resetVocabularyProgress(item: VocabularyItem): Unit =
@@ -89,6 +103,7 @@ class VocabularyRepositoryImpl
                         fsrsDueAt = 0L,
                     )
                 vocabularyDao.updateVocabulary(resetEntity)
+                undoSnapshotDao.deleteForVocab(item.id)
                 if (currentItem.value?.id == item.id) {
                     currentItem.value = resetEntity.toDomain()
                 }
@@ -104,44 +119,106 @@ class VocabularyRepositoryImpl
             rating: Rating,
         ): Unit =
             withContext(io) {
-                Log.i("fsrs", "reviewng $id")
-                val entity =
-                    vocabularyDao.getVocabularyById(id)
-                        ?: throw IllegalArgumentException("Vocabulary $id not found")
+                reviewMutex.withLock {
+                    Log.i("fsrs", "reviewng $id")
+                    val entity =
+                        vocabularyDao.getVocabularyById(id)
+                            ?: throw IllegalArgumentException("Vocabulary $id not found")
 
-                val card =
-                    if (entity.fsrsCardJson.isBlank()) {
-                        Card.builder().build()
-                    } else {
-                        Card.fromJson(entity.fsrsCardJson)
+                    val card =
+                        if (entity.fsrsCardJson.isBlank()) {
+                            Card.builder().build()
+                        } else {
+                            Card.fromJson(entity.fsrsCardJson)
+                        }
+
+                    val result = scheduler.reviewCard(card, rating)
+                    val updatedCard = result.card()
+                    val log = result.reviewLog()
+
+                    val reviewedAt = log.reviewDatetime().toEpochMilli()
+                    val nextDue = updatedCard.getDue().toEpochMilli()
+
+                    val incCorrect = if (rating == Rating.AGAIN) 0 else 1
+                    val incIncorrect = if (rating == Rating.AGAIN) 1 else 0
+
+                    val counters = prefs.read().first()
+                    val snapshot =
+                        UndoSnapshotEntity(
+                            vocabId = id,
+                            createdAt = System.currentTimeMillis(),
+                            snapshotDay = todayStamp(),
+                            ratingName = rating.name,
+                            fsrsCardJson = entity.fsrsCardJson,
+                            fsrsDueAt = entity.fsrsDueAt,
+                            lastShownAt = entity.lastShownAt,
+                            correctCount = entity.correctCount,
+                            incorrectCount = entity.incorrectCount,
+                            newShown = counters.newShown,
+                            reviewShown = counters.reviewShown,
+                            reviewsSinceLastNew = counters.reviewsSinceLastNew,
+                        )
+
+                    appDatabase.withTransaction {
+                        vocabularyDao.applyFsrsReview(
+                            id = id,
+                            cardJson = updatedCard.toJson(),
+                            dueAt = nextDue,
+                            reviewedAt = reviewedAt,
+                            incCorrect = incCorrect,
+                            incIncorrect = incIncorrect,
+                        )
+                        undoSnapshotDao.insert(snapshot)
+                        undoSnapshotDao.trimToLast(UNDO_STACK_CAP)
                     }
 
-                val result = scheduler.reviewCard(card, rating)
-                val updatedCard = result.card()
-                val log = result.reviewLog()
-
-                val reviewedAt = log.reviewDatetime().toEpochMilli()
-                val nextDue = updatedCard.getDue().toEpochMilli()
-
-                val incCorrect = if (rating == Rating.AGAIN) 0 else 1
-                val incIncorrect = if (rating == Rating.AGAIN) 1 else 0
-
-                vocabularyDao.applyFsrsReview(
-                    id = id,
-                    cardJson = updatedCard.toJson(),
-                    dueAt = nextDue,
-                    reviewedAt = reviewedAt,
-                    incCorrect = incCorrect,
-                    incIncorrect = incIncorrect,
-                )
-
-                // IMPORTANT: Clear current item after review to force new item on next call
-                currentItem.value = null
-                // Update day counters based on card type at *display* time
-                val isNew = (entity.correctCount == 0 && entity.incorrectCount == 0)
-                if (isNew) prefs.markNewShown() else prefs.markReviewShown()
-                Log.i("FSRS", "Reviewed $id as $rating; next due at $nextDue")
+                    // IMPORTANT: Clear current item after review to force new item on next call
+                    currentItem.value = null
+                    // Update day counters based on card type at *display* time
+                    val isNew = (entity.correctCount == 0 && entity.incorrectCount == 0)
+                    if (isNew) prefs.markNewShown() else prefs.markReviewShown()
+                    Log.i("FSRS", "Reviewed $id as $rating; next due at $nextDue")
+                }
             }
+
+        override suspend fun undoLastRating(): UndoResult? =
+            withContext(io) {
+                reviewMutex.withLock {
+                    val snapshot = undoSnapshotDao.peekLatest() ?: return@withLock null
+
+                    appDatabase.withTransaction {
+                        vocabularyDao.restoreFsrsState(
+                            id = snapshot.vocabId,
+                            cardJson = snapshot.fsrsCardJson,
+                            dueAt = snapshot.fsrsDueAt,
+                            lastShownAt = snapshot.lastShownAt,
+                            correctCount = snapshot.correctCount,
+                            incorrectCount = snapshot.incorrectCount,
+                        )
+                        undoSnapshotDao.deleteById(snapshot.id)
+                    }
+
+                    if (snapshot.snapshotDay == todayStamp()) {
+                        prefs.restoreCounters(
+                            newShown = snapshot.newShown,
+                            reviewShown = snapshot.reviewShown,
+                            reviewsSinceLastNew = snapshot.reviewsSinceLastNew,
+                        )
+                    }
+
+                    val restoredEntity =
+                        vocabularyDao.getVocabularyById(snapshot.vocabId)
+                            ?: return@withLock null
+                    val restoredItem = restoredEntity.toDomain()
+                    currentItem.value = restoredItem
+                    UndoResult(
+                        item = restoredItem,
+                        revertedRating = Rating.valueOf(snapshot.ratingName),
+                    )
+                }
+            }
+
+        override fun observeUndoCount(): Flow<Int> = undoSnapshotDao.observeCount()
 
         @Suppress("CyclomaticComplexMethod")
         override suspend fun getNextVocabularyItem(): VocabularyItem =

--- a/app/src/main/java/com/procrastilearn/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/procrastilearn/app/di/DatabaseModule.kt
@@ -3,9 +3,11 @@ package com.procrastilearn.app.di
 import android.content.Context
 import androidx.room.Room
 import com.procrastilearn.app.data.local.dao.PendingWordDao
+import com.procrastilearn.app.data.local.dao.UndoSnapshotDao
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.database.AppDatabase
 import com.procrastilearn.app.data.local.database.MIGRATION_1_2
+import com.procrastilearn.app.data.local.database.MIGRATION_2_3
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -26,7 +28,7 @@ object DatabaseModule {
                 context,
                 AppDatabase::class.java,
                 "app_database",
-            ).addMigrations(MIGRATION_1_2)
+            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3)
             .build()
 
     @Provides
@@ -36,4 +38,8 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun providePendingWordDao(database: AppDatabase): PendingWordDao = database.pendingWordDao()
+
+    @Provides
+    @Singleton
+    fun provideUndoSnapshotDao(database: AppDatabase): UndoSnapshotDao = database.undoSnapshotDao()
 }

--- a/app/src/main/java/com/procrastilearn/app/domain/model/UndoResult.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/model/UndoResult.kt
@@ -1,0 +1,8 @@
+package com.procrastilearn.app.domain.model
+
+import io.github.openspacedrepetition.Rating
+
+data class UndoResult(
+    val item: VocabularyItem,
+    val revertedRating: Rating,
+)

--- a/app/src/main/java/com/procrastilearn/app/domain/repository/VocabularyRepository.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/repository/VocabularyRepository.kt
@@ -1,9 +1,11 @@
 package com.procrastilearn.app.domain.repository
 
+import com.procrastilearn.app.domain.model.UndoResult
 import com.procrastilearn.app.domain.model.VocabularyItem
 import io.github.openspacedrepetition.Rating
 import kotlinx.coroutines.flow.Flow
 
+@Suppress("TooManyFunctions")
 interface VocabularyRepository {
     suspend fun getNextVocabularyItem(): VocabularyItem
 
@@ -27,4 +29,8 @@ interface VocabularyRepository {
         id: Long,
         rating: Rating,
     )
+
+    suspend fun undoLastRating(): UndoResult?
+
+    fun observeUndoCount(): Flow<Int>
 }

--- a/app/src/main/java/com/procrastilearn/app/domain/usecase/UndoLastRatingUseCase.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/usecase/UndoLastRatingUseCase.kt
@@ -1,0 +1,16 @@
+package com.procrastilearn.app.domain.usecase
+
+import com.procrastilearn.app.domain.model.UndoResult
+import com.procrastilearn.app.domain.repository.VocabularyRepository
+import javax.inject.Inject
+
+class UndoLastRatingUseCase
+    @Inject
+    constructor(
+        private val repository: VocabularyRepository,
+    ) {
+        suspend operator fun invoke(): Result<UndoResult?> =
+            runCatching {
+                repository.undoLastRating()
+            }
+    }

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoScreen.kt
@@ -9,11 +9,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -38,7 +44,13 @@ import io.github.openspacedrepetition.Rating
 @Composable
 fun DojoScreen(viewModel: DojoViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsState()
-    DojoScreen(uiState, viewModel::onToggleShowAnswer, viewModel::onDifficultySelected)
+    DojoScreen(
+        uiState,
+        viewModel::onToggleShowAnswer,
+        viewModel::onDifficultySelected,
+        viewModel::onUndo,
+        viewModel::onUndoEventShown,
+    )
 }
 
 @VisibleForTesting
@@ -47,17 +59,46 @@ internal fun DojoScreen(
     uiState: DojoUiState,
     onToggleShowAnswer: () -> Unit,
     onDifficultySelected: (Rating) -> Unit,
+    onUndo: () -> Unit = {},
+    onUndoEventShown: () -> Unit = {},
 ) {
     MyApplicationTheme {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background,
-        ) {
-            Column(modifier = Modifier.fillMaxSize()) {
+        val snackbarHostState = remember { SnackbarHostState() }
+        val undoEvent = uiState.undoEvent
+        val undoMessage =
+            undoEvent?.let { event ->
+                stringResource(
+                    R.string.dojo_undo_confirmation,
+                    ratingLabel(event.revertedRating),
+                    event.word,
+                )
+            }
+
+        LaunchedEffect(undoEvent?.id) {
+            if (undoMessage != null) {
+                snackbarHostState.showSnackbar(message = undoMessage)
+                onUndoEventShown()
+            }
+        }
+
+        Scaffold(
+            snackbarHost = {
+                SnackbarHost(hostState = snackbarHostState) { data ->
+                    Snackbar(snackbarData = data)
+                }
+            },
+        ) { scaffoldPadding ->
+            Surface(
+                modifier = Modifier.fillMaxSize().padding(scaffoldPadding),
+                color = MaterialTheme.colorScheme.background,
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
                 // Stats header always visible
                 DojoStatsHeader(
                     newQuotaRemaining = uiState.newQuotaRemaining,
                     pendingReviewCount = uiState.pendingReviewCount,
+                    canUndo = uiState.canUndo,
+                    onUndo = onUndo,
                 )
 
                 // Content area
@@ -102,10 +143,21 @@ internal fun DojoScreen(
                         }
                     }
                 }
+                }
             }
         }
     }
 }
+
+@Composable
+private fun ratingLabel(rating: Rating): String =
+    when (rating) {
+        Rating.AGAIN -> stringResource(R.string.rating_again)
+        Rating.HARD -> stringResource(R.string.rating_hard)
+        Rating.GOOD -> stringResource(R.string.rating_good)
+        Rating.EASY -> stringResource(R.string.rating_easy)
+        else -> rating.name
+    }
 
 @Composable
 private fun EmptyState(modifier: Modifier = Modifier) {

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoUiState.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoUiState.kt
@@ -1,6 +1,7 @@
 package com.procrastilearn.app.ui.dojo
 
 import com.procrastilearn.app.domain.model.VocabularyItem
+import io.github.openspacedrepetition.Rating
 
 data class DojoUiState(
     // Flashcard state (compatible with OverlayUiState)
@@ -10,6 +11,15 @@ data class DojoUiState(
     // Stats state
     val newQuotaRemaining: Int = 0,
     val pendingReviewCount: Int = 0,
+    // Undo state
+    val canUndo: Boolean = false,
+    val undoEvent: UndoEvent? = null,
 ) {
     val hasNoWords: Boolean get() = vocabularyItem == null && !isLoading
 }
+
+data class UndoEvent(
+    val id: Long,
+    val word: String,
+    val revertedRating: Rating,
+)

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoViewModel.kt
@@ -2,12 +2,14 @@ package com.procrastilearn.app.ui.dojo
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.procrastilearn.app.data.local.dao.UndoSnapshotDao
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
 import com.procrastilearn.app.data.repository.NoAvailableItemsException
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
+import com.procrastilearn.app.domain.usecase.UndoLastRatingUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.openspacedrepetition.Rating
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,21 +29,30 @@ class DojoViewModel
         private val saveDifficultyRating: SaveDifficultyRatingUseCase,
         private val vocabularyDao: VocabularyDao,
         private val dayCountersStore: DayCountersStore,
+        private val undoLastRating: UndoLastRatingUseCase,
+        private val undoSnapshotDao: UndoSnapshotDao,
     ) : ViewModel() {
         private val flashcardState = MutableStateFlow(FlashcardState())
+        private val undoEvent = MutableStateFlow<UndoEvent?>(null)
+
+        // Item just restored by undo, pinned on screen until the user re-rates it.
+        // Guards against the reactive re-fetch below (undo writes to both the vocabulary
+        // table and the day counters, either of which can otherwise trigger a fetch that
+        // would steal the restored card off the screen).
+        private var pendingRestoredItem: VocabularyItem? = null
 
         // Reactive: re-emits whenever the vocabulary table changes anywhere in the app
         // (e.g. a review recorded from the blocking overlay), not just from this screen.
         private val reviewsDueCount = vocabularyDao.observeReviewsDueCount(System.currentTimeMillis())
+        private val undoCount = undoSnapshotDao.observeCount()
 
-        val uiState: StateFlow<DojoUiState> =
+        private val baseState =
             combine(
                 flashcardState,
                 dayCountersStore.read(),
                 dayCountersStore.readPolicy(),
                 reviewsDueCount,
             ) { flashcard, counters, policy, pendingReviews ->
-                // Calculate stats reactively
                 val newQuotaRemaining =
                     (policy.newPerDay + counters.extraNewToday - counters.newShown).coerceAtLeast(0)
 
@@ -49,12 +60,19 @@ class DojoViewModel
                 val reviewQuotaRemaining = (policy.reviewPerDay - counters.reviewShown).coerceAtLeast(0)
                 val pendingReviewCount = if (reviewQuotaRemaining > 0) pendingReviews else 0
 
+                BaseDojoState(flashcard, newQuotaRemaining, pendingReviewCount)
+            }
+
+        val uiState: StateFlow<DojoUiState> =
+            combine(baseState, undoCount, undoEvent) { base, undoCountValue, event ->
                 DojoUiState(
-                    vocabularyItem = flashcard.vocabularyItem,
-                    showAnswer = flashcard.showAnswer,
-                    isLoading = flashcard.isLoading,
-                    newQuotaRemaining = newQuotaRemaining,
-                    pendingReviewCount = pendingReviewCount,
+                    vocabularyItem = base.flashcard.vocabularyItem,
+                    showAnswer = base.flashcard.showAnswer,
+                    isLoading = base.flashcard.isLoading,
+                    newQuotaRemaining = base.newQuotaRemaining,
+                    pendingReviewCount = base.pendingReviewCount,
+                    canUndo = undoCountValue > 0,
+                    undoEvent = event,
                 )
             }.stateIn(viewModelScope, SharingStarted.Eagerly, DojoUiState(isLoading = true))
 
@@ -87,6 +105,8 @@ class DojoViewModel
 
             viewModelScope.launch {
                 saveDifficultyRating(current.id, rating)
+                // Re-rating clears the pin: the next loadNextWord() should fetch for real.
+                pendingRestoredItem = null
                 // Reset showAnswer for next card
                 flashcardState.value = flashcardState.value.copy(showAnswer = false)
                 // Load next word; reviewsDueCount/counters will also react to the write
@@ -95,11 +115,47 @@ class DojoViewModel
             }
         }
 
+        fun onUndo() {
+            viewModelScope.launch {
+                val result = undoLastRating().getOrNull() ?: return@launch
+                pendingRestoredItem = result.item
+                flashcardState.value =
+                    FlashcardState(
+                        vocabularyItem = result.item,
+                        isLoading = false,
+                        showAnswer = true,
+                    )
+                undoEvent.value =
+                    UndoEvent(
+                        id = System.nanoTime(),
+                        word = result.item.word,
+                        revertedRating = result.revertedRating,
+                    )
+            }
+        }
+
+        fun onUndoEventShown() {
+            undoEvent.value = null
+        }
+
         private fun loadNextWord() {
             viewModelScope.launch {
+                pendingRestoredItem?.let { restored ->
+                    flashcardState.value =
+                        FlashcardState(
+                            vocabularyItem = restored,
+                            isLoading = false,
+                            showAnswer = true,
+                        )
+                    return@launch
+                }
+
                 flashcardState.value = flashcardState.value.copy(isLoading = true)
                 getNextVocabularyItem()
                     .onSuccess { item ->
+                        // A pin may have been set by onUndo() while this fetch was in
+                        // flight; don't let a stale fetch clobber the restored card.
+                        if (pendingRestoredItem != null) return@onSuccess
                         flashcardState.value =
                             FlashcardState(
                                 vocabularyItem = item,
@@ -107,6 +163,7 @@ class DojoViewModel
                                 showAnswer = false,
                             )
                     }.onFailure { exception ->
+                        if (pendingRestoredItem != null) return@onFailure
                         when (exception) {
                             is NoAvailableItemsException -> {
                                 // No words available - empty state
@@ -129,5 +186,11 @@ class DojoViewModel
             val vocabularyItem: VocabularyItem? = null,
             val showAnswer: Boolean = false,
             val isLoading: Boolean = false,
+        )
+
+        private data class BaseDojoState(
+            val flashcard: FlashcardState,
+            val newQuotaRemaining: Int,
+            val pendingReviewCount: Int,
         )
     }

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeader.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeader.kt
@@ -1,14 +1,20 @@
 package com.procrastilearn.app.ui.dojo.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -17,52 +23,73 @@ import androidx.compose.ui.unit.sp
 import com.procrastilearn.app.R
 import com.procrastilearn.app.ui.theme.MyApplicationTheme
 
+private const val DISABLED_ALPHA = 0.35f
+
 @Composable
 fun DojoStatsHeader(
     newQuotaRemaining: Int,
     pendingReviewCount: Int,
     modifier: Modifier = Modifier,
+    canUndo: Boolean = false,
+    onUndo: () -> Unit = {},
 ) {
-    Row(
+    Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
+                .padding(horizontal = 4.dp, vertical = 8.dp),
     ) {
-        // New words remaining
-        Text(
-            text = newQuotaRemaining.toString(),
-            fontSize = 16.sp,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.error,
-        )
-        Text(
-            text = " ${stringResource(R.string.dojo_stats_new_remaining)}",
-            fontSize = 14.sp,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        IconButton(
+            onClick = onUndo,
+            enabled = canUndo,
+            modifier = Modifier.align(Alignment.CenterStart),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Refresh,
+                contentDescription = stringResource(R.string.dojo_undo_content_description),
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.alpha(if (canUndo) 1f else DISABLED_ALPHA),
+            )
+        }
 
-        Text(
-            text = " / ",
-            fontSize = 14.sp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 4.dp),
-        )
+        Row(
+            modifier = Modifier.align(Alignment.Center),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // New words remaining
+            Text(
+                text = newQuotaRemaining.toString(),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                text = " ${stringResource(R.string.dojo_stats_new_remaining)}",
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
 
-        // Reviews due
-        Text(
-            text = pendingReviewCount.toString(),
-            fontSize = 16.sp,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.tertiary,
-        )
-        Text(
-            text = " ${stringResource(R.string.dojo_stats_reviews_due)}",
-            fontSize = 14.sp,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+            Text(
+                text = " / ",
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 4.dp),
+            )
+
+            // Reviews due
+            Text(
+                text = pendingReviewCount.toString(),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.tertiary,
+            )
+            Text(
+                text = " ${stringResource(R.string.dojo_stats_reviews_due)}",
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
     }
 }
 
@@ -74,6 +101,7 @@ private fun DojoStatsHeaderPreview() {
         DojoStatsHeader(
             newQuotaRemaining = 17,
             pendingReviewCount = 10,
+            canUndo = true,
         )
     }
 }
@@ -85,6 +113,7 @@ private fun DojoStatsHeaderZeroPreview() {
         DojoStatsHeader(
             newQuotaRemaining = 0,
             pendingReviewCount = 0,
+            canUndo = false,
         )
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -52,6 +52,8 @@
         <string name="dojo_stats_reviews_due">к повторению</string>
         <string name="dojo_empty_title">На сегодня всё готово!</string>
         <string name="dojo_empty_message">Вы прошли все доступные слова на сегодня. Возвращайтесь позже или измените дневные лимиты в настройках.</string>
+        <string name="dojo_undo_content_description">Отменить последнюю оценку</string>
+        <string name="dojo_undo_confirmation">Отменено «%1$s» для \"%2$s\"</string>
 
         <!-- ─── Overlay permission ──────────────────────────────────────────────── -->
         <string name="overlay_permission_title">Разрешить отображение поверх других окон</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
     <string name="dojo_stats_reviews_due">due</string>
     <string name="dojo_empty_title">All done for now!</string>
     <string name="dojo_empty_message">You\'ve completed all available words for today. Come back later or adjust your daily limits in Settings.</string>
+    <string name="dojo_undo_content_description">Undo last rating</string>
+    <string name="dojo_undo_confirmation">Undid %1$s for \"%2$s\"</string>
 
     <!-- ─── Overlay permission ──────────────────────────────────────────────── -->
     <string name="overlay_permission_title">Allow overlay display</string>

--- a/app/src/test/java/com/procrastilearn/app/data/local/dao/UndoSnapshotDaoTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/dao/UndoSnapshotDaoTest.kt
@@ -1,0 +1,175 @@
+package com.procrastilearn.app.data.local.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.database.AppDatabase
+import com.procrastilearn.app.data.local.entity.UndoSnapshotEntity
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class UndoSnapshotDaoTest {
+    private lateinit var database: AppDatabase
+    private lateinit var dao: UndoSnapshotDao
+
+    @Before
+    fun setup() {
+        database =
+            Room
+                .inMemoryDatabaseBuilder(
+                    ApplicationProvider.getApplicationContext(),
+                    AppDatabase::class.java,
+                ).allowMainThreadQueries()
+                .build()
+        dao = database.undoSnapshotDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private suspend fun vocabId(word: String): Long =
+        database.vocabularyDao().insertVocabulary(
+            VocabularyEntity(id = 0, word = word, translation = word),
+        )
+
+    private fun snapshot(
+        vocabId: Long,
+        createdAt: Long = System.currentTimeMillis(),
+    ) = UndoSnapshotEntity(
+        vocabId = vocabId,
+        createdAt = createdAt,
+        snapshotDay = 20260117,
+        ratingName = "GOOD",
+        fsrsCardJson = "",
+        fsrsDueAt = 0L,
+        lastShownAt = null,
+        correctCount = 0,
+        incorrectCount = 0,
+        newShown = 0,
+        reviewShown = 0,
+        reviewsSinceLastNew = 0,
+    )
+
+    @Test
+    fun `peekLatest returns null when empty`() =
+        runTest {
+            assertThat(dao.peekLatest()).isNull()
+        }
+
+    @Test
+    fun `peekLatest returns most recently inserted snapshot`() =
+        runTest {
+            val id = vocabId("eins")
+            dao.insert(snapshot(id, createdAt = 1L))
+            dao.insert(snapshot(id, createdAt = 2L))
+            val third = dao.insert(snapshot(id, createdAt = 3L))
+
+            val latest = dao.peekLatest()
+
+            assertThat(latest?.id).isEqualTo(third)
+        }
+
+    @Test
+    fun `trimToLast keeps only the most recent N rows`() =
+        runTest {
+            val id = vocabId("zwei")
+            repeat(5) { dao.insert(snapshot(id, createdAt = it.toLong())) }
+
+            dao.trimToLast(3)
+
+            assertThat(dao.count()).isEqualTo(3)
+        }
+
+    @Test
+    fun `trimToLast is a no-op when under the cap`() =
+        runTest {
+            val id = vocabId("drei")
+            dao.insert(snapshot(id))
+            dao.insert(snapshot(id))
+
+            dao.trimToLast(3)
+
+            assertThat(dao.count()).isEqualTo(2)
+        }
+
+    @Test
+    fun `trimToLast with zero clears the stack`() =
+        runTest {
+            val id = vocabId("vier")
+            dao.insert(snapshot(id))
+            dao.insert(snapshot(id))
+
+            dao.trimToLast(0)
+
+            assertThat(dao.count()).isEqualTo(0)
+        }
+
+    @Test
+    fun `deleteById removes only the targeted row`() =
+        runTest {
+            val id = vocabId("fuenf")
+            val keep = dao.insert(snapshot(id))
+            val remove = dao.insert(snapshot(id))
+
+            dao.deleteById(remove)
+
+            assertThat(dao.count()).isEqualTo(1)
+            assertThat(dao.peekLatest()?.id).isEqualTo(keep)
+        }
+
+    @Test
+    fun `deleteForVocab removes all snapshots for that vocab only`() =
+        runTest {
+            val a = vocabId("a")
+            val b = vocabId("b")
+            dao.insert(snapshot(a))
+            dao.insert(snapshot(a))
+            dao.insert(snapshot(b))
+
+            dao.deleteForVocab(a)
+
+            assertThat(dao.count()).isEqualTo(1)
+            assertThat(dao.peekLatest()?.vocabId).isEqualTo(b)
+        }
+
+    @Test
+    fun `deleteAll clears every snapshot`() =
+        runTest {
+            val id = vocabId("all")
+            dao.insert(snapshot(id))
+            dao.insert(snapshot(id))
+
+            dao.deleteAll()
+
+            assertThat(dao.count()).isEqualTo(0)
+        }
+
+    @Test
+    fun `observeCount emits on every insert and delete`() =
+        runTest {
+            val id = vocabId("obs")
+
+            dao.observeCount().test {
+                assertThat(awaitItem()).isEqualTo(0)
+
+                val inserted = dao.insert(snapshot(id))
+                assertThat(awaitItem()).isEqualTo(1)
+
+                dao.deleteById(inserted)
+                assertThat(awaitItem()).isEqualTo(0)
+
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/data/local/prefs/DayCountersStoreTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/prefs/DayCountersStoreTest.kt
@@ -106,6 +106,39 @@ class DayCountersStoreTest {
         }
 
     @Test
+    fun restoreCountersSetsValuesAbsolutelyAndLeavesExtraNewTodayAndDayUntouched() =
+        runTest {
+            store.resetFor(20240131)
+            store.addExtraNewToday(7)
+            store.markReviewShown()
+            store.markReviewShown()
+            store.markNewShown()
+
+            store.restoreCounters(newShown = 0, reviewShown = 0, reviewsSinceLastNew = 0)
+
+            val counters = store.read().first()
+            assertThat(counters.newShown).isEqualTo(0)
+            assertThat(counters.reviewShown).isEqualTo(0)
+            assertThat(counters.reviewsSinceLastNew).isEqualTo(0)
+            // Untouched by restore:
+            assertThat(counters.extraNewToday).isEqualTo(7)
+            assertThat(counters.yyyymmdd).isEqualTo(20240131)
+        }
+
+    @Test
+    fun restoreCountersCanIncreaseValuesToo() =
+        runTest {
+            store.resetFor(20240131)
+
+            store.restoreCounters(newShown = 4, reviewShown = 9, reviewsSinceLastNew = 2)
+
+            val counters = store.read().first()
+            assertThat(counters.newShown).isEqualTo(4)
+            assertThat(counters.reviewShown).isEqualTo(9)
+            assertThat(counters.reviewsSinceLastNew).isEqualTo(2)
+        }
+
+    @Test
     fun policyLimitsAreClampedAndMixModePersists() =
         runTest {
             store.setMixMode(MixMode.NEW_FIRST)

--- a/app/src/test/java/com/procrastilearn/app/data/repository/AddCardsForTodayIntegrationTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/AddCardsForTodayIntegrationTest.kt
@@ -66,6 +66,8 @@ class AddCardsForTodayIntegrationTest {
                 vocabularyDao = database.vocabularyDao(),
                 scheduler = Scheduler.builder().build(),
                 prefs = dayCountersStore,
+                undoSnapshotDao = database.undoSnapshotDao(),
+                appDatabase = database,
             )
     }
 

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryGetNextItemTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryGetNextItemTest.kt
@@ -57,6 +57,8 @@ class VocabularyRepositoryGetNextItemTest {
                 vocabularyDao = vocabularyDao,
                 scheduler = scheduler,
                 prefs = dayCountersStore,
+                undoSnapshotDao = database.undoSnapshotDao(),
+                appDatabase = database,
             )
     }
 
@@ -227,6 +229,8 @@ class VocabularyRepositoryGetNextItemTest {
                     vocabularyDao = vocabularyDao,
                     scheduler = scheduler,
                     prefs = dayCountersStore,
+                    undoSnapshotDao = database.undoSnapshotDao(),
+                    appDatabase = database,
                 )
 
             coEvery { dayCountersStore.readPolicy() } returns
@@ -708,6 +712,8 @@ class VocabularyRepositoryGetNextItemTest {
                     vocabularyDao = vocabularyDao,
                     scheduler = scheduler,
                     prefs = dayCountersStore,
+                    undoSnapshotDao = database.undoSnapshotDao(),
+                    appDatabase = database,
                 )
             coEvery { dayCountersStore.readPolicy() } returns
                 flowOf(

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImplTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImplTest.kt
@@ -5,8 +5,10 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.procrastilearn.app.data.counter.DayCounters
+import com.procrastilearn.app.data.local.dao.UndoSnapshotDao
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.database.AppDatabase
+import com.procrastilearn.app.data.local.entity.UndoSnapshotEntity
 import com.procrastilearn.app.data.local.entity.VocabularyEntity
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
 import com.procrastilearn.app.domain.model.LearningPreferencesConfig
@@ -39,6 +41,7 @@ class VocabularyRepositoryImplTest {
     private lateinit var vocabularyDao: VocabularyDao
     private lateinit var dayCountersStore: DayCountersStore
     private lateinit var scheduler: Scheduler
+    private lateinit var undoSnapshotDao: UndoSnapshotDao
     private lateinit var repository: VocabularyRepositoryImpl
 
     @Before
@@ -61,11 +64,14 @@ class VocabularyRepositoryImplTest {
         scheduler = Scheduler.builder().build()
 
         // Create repository
+        undoSnapshotDao = database.undoSnapshotDao()
         repository =
             VocabularyRepositoryImpl(
                 vocabularyDao = vocabularyDao,
                 scheduler = scheduler,
                 prefs = dayCountersStore,
+                undoSnapshotDao = undoSnapshotDao,
+                appDatabase = database,
             )
     }
 
@@ -282,6 +288,8 @@ class VocabularyRepositoryImplTest {
         runTest {
             val id = insertTestVocabulary("sehen", "see")
             coEvery { dayCountersStore.markNewShown() } just Runs
+            coEvery { dayCountersStore.read() } returns
+                flowOf(DayCounters(yyyymmdd = todayStamp(), newShown = 0, reviewShown = 0, reviewsSinceLastNew = 0))
 
             repository.reviewVocabularyItem(id, Rating.GOOD)
 
@@ -308,6 +316,8 @@ class VocabularyRepositoryImplTest {
                     incorrectCount = 1,
                 )
             coEvery { dayCountersStore.markReviewShown() } just Runs
+            coEvery { dayCountersStore.read() } returns
+                flowOf(DayCounters(yyyymmdd = todayStamp(), newShown = 0, reviewShown = 2, reviewsSinceLastNew = 1))
 
             repository.reviewVocabularyItem(id, Rating.GOOD)
 

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
@@ -1,0 +1,430 @@
+package com.procrastilearn.app.data.repository
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.dao.UndoSnapshotDao
+import com.procrastilearn.app.data.local.dao.VocabularyDao
+import com.procrastilearn.app.data.local.database.AppDatabase
+import com.procrastilearn.app.data.local.entity.UndoSnapshotEntity
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import com.procrastilearn.app.data.local.prefs.DayCountersStore
+import com.procrastilearn.app.data.local.prefs.StudyPreferencesDataStore
+import io.github.openspacedrepetition.Card
+import io.github.openspacedrepetition.Rating
+import io.github.openspacedrepetition.Scheduler
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Real Room + real (DataStore-backed) DayCountersStore - no mocks - so the exact
+ * snapshot/restore semantics of undo (row columns + day counters together) can be
+ * verified end to end, including the cross-day guard.
+ */
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class VocabularyRepositoryUndoTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var database: AppDatabase
+    private lateinit var vocabularyDao: VocabularyDao
+    private lateinit var undoSnapshotDao: UndoSnapshotDao
+    private lateinit var dayCountersStore: DayCountersStore
+    private lateinit var repository: VocabularyRepositoryImpl
+
+    @Before
+    fun setup() {
+        database =
+            Room
+                .inMemoryDatabaseBuilder(
+                    ApplicationProvider.getApplicationContext(),
+                    AppDatabase::class.java,
+                ).allowMainThreadQueries()
+                .build()
+        vocabularyDao = database.vocabularyDao()
+        undoSnapshotDao = database.undoSnapshotDao()
+
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val filesRoot = temporaryFolder.newFolder("datastore-root")
+        val dataStoreContext =
+            object : ContextWrapper(baseContext) {
+                override fun getFilesDir(): File = filesRoot
+
+                override fun getApplicationContext(): Context = this
+            }
+        dayCountersStore = DayCountersStore(StudyPreferencesDataStore(dataStoreContext))
+
+        repository =
+            VocabularyRepositoryImpl(
+                vocabularyDao = vocabularyDao,
+                scheduler = Scheduler.builder().build(),
+                prefs = dayCountersStore,
+                undoSnapshotDao = undoSnapshotDao,
+                appDatabase = database,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private fun todayStamp(): Int = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE).toInt()
+
+    @Suppress("LongParameterList")
+    private suspend fun insertVocab(
+        word: String,
+        translation: String = word,
+        fsrsCardJson: String = "",
+        fsrsDueAt: Long = 0L,
+        correctCount: Int = 0,
+        incorrectCount: Int = 0,
+        lastShownAt: Long? = null,
+    ): Long =
+        vocabularyDao.insertVocabulary(
+            VocabularyEntity(
+                id = 0,
+                word = word,
+                translation = translation,
+                fsrsCardJson = fsrsCardJson,
+                fsrsDueAt = fsrsDueAt,
+                correctCount = correctCount,
+                incorrectCount = incorrectCount,
+                lastShownAt = lastShownAt,
+            ),
+        )
+
+    @Test
+    fun `undoLastRating returns null when stack is empty`() =
+        runTest {
+            val result = repository.undoLastRating()
+
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `reviewVocabularyItem pushes a snapshot capturing pre-rating state`() =
+        runTest {
+            val id = insertVocab("lernen")
+
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(1)
+            val snapshot = undoSnapshotDao.peekLatest()
+            assertThat(snapshot?.vocabId).isEqualTo(id)
+            assertThat(snapshot?.fsrsCardJson).isEmpty()
+            assertThat(snapshot?.fsrsDueAt).isEqualTo(0L)
+            assertThat(snapshot?.correctCount).isEqualTo(0)
+            assertThat(snapshot?.incorrectCount).isEqualTo(0)
+            assertThat(snapshot?.ratingName).isEqualTo("GOOD")
+            assertThat(snapshot?.snapshotDay).isEqualTo(todayStamp())
+        }
+
+    @Test
+    fun `undoLastRating restores fsrs card state exactly for a new card`() =
+        runTest {
+            val id = insertVocab("lesen")
+
+            repository.reviewVocabularyItem(id, Rating.EASY)
+            val ratedEntity = vocabularyDao.getVocabularyById(id)!!
+            assertThat(ratedEntity.correctCount).isEqualTo(1)
+
+            val result = repository.undoLastRating()
+
+            val restored = vocabularyDao.getVocabularyById(id)!!
+            assertThat(result?.item?.id).isEqualTo(id)
+            assertThat(result?.revertedRating).isEqualTo(Rating.EASY)
+            assertThat(restored.fsrsCardJson).isEmpty()
+            assertThat(restored.fsrsDueAt).isEqualTo(0L)
+            assertThat(restored.lastShownAt).isNull()
+            assertThat(restored.correctCount).isEqualTo(0)
+            assertThat(restored.incorrectCount).isEqualTo(0)
+        }
+
+    @Test
+    fun `undoLastRating restores fsrs card state exactly for an existing review card`() =
+        runTest {
+            val now = System.currentTimeMillis()
+            val oldCardJson = Card.builder().build().toJson()
+            val id =
+                insertVocab(
+                    word = "sprechen",
+                    fsrsCardJson = oldCardJson,
+                    fsrsDueAt = now - 1_000L,
+                    correctCount = 2,
+                    incorrectCount = 1,
+                    lastShownAt = now - 100_000L,
+                )
+
+            repository.reviewVocabularyItem(id, Rating.AGAIN)
+            val ratedEntity = vocabularyDao.getVocabularyById(id)!!
+            assertThat(ratedEntity.incorrectCount).isEqualTo(2)
+
+            val result = repository.undoLastRating()
+
+            val restored = vocabularyDao.getVocabularyById(id)!!
+            assertThat(result?.revertedRating).isEqualTo(Rating.AGAIN)
+            assertThat(restored.fsrsCardJson).isEqualTo(oldCardJson)
+            assertThat(restored.fsrsDueAt).isEqualTo(now - 1_000L)
+            assertThat(restored.lastShownAt).isEqualTo(now - 100_000L)
+            assertThat(restored.correctCount).isEqualTo(2)
+            assertThat(restored.incorrectCount).isEqualTo(1)
+        }
+
+    @Test
+    fun `undoLastRating deletes the consumed snapshot`() =
+        runTest {
+            val id = insertVocab("gehen")
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+            assertThat(undoSnapshotDao.count()).isEqualTo(1)
+
+            repository.undoLastRating()
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(0)
+        }
+
+    @Test
+    fun `undoLastRating sets restored item as current item`() =
+        runTest {
+            val id = insertVocab("sehen")
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+
+            repository.undoLastRating()
+
+            repository.observeCurrentItem().test {
+                assertThat(awaitItem().id).isEqualTo(id)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `undoLastRating restores day counters when snapshot is from today`() =
+        runTest {
+            val id = insertVocab("laufen")
+
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+            assertThat(dayCountersStore.read().first().newShown).isEqualTo(1)
+
+            repository.undoLastRating()
+
+            val counters = dayCountersStore.read().first()
+            assertThat(counters.newShown).isEqualTo(0)
+            assertThat(counters.reviewShown).isEqualTo(0)
+            assertThat(counters.reviewsSinceLastNew).isEqualTo(0)
+        }
+
+    @Test
+    fun `undoLastRating skips day counter restore for a snapshot from a previous day`() =
+        runTest {
+            val id = insertVocab("schreiben")
+            // Simulate a rating made yesterday: insert the snapshot directly rather than
+            // going through reviewVocabularyItem (which always stamps "today").
+            undoSnapshotDao.insert(
+                UndoSnapshotEntity(
+                    vocabId = id,
+                    createdAt = System.currentTimeMillis() - 86_400_000L,
+                    snapshotDay = todayStamp() - 1,
+                    ratingName = Rating.EASY.name,
+                    fsrsCardJson = "",
+                    fsrsDueAt = 0L,
+                    lastShownAt = null,
+                    correctCount = 0,
+                    incorrectCount = 0,
+                    newShown = 0,
+                    reviewShown = 0,
+                    reviewsSinceLastNew = 0,
+                ),
+            )
+            // Today's counters already have real activity that must survive the undo.
+            dayCountersStore.resetFor(todayStamp())
+            dayCountersStore.markNewShown()
+            dayCountersStore.markReviewShown()
+            val beforeUndo = dayCountersStore.read().first()
+
+            // Give the card today's state so we can also confirm the FSRS half *is* restored.
+            vocabularyDao.applyFsrsReview(
+                id = id,
+                cardJson = Card.builder().build().toJson(),
+                dueAt = System.currentTimeMillis() + 1_000L,
+                reviewedAt = System.currentTimeMillis(),
+                incCorrect = 0,
+                incIncorrect = 1,
+            )
+
+            val result = repository.undoLastRating()
+
+            assertThat(result).isNotNull()
+            val restoredEntity = vocabularyDao.getVocabularyById(id)!!
+            assertThat(restoredEntity.fsrsCardJson).isEmpty()
+            assertThat(restoredEntity.incorrectCount).isEqualTo(0)
+
+            val afterUndo = dayCountersStore.read().first()
+            assertThat(afterUndo).isEqualTo(beforeUndo)
+        }
+
+    @Test
+    fun `undoLastRating never touches extraNewToday`() =
+        runTest {
+            val id = insertVocab("kaufen")
+            dayCountersStore.addExtraNewToday(5)
+
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+            repository.undoLastRating()
+
+            assertThat(dayCountersStore.read().first().extraNewToday).isEqualTo(5)
+        }
+
+    @Test
+    fun `undo stack keeps only the last three ratings`() =
+        runTest {
+            val ids = (1..4).map { insertVocab("word$it") }
+            ids.forEach { repository.reviewVocabularyItem(it, Rating.GOOD) }
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(3)
+
+            // The oldest (first) rating fell off the stack; only the last three are undoable.
+            val undone = mutableListOf<Long>()
+            repeat(3) {
+                repository.undoLastRating()?.let { undone.add(it.item.id) }
+            }
+            assertThat(undone).containsExactly(ids[3], ids[2], ids[1]).inOrder()
+            assertThat(repository.undoLastRating()).isNull()
+        }
+
+    @Test
+    fun `undoing the same card rated twice restores state in LIFO order`() =
+        runTest {
+            val id = insertVocab("machen")
+
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+            val afterFirst = vocabularyDao.getVocabularyById(id)!!
+            val countersAfterFirst = dayCountersStore.read().first()
+
+            repository.reviewVocabularyItem(id, Rating.EASY)
+            assertThat(vocabularyDao.getVocabularyById(id)!!.correctCount).isEqualTo(2)
+
+            // First undo reverts the *second* rating -> back to the post-first-rating state.
+            repository.undoLastRating()
+            val afterFirstUndo = vocabularyDao.getVocabularyById(id)!!
+            assertThat(afterFirstUndo.fsrsCardJson).isEqualTo(afterFirst.fsrsCardJson)
+            assertThat(afterFirstUndo.correctCount).isEqualTo(1)
+            assertThat(dayCountersStore.read().first()).isEqualTo(countersAfterFirst)
+
+            // Second undo reverts the *first* rating -> back to pristine.
+            repository.undoLastRating()
+            val afterSecondUndo = vocabularyDao.getVocabularyById(id)!!
+            assertThat(afterSecondUndo.fsrsCardJson).isEmpty()
+            assertThat(afterSecondUndo.correctCount).isEqualTo(0)
+            assertThat(dayCountersStore.read().first().newShown).isEqualTo(0)
+        }
+
+    @Test
+    fun `editing a word after rating it prunes its undo snapshot`() =
+        runTest {
+            val id = insertVocab("essen")
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+            assertThat(undoSnapshotDao.count()).isEqualTo(1)
+
+            repository.updateVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "essen (edited)",
+                    translation = "eat",
+                    isNew = false,
+                ),
+            )
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(0)
+            assertThat(repository.undoLastRating()).isNull()
+        }
+
+    @Test
+    fun `resetting progress after rating prunes its undo snapshot`() =
+        runTest {
+            val id = insertVocab("trinken")
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+
+            repository.resetVocabularyProgress(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "trinken",
+                    translation = "drink",
+                    isNew = false,
+                ),
+            )
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(0)
+        }
+
+    @Test
+    fun `deleting a word after rating it prunes its undo snapshot`() =
+        runTest {
+            val id = insertVocab("fahren")
+            repository.reviewVocabularyItem(id, Rating.GOOD)
+
+            repository.deleteVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "fahren",
+                    translation = "drive",
+                    isNew = false,
+                ),
+            )
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(0)
+        }
+
+    @Test
+    fun `deleting one word does not prune another word's undo snapshot`() =
+        runTest {
+            val keepId = insertVocab("bleiben")
+            val deleteId = insertVocab("gehen weg")
+            repository.reviewVocabularyItem(keepId, Rating.GOOD)
+            repository.reviewVocabularyItem(deleteId, Rating.GOOD)
+            assertThat(undoSnapshotDao.count()).isEqualTo(2)
+
+            repository.deleteVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = deleteId,
+                    word = "gehen weg",
+                    translation = "go away",
+                    isNew = false,
+                ),
+            )
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(1)
+            assertThat(undoSnapshotDao.peekLatest()?.vocabId).isEqualTo(keepId)
+        }
+
+    @Test
+    fun `observeUndoCount reflects stack size as ratings and undos happen`() =
+        runTest {
+            repository.observeUndoCount().test {
+                assertThat(awaitItem()).isEqualTo(0)
+
+                val id = insertVocab("wissen")
+                repository.reviewVocabularyItem(id, Rating.GOOD)
+                assertThat(awaitItem()).isEqualTo(1)
+
+                repository.undoLastRating()
+                assertThat(awaitItem()).isEqualTo(0)
+
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
@@ -30,11 +30,6 @@ import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-/**
- * Real Room + real (DataStore-backed) DayCountersStore - no mocks - so the exact
- * snapshot/restore semantics of undo (row columns + day counters together) can be
- * verified end to end, including the cross-day guard.
- */
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class VocabularyRepositoryUndoTest {

--- a/app/src/test/java/com/procrastilearn/app/domain/usecase/UndoLastRatingUseCaseTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/domain/usecase/UndoLastRatingUseCaseTest.kt
@@ -1,0 +1,68 @@
+package com.procrastilearn.app.domain.usecase
+
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.domain.model.UndoResult
+import com.procrastilearn.app.domain.model.VocabularyItem
+import com.procrastilearn.app.domain.repository.VocabularyRepository
+import io.github.openspacedrepetition.Rating
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class UndoLastRatingUseCaseTest {
+    private val repository: VocabularyRepository = mockk()
+
+    private lateinit var useCase: UndoLastRatingUseCase
+
+    @Before
+    fun setUp() {
+        useCase = UndoLastRatingUseCase(repository)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `invoke returns success with the restored item when repository has something to undo`() =
+        runTest {
+            val item = VocabularyItem(id = 7, word = "Baum", translation = "tree", isNew = false)
+            val undoResult = UndoResult(item = item, revertedRating = Rating.EASY)
+            coEvery { repository.undoLastRating() } returns undoResult
+
+            val result = useCase()
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrNull()).isEqualTo(undoResult)
+            coVerify(exactly = 1) { repository.undoLastRating() }
+        }
+
+    @Test
+    fun `invoke returns success with null when there is nothing to undo`() =
+        runTest {
+            coEvery { repository.undoLastRating() } returns null
+
+            val result = useCase()
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrNull()).isNull()
+        }
+
+    @Test
+    fun `invoke returns failure when repository throws`() =
+        runTest {
+            val error = IllegalStateException("boom")
+            coEvery { repository.undoLastRating() } throws error
+
+            val result = useCase()
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isEqualTo(error)
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
@@ -2,14 +2,17 @@ package com.procrastilearn.app.ui.dojo
 
 import com.google.common.truth.Truth.assertThat
 import com.procrastilearn.app.data.counter.DayCounters
+import com.procrastilearn.app.data.local.dao.UndoSnapshotDao
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
 import com.procrastilearn.app.data.repository.NoAvailableItemsException
 import com.procrastilearn.app.domain.model.LearningPreferencesConfig
 import com.procrastilearn.app.domain.model.MixMode
+import com.procrastilearn.app.domain.model.UndoResult
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.usecase.GetNextVocabularyItemUseCase
 import com.procrastilearn.app.domain.usecase.SaveDifficultyRatingUseCase
+import com.procrastilearn.app.domain.usecase.UndoLastRatingUseCase
 import com.procrastilearn.app.utils.MainDispatcherRule
 import io.github.openspacedrepetition.Rating
 import io.mockk.clearAllMocks
@@ -35,10 +38,13 @@ class DojoViewModelTest {
     private lateinit var saveDifficultyRating: SaveDifficultyRatingUseCase
     private lateinit var vocabularyDao: VocabularyDao
     private lateinit var dayCountersStore: DayCountersStore
+    private lateinit var undoLastRating: UndoLastRatingUseCase
+    private lateinit var undoSnapshotDao: UndoSnapshotDao
 
     private lateinit var countersFlow: MutableStateFlow<DayCounters>
     private lateinit var policyFlow: MutableStateFlow<LearningPreferencesConfig>
     private lateinit var dueCountFlow: MutableStateFlow<Int>
+    private lateinit var undoCountFlow: MutableStateFlow<Int>
 
     @Before
     fun setUp() {
@@ -46,6 +52,8 @@ class DojoViewModelTest {
         saveDifficultyRating = mockk()
         vocabularyDao = mockk()
         dayCountersStore = mockk()
+        undoLastRating = mockk()
+        undoSnapshotDao = mockk()
 
         // Default flows
         countersFlow =
@@ -67,11 +75,13 @@ class DojoViewModelTest {
                 ),
             )
         dueCountFlow = MutableStateFlow(10)
+        undoCountFlow = MutableStateFlow(0)
 
         every { dayCountersStore.read() } returns countersFlow
         every { dayCountersStore.readPolicy() } returns policyFlow
         coEvery { vocabularyDao.countReviewsDue(any()) } returns 10
         every { vocabularyDao.observeReviewsDueCount(any()) } returns dueCountFlow
+        every { undoSnapshotDao.observeCount() } returns undoCountFlow
     }
 
     @After
@@ -85,6 +95,8 @@ class DojoViewModelTest {
             saveDifficultyRating,
             vocabularyDao,
             dayCountersStore,
+            undoLastRating,
+            undoSnapshotDao,
         )
 
     @Test
@@ -468,5 +480,177 @@ class DojoViewModelTest {
 
             // showAnswer should be reset
             assertThat(viewModel.uiState.value.showAnswer).isFalse()
+        }
+
+    @Test
+    fun `canUndo reflects the undo stack size`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = true)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.canUndo).isFalse()
+
+            undoCountFlow.value = 1
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.canUndo).isTrue()
+
+            undoCountFlow.value = 0
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.canUndo).isFalse()
+        }
+
+    @Test
+    fun `onUndo with nothing to undo is a no-op`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = true)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+            coEvery { undoLastRating.invoke() } returns Result.success(null)
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUndo()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(item)
+            assertThat(viewModel.uiState.value.undoEvent).isNull()
+        }
+
+    @Test
+    fun `onUndo pins the restored word on screen with its answer shown`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val current = VocabularyItem(id = 1, word = "current", translation = "текущий", isNew = true)
+            val restored = VocabularyItem(id = 99, word = "restored", translation = "восстановлен", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(current)
+            coEvery { undoLastRating.invoke() } returns
+                Result.success(UndoResult(item = restored, revertedRating = Rating.EASY))
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUndo()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.vocabularyItem).isEqualTo(restored)
+            assertThat(state.showAnswer).isTrue()
+            assertThat(state.undoEvent?.word).isEqualTo("restored")
+            assertThat(state.undoEvent?.revertedRating).isEqualTo(Rating.EASY)
+        }
+
+    @Test
+    fun `onUndoEventShown clears the undo event`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val current = VocabularyItem(id = 1, word = "current", translation = "текущий", isNew = true)
+            val restored = VocabularyItem(id = 99, word = "restored", translation = "восстановлен", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(current)
+            coEvery { undoLastRating.invoke() } returns
+                Result.success(UndoResult(item = restored, revertedRating = Rating.GOOD))
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+            viewModel.onUndo()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.undoEvent).isNotNull()
+
+            viewModel.onUndoEventShown()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.undoEvent).isNull()
+        }
+
+    @Test
+    fun `restored word survives the reactive re-fetch triggered by undo's own writes`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            // Regression test for the pinned-item guard: undo writes to both the vocabulary
+            // table and the day counters, either of which can trigger the reactive
+            // combine() in init{} that normally calls loadNextWord(). That must not be
+            // allowed to steal the just-restored card off the screen.
+            val current = VocabularyItem(id = 1, word = "current", translation = "текущий", isNew = true)
+            val restored = VocabularyItem(id = 99, word = "restored", translation = "восстановлен", isNew = false)
+            val someOtherWord = VocabularyItem(id = 2, word = "other", translation = "другой", isNew = true)
+            coEvery { getNextVocabularyItem.invoke() } returnsMany
+                listOf(Result.success(current), Result.success(someOtherWord))
+            coEvery { undoLastRating.invoke() } returns
+                Result.success(UndoResult(item = restored, revertedRating = Rating.EASY))
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUndo()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(restored)
+
+            // Simulate the reactive triggers undo's own DB/counter writes would cause.
+            dueCountFlow.value = 999
+            advanceUntilIdle()
+            countersFlow.value = countersFlow.value.copy(newShown = 0)
+            advanceUntilIdle()
+
+            // The restored card must still be pinned; it must not have been replaced by
+            // "someOtherWord" from a stray loadNextWord() call.
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(restored)
+        }
+
+    @Test
+    fun `re-rating the restored word clears the pin and resumes normal fetching`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val current = VocabularyItem(id = 1, word = "current", translation = "текущий", isNew = true)
+            val restored = VocabularyItem(id = 99, word = "restored", translation = "восстановлен", isNew = false)
+            val next = VocabularyItem(id = 2, word = "next", translation = "следующий", isNew = true)
+            coEvery { getNextVocabularyItem.invoke() } returnsMany
+                listOf(Result.success(current), Result.success(next))
+            coEvery { undoLastRating.invoke() } returns
+                Result.success(UndoResult(item = restored, revertedRating = Rating.EASY))
+            coEvery { saveDifficultyRating.invoke(any(), any()) } returns Result.success(Unit)
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUndo()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(restored)
+
+            viewModel.onDifficultySelected(Rating.GOOD)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { saveDifficultyRating.invoke(99, Rating.GOOD) }
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(next)
+
+            // Pin is cleared: further reactive triggers now fetch for real again rather
+            // than re-pinning the old restored word.
+            dueCountFlow.value = 1234
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(next)
+        }
+
+    @Test
+    fun `undoing twice re-pins each newly restored word`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val current = VocabularyItem(id = 1, word = "current", translation = "текущий", isNew = true)
+            val restoredFirst = VocabularyItem(id = 98, word = "first-undo", translation = "первый", isNew = false)
+            val restoredSecond = VocabularyItem(id = 99, word = "second-undo", translation = "второй", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(current)
+            coEvery { undoLastRating.invoke() } returnsMany
+                listOf(
+                    Result.success(UndoResult(item = restoredFirst, revertedRating = Rating.GOOD)),
+                    Result.success(UndoResult(item = restoredSecond, revertedRating = Rating.AGAIN)),
+                )
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUndo()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(restoredFirst)
+
+            viewModel.onUndo()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.vocabularyItem).isEqualTo(restoredSecond)
+            assertThat(viewModel.uiState.value.undoEvent?.word).isEqualTo("second-undo")
         }
 }

--- a/app/src/test/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeaderTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeaderTest.kt
@@ -1,0 +1,99 @@
+package com.procrastilearn.app.ui.dojo.components
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.procrastilearn.app.R
+import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
+import com.procrastilearn.app.ui.theme.MyApplicationTheme
+import io.mockk.called
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    sdk = [33],
+    manifest = Config.NONE,
+    qualifiers = "xlarge",
+)
+class DojoStatsHeaderTest {
+    private val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val rules: TestRule =
+        RuleChain
+            .outerRule(ComponentActivityRegistrationRule())
+            .around(composeTestRule)
+
+    private lateinit var onUndo: () -> Unit
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        onUndo = mockk(relaxed = true)
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `displays new and due counts`() {
+        setContent(newQuotaRemaining = 17, pendingReviewCount = 10, canUndo = false)
+
+        composeTestRule.onNodeWithText("17", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("10", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `undo button is disabled and inert when canUndo is false`() {
+        setContent(newQuotaRemaining = 5, pendingReviewCount = 5, canUndo = false)
+
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.dojo_undo_content_description))
+            .assertIsNotEnabled()
+            .performClick()
+
+        verify { onUndo wasNot called }
+    }
+
+    @Test
+    fun `undo button triggers callback when canUndo is true`() {
+        setContent(newQuotaRemaining = 5, pendingReviewCount = 5, canUndo = true)
+
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.dojo_undo_content_description))
+            .performClick()
+
+        verify(exactly = 1) { onUndo.invoke() }
+    }
+
+    private fun setContent(
+        newQuotaRemaining: Int,
+        pendingReviewCount: Int,
+        canUndo: Boolean,
+    ) {
+        composeTestRule.setContent {
+            MyApplicationTheme {
+                DojoStatsHeader(
+                    newQuotaRemaining = newQuotaRemaining,
+                    pendingReviewCount = pendingReviewCount,
+                    canUndo = canUndo,
+                    onUndo = onUndo,
+                )
+            }
+        }
+    }
+
+    private fun string(resId: Int): String = context.getString(resId)
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeaderTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeaderTest.kt
@@ -21,14 +21,8 @@ import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(
-    sdk = [33],
-    manifest = Config.NONE,
-    qualifiers = "xlarge",
-)
 class DojoStatsHeaderTest {
     private val composeTestRule = createComposeRule()
 


### PR DESCRIPTION
## Summary

Misclicking a difficulty button (Again/Hard/Good/Easy) in the dojo or the blocking overlay had no recovery path — the wrong rating silently corrupted the card's FSRS schedule with no way to fix it.

This adds a small undo feature:

- A persisted undo stack (Room table, cap **3**, strict **LIFO**) that snapshots the pre-rating FSRS card state (`fsrsCardJson`, `fsrsDueAt`, `lastShownAt`, `correctCount`, `incorrectCount`) and day counters (`newShown`, `reviewShown`, `reviewsSinceLastNew`) at the single shared rating choke point (`VocabularyRepositoryImpl.reviewVocabularyItem`), so ratings from **both** the dojo and the overlay push onto one shared stack.
- A circular-arrow undo button at the left of the dojo stats bar (greyed out when the stack is empty) reverts the most recent rating — from either surface — restores the word on screen with its answer revealed for re-rating, and shows a brief "Undid `<rating>` for `<word>`" confirmation.
- Cross-day ratings: undo always restores the FSRS card state, but skips restoring the day counters if the rating happened on a previous day (that day's quota bucket is already gone — restoring it would corrupt *today's* counters instead).
- Editing, resetting, or deleting a word prunes any pending undo snapshots for it, so undo can never resurrect state that's since been intentionally cleared.
- A `Mutex` in the repository serializes rating and undo so a dojo rating and an overlay rating can't interleave and corrupt a snapshot.
- Room schema bumped to v3 with a migration (`MIGRATION_2_3`) adding the `undo_snapshot` table.

## Test plan

- [x] New `VocabularyRepositoryUndoTest` (real Room + real DataStore-backed `DayCountersStore`, no mocks): snapshot capture, exact FSRS restore (new + existing cards), snapshot deletion, current-item update, same-day counter restore, cross-day counter-restore guard, `extraNewToday` preservation, cap-of-3 trimming, LIFO restore for the same card rated twice, pruning on edit/reset/delete, `observeUndoCount` reactivity.
- [x] New `UndoSnapshotDaoTest`: `peekLatest`, `trimToLast` (over/under/zero cap), `deleteById`, `deleteForVocab`, `deleteAll`, `observeCount`.
- [x] New `UndoLastRatingUseCaseTest`: success with/without a result, failure propagation.
- [x] New `DojoStatsHeaderTest`: counts render, undo button disabled/inert when nothing to undo, triggers callback when enabled.
- [x] Extended `DojoViewModelTest`: `canUndo` reactivity, no-op undo, pin-and-reveal on undo, undo-event lifecycle, the reactive re-fetch guard (undo's own DB/counter writes don't steal the restored card), pin clears on re-rating, repeated undo re-pins each newly restored word.
- [x] Extended `DayCountersStoreTest` for `restoreCounters` (absolute set, leaves `extraNewToday`/day untouched).
- [x] New migration test `migrate2To3AddsTheUndoSnapshotTableAndKeepsExistingVocabulary` in `AppDatabaseMigrationTest`.
- [x] Updated existing repository/view-model tests for the new constructor dependencies.
- [x] `./gradlew testDebugUnitTest` — all 375 unit tests pass.
- [x] `./gradlew ktlintCheck detekt lintDebug` — clean.
- [x] `./gradlew :app:assembleDebug :app:compileDebugAndroidTestKotlin` — builds successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VG6XwSuA7yM1ZxsCGJCAWQ)_