### PR TITLE
fix: clamp Add Cards For Today to the actual unseen card count

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
@@ -196,6 +196,11 @@ interface VocabularyDao {
     @Query("SELECT COUNT(*) FROM vocabulary WHERE correctCount = 0 AND incorrectCount = 0")
     suspend fun countNewTotal(): Int
 
+    // Reactive twin of [countNewTotal]: re-emits whenever the vocabulary table changes,
+    // so screens showing new-count-derived state can stay in sync without polling.
+    @Query("SELECT COUNT(*) FROM vocabulary WHERE correctCount = 0 AND incorrectCount = 0")
+    fun observeNewTotalCount(): Flow<Int>
+
     // Pick next review (due now), earliest first
     @Query(
         """

--- a/app/src/main/java/com/procrastilearn/app/data/local/prefs/DayCountersStore.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/prefs/DayCountersStore.kt
@@ -84,10 +84,20 @@ class DayCountersStore
             }
         }
 
-        suspend fun addExtraNewToday(amount: Int) {
+        // Clamps the boost so newPerDay + extraNewToday - newShown can never exceed
+        // [availableNew], the actual number of unseen cards left in the deck.
+        suspend fun addExtraNewToday(
+            amount: Int,
+            availableNew: Int,
+        ) {
             if (amount <= 0) return
             ds.edit { p ->
-                p[K.EXTRA_NEW_TODAY] = (p[K.EXTRA_NEW_TODAY] ?: 0) + amount
+                val newPerDay = p[K.NEW_PER_DAY_LIMIT] ?: DEFAULT_NEW_PER_DAY
+                val newShown = p[K.NEW_SHOWN] ?: 0
+                val extra = p[K.EXTRA_NEW_TODAY] ?: 0
+                val remaining = (newPerDay + extra - newShown).coerceAtLeast(0)
+                val capacity = (availableNew - remaining).coerceAtLeast(0)
+                p[K.EXTRA_NEW_TODAY] = extra + amount.coerceAtMost(capacity)
             }
         }
 

--- a/app/src/main/java/com/procrastilearn/app/data/local/prefs/DayCountersStore.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/prefs/DayCountersStore.kt
@@ -84,8 +84,6 @@ class DayCountersStore
             }
         }
 
-        // Clamps the boost so newPerDay + extraNewToday - newShown can never exceed
-        // [availableNew], the actual number of unseen cards left in the deck.
         suspend fun addExtraNewToday(
             amount: Int,
             availableNew: Int,

--- a/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
@@ -229,6 +229,7 @@ class VocabularyRepositoryImpl
                 // Read day counters once
                 val counters = prefs.read().first()
                 val policy = prefs.readPolicy().first()
+                val totalNew = vocabularyDao.countNewTotal()
 
                 Log.i("fsrs", counters.toString())
                 val newRemaining =
@@ -264,7 +265,6 @@ class VocabularyRepositoryImpl
 
                         // If we want a new now (ratio hit) or no reviews due, try new (within daily cap)
                         newRemaining > 0 && (wantNew || dueCount == 0) -> {
-                            val totalNew = vocabularyDao.countNewTotal()
                             if (totalNew > 0) {
                                 val offset = kotlin.random.Random.nextInt(totalNew) // O(1) sampler
                                 vocabularyDao.pickNewIdByOffset(offset)
@@ -290,6 +290,7 @@ class VocabularyRepositoryImpl
 
                 val counters = prefs.read().first()
                 val policy = prefs.readPolicy().first()
+                val totalNew = vocabularyDao.countNewTotal()
                 val newRemaining =
                     (policy.newPerDay + counters.extraNewToday - counters.newShown).coerceAtLeast(0)
                 val reviewRemaining = (policy.reviewPerDay - counters.reviewShown).coerceAtLeast(0)
@@ -302,7 +303,7 @@ class VocabularyRepositoryImpl
                 // 2. We haven't hit the new card limit AND there are new cards
                 return@withContext when {
                     dueCount > 0 -> true
-                    newRemaining > 0 && vocabularyDao.countNewTotal() > 0 -> true
+                    newRemaining > 0 && totalNew > 0 -> true
                     else -> false
                 }
             }

--- a/app/src/main/java/com/procrastilearn/app/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/SettingsViewModel.kt
@@ -76,9 +76,21 @@ class SettingsViewModel
         private val _availableNewCount = MutableStateFlow(0)
         val availableNewCount: StateFlow<Int> = _availableNewCount
 
+        // How many more new cards can still be added to today's quota before the
+        // total new-card quota would exceed the actual number of unseen cards.
+        private val _availableToAddToday = MutableStateFlow(0)
+        val availableToAddToday: StateFlow<Int> = _availableToAddToday
+
         fun loadAvailableNewCount() {
             viewModelScope.launch {
-                _availableNewCount.value = vocabularyDao.countNewTotal()
+                val totalNew = vocabularyDao.countNewTotal()
+                _availableNewCount.value = totalNew
+
+                val policy = dayCountersStore.readPolicy().first()
+                val counters = dayCountersStore.read().first()
+                val remaining =
+                    (policy.newPerDay + counters.extraNewToday - counters.newShown).coerceAtLeast(0)
+                _availableToAddToday.value = (totalNew - remaining).coerceAtLeast(0)
             }
         }
 
@@ -103,7 +115,9 @@ class SettingsViewModel
         }
 
         fun onAddCardsForToday(amount: Int) {
-            viewModelScope.launch { dayCountersStore.addExtraNewToday(amount) }
+            viewModelScope.launch {
+                dayCountersStore.addExtraNewToday(amount, vocabularyDao.countNewTotal())
+            }
         }
 
         fun onReviewPerDayChange(value: Int) {

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoViewModel.kt
@@ -44,6 +44,7 @@ class DojoViewModel
         // Reactive: re-emits whenever the vocabulary table changes anywhere in the app
         // (e.g. a review recorded from the blocking overlay), not just from this screen.
         private val reviewsDueCount = vocabularyDao.observeReviewsDueCount(System.currentTimeMillis())
+        private val newTotalCount = vocabularyDao.observeNewTotalCount()
         private val undoCount = undoSnapshotDao.observeCount()
 
         private val baseState =
@@ -52,9 +53,13 @@ class DojoViewModel
                 dayCountersStore.read(),
                 dayCountersStore.readPolicy(),
                 reviewsDueCount,
-            ) { flashcard, counters, policy, pendingReviews ->
+                newTotalCount,
+            ) { flashcard, counters, policy, pendingReviews, newTotal ->
+                // Capped at newTotal: the quota can never claim more new cards exist
+                // than are actually left unseen in the deck.
                 val newQuotaRemaining =
-                    (policy.newPerDay + counters.extraNewToday - counters.newShown).coerceAtLeast(0)
+                    (policy.newPerDay + counters.extraNewToday - counters.newShown)
+                        .coerceIn(0, newTotal)
 
                 // Only show pending reviews if review quota available
                 val reviewQuotaRemaining = (policy.reviewPerDay - counters.reviewShown).coerceAtLeast(0)

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
@@ -97,6 +97,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
     val permissionStates = rememberPermissionStates(ctx)
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val availableNewCount by viewModel.availableNewCount.collectAsStateWithLifecycle()
+    val availableToAddToday by viewModel.availableToAddToday.collectAsStateWithLifecycle()
     val importOptions = viewModel.importOptions
     var pendingImportOptionId by rememberSaveable { mutableStateOf<String?>(null) }
 
@@ -157,6 +158,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
             mixMode = state.mixMode,
             newPerDay = state.newPerDay,
             availableNewCount = availableNewCount,
+            availableToAddToday = availableToAddToday,
             reviewPerDay = state.reviewPerDay,
             overlayInterval = state.overlayInterval,
             openAiApiKey = state.openAiApiKey,
@@ -207,6 +209,7 @@ internal fun SettingsContent(
     mixMode: MixMode,
     newPerDay: Int,
     availableNewCount: Int = 0,
+    availableToAddToday: Int = 0,
     reviewPerDay: Int,
     overlayInterval: Int,
     openAiApiKey: String?,
@@ -342,9 +345,10 @@ internal fun SettingsContent(
         }
         DialogState.AddCardsForToday -> {
             NumberInputDialog(
-                title = stringResource(R.string.settings_add_cards_for_today_dialog_title, availableNewCount),
+                title = stringResource(R.string.settings_add_cards_for_today_dialog_title, availableToAddToday),
                 currentValue = 0,
                 minValue = 1,
+                maxValue = availableToAddToday,
                 onValueConfirm = {
                     onAddCardsForToday(it)
                     dialogState = DialogState.None

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/NumberInputDialog.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/NumberInputDialog.kt
@@ -25,6 +25,7 @@ fun NumberInputDialog(
     onValueConfirm: (Int) -> Unit,
     onDismiss: () -> Unit,
     minValue: Int = 0,
+    maxValue: Int = Int.MAX_VALUE,
 ) {
     var textValue by remember { mutableStateOf(currentValue.toString()) }
 
@@ -50,10 +51,10 @@ fun NumberInputDialog(
         confirmButton = {
             val currentInput = textValue.toIntOrNull()
             TextButton(
-                enabled = currentInput != null && currentInput >= minValue,
+                enabled = currentInput != null && currentInput in minValue..maxValue,
                 onClick = {
                     textValue.toIntOrNull()?.let { value ->
-                        if (value >= minValue) {
+                        if (value in minValue..maxValue) {
                             onValueConfirm(value)
                         }
                     }

--- a/app/src/test/java/com/procrastilearn/app/data/local/prefs/DayCountersStoreTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/prefs/DayCountersStoreTest.kt
@@ -72,8 +72,8 @@ class DayCountersStoreTest {
     fun addExtraNewTodayAccumulatesAcrossCalls() =
         runTest {
             store.resetFor(20240131)
-            store.addExtraNewToday(5)
-            store.addExtraNewToday(3)
+            store.addExtraNewToday(5, availableNew = 100)
+            store.addExtraNewToday(3, availableNew = 100)
 
             val counters = store.read().first()
             assertThat(counters.extraNewToday).isEqualTo(8)
@@ -83,19 +83,79 @@ class DayCountersStoreTest {
     fun addExtraNewTodayIgnoresZeroAndNegativeAmounts() =
         runTest {
             store.resetFor(20240131)
-            store.addExtraNewToday(10)
-            store.addExtraNewToday(0)
-            store.addExtraNewToday(-5)
+            store.addExtraNewToday(10, availableNew = 100)
+            store.addExtraNewToday(0, availableNew = 100)
+            store.addExtraNewToday(-5, availableNew = 100)
 
             val counters = store.read().first()
             assertThat(counters.extraNewToday).isEqualTo(10)
         }
 
     @Test
+    fun addExtraNewTodayClampsToAvailableNewWhenAmountExceedsCapacity() =
+        runTest {
+            // newPerDay defaults to 15, nothing shown yet -> 15 already "remaining".
+            // Only 20 cards are unseen in the deck, so at most 5 more can be added.
+            store.resetFor(20240131)
+
+            store.addExtraNewToday(50, availableNew = 20)
+
+            assertThat(store.read().first().extraNewToday).isEqualTo(5)
+        }
+
+    @Test
+    fun addExtraNewTodayAddsNothingWhenNoCapacityRemains() =
+        runTest {
+            // availableNew = 0: no unseen cards left, so no boost can be granted at all.
+            store.resetFor(20240131)
+
+            store.addExtraNewToday(10, availableNew = 0)
+
+            assertThat(store.read().first().extraNewToday).isEqualTo(0)
+        }
+
+    @Test
+    fun addExtraNewTodayRepeatedAddsStopAtCapacityInsteadOfAccumulatingPastIt() =
+        runTest {
+            // Regression for the "Add Cards For Today" bug: each add alone might look
+            // like it's within bounds, but repeated adds must not accumulate past the
+            // number of cards that actually exist.
+            store.resetFor(20240131)
+
+            store.addExtraNewToday(3, availableNew = 20) // remaining 15 -> +3 = 18, capacity was 5
+            store.addExtraNewToday(3, availableNew = 20) // remaining 18 -> capacity now 2, clamps to +2
+
+            assertThat(store.read().first().extraNewToday).isEqualTo(5)
+        }
+
+    @Test
+    fun addExtraNewTodayAccountsForNewShownWhenComputingCapacity() =
+        runTest {
+            // newPerDay=15, 10 already shown -> 5 remaining. 8 unseen cards left in the
+            // deck means only 3 more can be granted before remaining would exceed unseen.
+            store.resetFor(20240131)
+            repeat(10) { store.markNewShown() }
+
+            store.addExtraNewToday(100, availableNew = 8)
+
+            assertThat(store.read().first().extraNewToday).isEqualTo(3)
+        }
+
+    @Test
+    fun addExtraNewTodayAllowsFullAmountWhenWithinCapacity() =
+        runTest {
+            store.resetFor(20240131)
+
+            store.addExtraNewToday(4, availableNew = 100)
+
+            assertThat(store.read().first().extraNewToday).isEqualTo(4)
+        }
+
+    @Test
     fun resetForClearsExtraNewToday() =
         runTest {
             store.resetFor(20240131)
-            store.addExtraNewToday(10)
+            store.addExtraNewToday(10, availableNew = 100)
             assertThat(store.read().first().extraNewToday).isEqualTo(10)
 
             store.resetFor(20240201)
@@ -109,7 +169,7 @@ class DayCountersStoreTest {
     fun restoreCountersSetsValuesAbsolutelyAndLeavesExtraNewTodayAndDayUntouched() =
         runTest {
             store.resetFor(20240131)
-            store.addExtraNewToday(7)
+            store.addExtraNewToday(7, availableNew = 100)
             store.markReviewShown()
             store.markReviewShown()
             store.markNewShown()

--- a/app/src/test/java/com/procrastilearn/app/data/local/prefs/DayCountersStoreTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/prefs/DayCountersStoreTest.kt
@@ -117,9 +117,6 @@ class DayCountersStoreTest {
     @Test
     fun addExtraNewTodayRepeatedAddsStopAtCapacityInsteadOfAccumulatingPastIt() =
         runTest {
-            // Regression for the "Add Cards For Today" bug: each add alone might look
-            // like it's within bounds, but repeated adds must not accumulate past the
-            // number of cards that actually exist.
             store.resetFor(20240131)
 
             store.addExtraNewToday(3, availableNew = 20) // remaining 15 -> +3 = 18, capacity was 5

--- a/app/src/test/java/com/procrastilearn/app/data/repository/AddCardsForTodayIntegrationTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/AddCardsForTodayIntegrationTest.kt
@@ -110,7 +110,7 @@ class AddCardsForTodayIntegrationTest {
             assertThat(dayCountersStore.read().first().newShown).isEqualTo(2)
 
             // "open Settings -> Add Cards For Today, add 3"
-            dayCountersStore.addExtraNewToday(3)
+            dayCountersStore.addExtraNewToday(3, availableNew = database.vocabularyDao().countNewTotal())
 
             // "confirm 3 more cards appear in Dojo"
             assertThat(repository.hasAvailableItems()).isTrue()
@@ -135,6 +135,53 @@ class AddCardsForTodayIntegrationTest {
             // Only 2 new cards (the permanent quota) are available, not 5.
             reviewNextNewCard()
             reviewNextNewCard()
+            assertThat(repository.hasAvailableItems()).isFalse()
+        }
+
+    @Test
+    fun `add cards for today cannot grant more than the actual unseen cards in the deck`() =
+        runTest {
+            // Regression test for the reported bug: the user could type any number into
+            // "Add Cards For Today" - even one far larger than the number of unseen cards
+            // that exist - and it would be accepted and rendered as the day's new quota.
+            dayCountersStore.setNewPerDay(1)
+            insertNewWords(4) // Only 4 unseen cards ever exist in the deck.
+            // Establish "today" first (mirrors real usage where the day is already
+            // current by the time Settings is opened); otherwise ensureDay()'s
+            // first-run reset would wipe the boost we're about to add.
+            dayCountersStore.resetFor(todayStamp())
+
+            // Request a wildly oversized boost, as reported (e.g. entering 222 with a
+            // near-empty deck).
+            dayCountersStore.addExtraNewToday(999, availableNew = database.vocabularyDao().countNewTotal())
+
+            // The boost must be clamped: 1 permanent + boost can never exceed 4 unseen.
+            val counters = dayCountersStore.read().first()
+            val policy = dayCountersStore.readPolicy().first()
+            assertThat(policy.newPerDay + counters.extraNewToday).isEqualTo(4)
+
+            // And the deck can in fact only serve exactly 4 new cards today, not 999.
+            reviewNextNewCard()
+            reviewNextNewCard()
+            reviewNextNewCard()
+            reviewNextNewCard()
+            assertThat(repository.hasAvailableItems()).isFalse()
+        }
+
+    @Test
+    fun `add cards for today grants nothing when there are no unseen cards left`() =
+        runTest {
+            // Regression test: the dialog accepted input even when "Available New: 0" -
+            // adding cards must be a no-op once the deck has no unseen cards left.
+            dayCountersStore.setNewPerDay(2)
+            insertNewWords(2)
+            reviewNextNewCard()
+            reviewNextNewCard()
+            assertThat(database.vocabularyDao().countNewTotal()).isEqualTo(0)
+
+            dayCountersStore.addExtraNewToday(50, availableNew = database.vocabularyDao().countNewTotal())
+
+            assertThat(dayCountersStore.read().first().extraNewToday).isEqualTo(0)
             assertThat(repository.hasAvailableItems()).isFalse()
         }
 }

--- a/app/src/test/java/com/procrastilearn/app/data/repository/AddCardsForTodayIntegrationTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/AddCardsForTodayIntegrationTest.kt
@@ -141,9 +141,6 @@ class AddCardsForTodayIntegrationTest {
     @Test
     fun `add cards for today cannot grant more than the actual unseen cards in the deck`() =
         runTest {
-            // Regression test for the reported bug: the user could type any number into
-            // "Add Cards For Today" - even one far larger than the number of unseen cards
-            // that exist - and it would be accepted and rendered as the day's new quota.
             dayCountersStore.setNewPerDay(1)
             insertNewWords(4) // Only 4 unseen cards ever exist in the deck.
             // Establish "today" first (mirrors real usage where the day is already
@@ -171,8 +168,6 @@ class AddCardsForTodayIntegrationTest {
     @Test
     fun `add cards for today grants nothing when there are no unseen cards left`() =
         runTest {
-            // Regression test: the dialog accepted input even when "Available New: 0" -
-            // adding cards must be a no-op once the deck has no unseen cards left.
             dayCountersStore.setNewPerDay(2)
             insertNewWords(2)
             reviewNextNewCard()

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
@@ -276,7 +276,7 @@ class VocabularyRepositoryUndoTest {
     fun `undoLastRating never touches extraNewToday`() =
         runTest {
             val id = insertVocab("kaufen")
-            dayCountersStore.addExtraNewToday(5)
+            dayCountersStore.addExtraNewToday(5, availableNew = 100)
 
             repository.reviewVocabularyItem(id, Rating.GOOD)
             repository.undoLastRating()

--- a/app/src/test/java/com/procrastilearn/app/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/SettingsViewModelTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.procrastilearn.app.R
+import com.procrastilearn.app.data.counter.DayCounters
 import com.procrastilearn.app.data.local.dao.VocabularyDao
 import com.procrastilearn.app.data.local.entity.VocabularyEntity
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
@@ -52,6 +53,7 @@ class SettingsViewModelTest {
     private lateinit var vocabularyDao: VocabularyDao
     private lateinit var vocabularyRepository: VocabularyRepository
     private lateinit var policyFlow: MutableStateFlow<LearningPreferencesConfig>
+    private lateinit var countersFlow: MutableStateFlow<DayCounters>
     private lateinit var apiKeyFlow: MutableStateFlow<String?>
     private lateinit var promptFlow: MutableStateFlow<String>
     private lateinit var reversePromptFlow: MutableStateFlow<String>
@@ -82,11 +84,22 @@ class SettingsViewModelTest {
                     mixMode = MixMode.MIX,
                 ),
             )
+        countersFlow =
+            MutableStateFlow(
+                DayCounters(
+                    yyyymmdd = 20260716,
+                    newShown = 0,
+                    reviewShown = 0,
+                    reviewsSinceLastNew = 0,
+                    extraNewToday = 0,
+                ),
+            )
         apiKeyFlow = MutableStateFlow(null)
         promptFlow = MutableStateFlow(OpenAiPromptDefaults.translationPrompt)
         reversePromptFlow = MutableStateFlow(OpenAiPromptDefaults.reverseTranslationPrompt)
 
         every { dayCountersStore.readPolicy() } returns policyFlow
+        every { dayCountersStore.read() } returns countersFlow
         every { openAiStore.readOpenAiApiKey() } returns apiKeyFlow
         every { openAiStore.readOpenAiPrompt() } returns promptFlow
         every { openAiStore.readOpenAiReversePrompt() } returns reversePromptFlow
@@ -179,6 +192,50 @@ class SettingsViewModelTest {
         }
 
     @Test
+    fun `loadAvailableNewCount computes availableToAddToday from unseen total minus current quota`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            // newPerDay=20 (from policyFlow), newShown=0, extraNewToday=0 -> quota remaining = 20.
+            val viewModel = buildViewModel()
+            coEvery { vocabularyDao.countNewTotal() } returns 50
+
+            viewModel.loadAvailableNewCount()
+            advanceUntilIdle()
+
+            // remaining quota = 20 (newPerDay) + 0 (extra) - 0 (shown) = 20
+            // availableToAddToday = 50 (unseen) - 20 (remaining quota) = 30
+            assertThat(viewModel.availableToAddToday.value).isEqualTo(30)
+        }
+
+    @Test
+    fun `loadAvailableNewCount reports zero availableToAddToday when unseen count is at or below current quota`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            // Regression test for the reported bug: when the deck has fewer (or no) unseen
+            // cards than the current quota already claims, there is no room to add more.
+            val viewModel = buildViewModel()
+            coEvery { vocabularyDao.countNewTotal() } returns 0
+
+            viewModel.loadAvailableNewCount()
+            advanceUntilIdle()
+
+            assertThat(viewModel.availableToAddToday.value).isEqualTo(0)
+        }
+
+    @Test
+    fun `loadAvailableNewCount accounts for extraNewToday already granted when computing capacity`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            // newPerDay=20, extraNewToday=15 already granted, newShown=0 -> quota remaining = 35.
+            // Only 40 cards are unseen, so just 5 more can still be added before hitting the cap.
+            countersFlow.value = countersFlow.value.copy(extraNewToday = 15)
+            val viewModel = buildViewModel()
+            coEvery { vocabularyDao.countNewTotal() } returns 40
+
+            viewModel.loadAvailableNewCount()
+            advanceUntilIdle()
+
+            assertThat(viewModel.availableToAddToday.value).isEqualTo(5)
+        }
+
+    @Test
     fun `onMixModeChange delegates to store`() =
         runTest(mainDispatcherRule.testDispatcher) {
             val viewModel = buildViewModel()
@@ -203,15 +260,16 @@ class SettingsViewModelTest {
         }
 
     @Test
-    fun `onAddCardsForToday delegates to store`() =
+    fun `onAddCardsForToday delegates to store with current available new count`() =
         runTest(mainDispatcherRule.testDispatcher) {
             val viewModel = buildViewModel()
-            coEvery { dayCountersStore.addExtraNewToday(any()) } returns Unit
+            coEvery { vocabularyDao.countNewTotal() } returns 30
+            coEvery { dayCountersStore.addExtraNewToday(any(), any()) } returns Unit
 
             viewModel.onAddCardsForToday(16)
             advanceUntilIdle()
 
-            coVerify { dayCountersStore.addExtraNewToday(16) }
+            coVerify { dayCountersStore.addExtraNewToday(16, 30) }
         }
 
     @Test

--- a/app/src/test/java/com/procrastilearn/app/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/SettingsViewModelTest.kt
@@ -209,8 +209,6 @@ class SettingsViewModelTest {
     @Test
     fun `loadAvailableNewCount reports zero availableToAddToday when unseen count is at or below current quota`() =
         runTest(mainDispatcherRule.testDispatcher) {
-            // Regression test for the reported bug: when the deck has fewer (or no) unseen
-            // cards than the current quota already claims, there is no room to add more.
             val viewModel = buildViewModel()
             coEvery { vocabularyDao.countNewTotal() } returns 0
 

--- a/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
@@ -44,6 +44,7 @@ class DojoViewModelTest {
     private lateinit var countersFlow: MutableStateFlow<DayCounters>
     private lateinit var policyFlow: MutableStateFlow<LearningPreferencesConfig>
     private lateinit var dueCountFlow: MutableStateFlow<Int>
+    private lateinit var newTotalCountFlow: MutableStateFlow<Int>
     private lateinit var undoCountFlow: MutableStateFlow<Int>
 
     @Before
@@ -75,12 +76,16 @@ class DojoViewModelTest {
                 ),
             )
         dueCountFlow = MutableStateFlow(10)
+        // High default so existing formula-only tests aren't affected by the new cap;
+        // tests that specifically exercise the cap override this per-test.
+        newTotalCountFlow = MutableStateFlow(1000)
         undoCountFlow = MutableStateFlow(0)
 
         every { dayCountersStore.read() } returns countersFlow
         every { dayCountersStore.readPolicy() } returns policyFlow
         coEvery { vocabularyDao.countReviewsDue(any()) } returns 10
         every { vocabularyDao.observeReviewsDueCount(any()) } returns dueCountFlow
+        every { vocabularyDao.observeNewTotalCount() } returns newTotalCountFlow
         every { undoSnapshotDao.observeCount() } returns undoCountFlow
     }
 
@@ -246,6 +251,92 @@ class DojoViewModelTest {
 
             val state = viewModel.uiState.value
             assertThat(state.newQuotaRemaining).isEqualTo(0)
+        }
+
+    @Test
+    fun `newQuotaRemaining is capped at the actual number of unseen cards left in the deck`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            // Regression test for the reported bug: the "N new" counter must never claim
+            // more new cards exist than are actually unseen in the deck, even if
+            // newPerDay + extraNewToday - newShown computes to a larger number.
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+            // newPerDay=20, newShown=3, extraNewToday=0 -> formula gives 17, but only 4 unseen.
+            newTotalCountFlow.value = 4
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.newQuotaRemaining).isEqualTo(4)
+        }
+
+    @Test
+    fun `newQuotaRemaining stays under the formula value when unseen count exceeds it`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+            // newPerDay=20, newShown=3 -> formula gives 17; plenty of unseen cards (100) exist.
+            newTotalCountFlow.value = 100
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.newQuotaRemaining).isEqualTo(17)
+        }
+
+    @Test
+    fun `newQuotaRemaining caps an oversized extraNewToday boost at the unseen total`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            // Simulates a boost that was granted before the write-side clamp existed
+            // (or any other way an oversized value ends up persisted): the display must
+            // still never exceed reality.
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+            countersFlow.value =
+                DayCounters(
+                    yyyymmdd = 20260117,
+                    newShown = 3,
+                    reviewShown = 5,
+                    reviewsSinceLastNew = 2,
+                    extraNewToday = 500,
+                )
+            newTotalCountFlow.value = 6
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.newQuotaRemaining).isEqualTo(6)
+        }
+
+    @Test
+    fun `newQuotaRemaining is zero when there are no unseen cards left regardless of quota`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+            newTotalCountFlow.value = 0
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.newQuotaRemaining).isEqualTo(0)
+        }
+
+    @Test
+    fun `newQuotaRemaining reacts when the unseen total changes elsewhere`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
+            coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
+            newTotalCountFlow.value = 4
+
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.newQuotaRemaining).isEqualTo(4)
+
+            // More words get imported/added elsewhere in the app.
+            newTotalCountFlow.value = 50
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.newQuotaRemaining).isEqualTo(17) // 20 - 3
         }
 
     @Test

--- a/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/dojo/DojoViewModelTest.kt
@@ -256,12 +256,8 @@ class DojoViewModelTest {
     @Test
     fun `newQuotaRemaining is capped at the actual number of unseen cards left in the deck`() =
         runTest(mainDispatcherRule.testDispatcher) {
-            // Regression test for the reported bug: the "N new" counter must never claim
-            // more new cards exist than are actually unseen in the deck, even if
-            // newPerDay + extraNewToday - newShown computes to a larger number.
             val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
             coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
-            // newPerDay=20, newShown=3, extraNewToday=0 -> formula gives 17, but only 4 unseen.
             newTotalCountFlow.value = 4
 
             val viewModel = buildViewModel()
@@ -287,9 +283,6 @@ class DojoViewModelTest {
     @Test
     fun `newQuotaRemaining caps an oversized extraNewToday boost at the unseen total`() =
         runTest(mainDispatcherRule.testDispatcher) {
-            // Simulates a boost that was granted before the write-side clamp existed
-            // (or any other way an oversized value ends up persisted): the display must
-            // still never exceed reality.
             val item = VocabularyItem(id = 1, word = "test", translation = "тест", isNew = false)
             coEvery { getNextVocabularyItem.invoke() } returns Result.success(item)
             countersFlow.value =

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/settings/SettingsContentTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/settings/SettingsContentTest.kt
@@ -134,8 +134,8 @@ class SettingsContentTest {
     }
 
     @Test
-    fun `add cards for today dialog title shows available new count`() {
-        setContent(availableNewCount = 23)
+    fun `add cards for today dialog title shows how many more can be added today`() {
+        setContent(availableToAddToday = 23)
 
         composeTestRule.onNodeWithText(string(R.string.settings_add_cards_for_today_title)).performClick()
 
@@ -189,6 +189,60 @@ class SettingsContentTest {
     }
 
     @Test
+    fun `add cards for today OK is disabled once entered value exceeds what can still be added`() {
+        // Regression test for the reported bug: entering a number greater than the
+        // available capacity must not be accepted.
+        var addedAmount: Int? = null
+        setContent(availableToAddToday = 5, onAddCardsForToday = { addedAmount = it })
+
+        composeTestRule.onNodeWithText(string(R.string.settings_add_cards_for_today_title)).performClick()
+
+        val field = composeTestRule.onNode(hasSetTextAction())
+        field.performTextClearance()
+        field.performTextInput("222")
+
+        composeTestRule.onNodeWithText(string(R.string.action_ok)).assertIsNotEnabled()
+        composeTestRule.onNodeWithText(string(R.string.action_ok)).performClick()
+
+        assertThat(addedAmount).isNull()
+    }
+
+    @Test
+    fun `add cards for today OK is enabled at exactly the remaining capacity`() {
+        var addedAmount: Int? = null
+        setContent(availableToAddToday = 5, onAddCardsForToday = { addedAmount = it })
+
+        composeTestRule.onNodeWithText(string(R.string.settings_add_cards_for_today_title)).performClick()
+
+        val field = composeTestRule.onNode(hasSetTextAction())
+        field.performTextClearance()
+        field.performTextInput("5")
+
+        composeTestRule.onNodeWithText(string(R.string.action_ok)).assertIsEnabled()
+        composeTestRule.onNodeWithText(string(R.string.action_ok)).performClick()
+
+        assertThat(addedAmount).isEqualTo(5)
+    }
+
+    @Test
+    fun `add cards for today OK stays disabled for any input when nothing can be added`() {
+        // Mirrors the screenshot scenario: "Available New: 0" - typing 222 must not enable OK.
+        var addedAmount: Int? = null
+        setContent(availableToAddToday = 0, onAddCardsForToday = { addedAmount = it })
+
+        composeTestRule.onNodeWithText(string(R.string.settings_add_cards_for_today_title)).performClick()
+
+        val field = composeTestRule.onNode(hasSetTextAction())
+        field.performTextClearance()
+        field.performTextInput("222")
+
+        composeTestRule.onNodeWithText(string(R.string.action_ok)).assertIsNotEnabled()
+        composeTestRule.onNodeWithText(string(R.string.action_ok)).performClick()
+
+        assertThat(addedAmount).isNull()
+    }
+
+    @Test
     fun `overlay permission click delegates to callback`() {
         var overlayClicks = 0
         setContent(onOverlayClick = { overlayClicks++ })
@@ -214,6 +268,7 @@ class SettingsContentTest {
         mixMode: MixMode = MixMode.MIX,
         newPerDay: Int = 10,
         availableNewCount: Int = 0,
+        availableToAddToday: Int = 100,
         reviewPerDay: Int = 50,
         overlayInterval: Int = 5,
         openAiApiKey: String? = null,
@@ -244,6 +299,7 @@ class SettingsContentTest {
                     mixMode = mixMode,
                     newPerDay = newPerDay,
                     availableNewCount = availableNewCount,
+                    availableToAddToday = availableToAddToday,
                     reviewPerDay = reviewPerDay,
                     overlayInterval = overlayInterval,
                     openAiApiKey = openAiApiKey,

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/settings/SettingsContentTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/settings/SettingsContentTest.kt
@@ -190,8 +190,6 @@ class SettingsContentTest {
 
     @Test
     fun `add cards for today OK is disabled once entered value exceeds what can still be added`() {
-        // Regression test for the reported bug: entering a number greater than the
-        // available capacity must not be accepted.
         var addedAmount: Int? = null
         setContent(availableToAddToday = 5, onAddCardsForToday = { addedAmount = it })
 
@@ -226,7 +224,6 @@ class SettingsContentTest {
 
     @Test
     fun `add cards for today OK stays disabled for any input when nothing can be added`() {
-        // Mirrors the screenshot scenario: "Available New: 0" - typing 222 must not enable OK.
         var addedAmount: Int? = null
         setContent(availableToAddToday = 0, onAddCardsForToday = { addedAmount = it })
 

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/settings/components/NumberInputDialogTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/settings/components/NumberInputDialogTest.kt
@@ -211,8 +211,6 @@ class NumberInputDialogTest {
 
     @Test
     fun `OK stays disabled for any input when maximum is zero`() {
-        // Mirrors the "Available New: 0" dialog state from the reported bug: with no
-        // capacity left, no typed value should be accepted.
         setContent(
             title = "No capacity",
             currentValue = 0,

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/settings/components/NumberInputDialogTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/settings/components/NumberInputDialogTest.kt
@@ -170,6 +170,68 @@ class NumberInputDialogTest {
     }
 
     @Test
+    fun `OK is enabled when value equals maximum boundary`() {
+        setContent(
+            title = "Max boundary",
+            currentValue = 0,
+            minValue = 1,
+            maxValue = 10,
+        )
+
+        val field = composeTestRule.onNode(hasSetTextAction())
+        field.performTextClearance()
+        field.performTextInput("10")
+
+        val okButton = composeTestRule.onNodeWithText(string(R.string.action_ok))
+        okButton.assertIsEnabled()
+        okButton.performClick()
+
+        verify(exactly = 1) { onValueConfirm.invoke(10) }
+    }
+
+    @Test
+    fun `confirm ignores values above maximum`() {
+        setContent(
+            title = "Max value",
+            currentValue = 0,
+            minValue = 1,
+            maxValue = 10,
+        )
+
+        val field = composeTestRule.onNode(hasSetTextAction())
+        field.performTextClearance()
+        field.performTextInput("11")
+
+        val okButton = composeTestRule.onNodeWithText(string(R.string.action_ok))
+        okButton.assertIsNotEnabled()
+        okButton.performClick()
+
+        verify(exactly = 0) { onValueConfirm(any()) }
+    }
+
+    @Test
+    fun `OK stays disabled for any input when maximum is zero`() {
+        // Mirrors the "Available New: 0" dialog state from the reported bug: with no
+        // capacity left, no typed value should be accepted.
+        setContent(
+            title = "No capacity",
+            currentValue = 0,
+            minValue = 1,
+            maxValue = 0,
+        )
+
+        val field = composeTestRule.onNode(hasSetTextAction())
+        field.performTextClearance()
+        field.performTextInput("222")
+
+        val okButton = composeTestRule.onNodeWithText(string(R.string.action_ok))
+        okButton.assertIsNotEnabled()
+        okButton.performClick()
+
+        verify(exactly = 0) { onValueConfirm(any()) }
+    }
+
+    @Test
     fun `dismiss button invokes onDismiss`() {
         setContent(
             title = "Dismiss",
@@ -188,6 +250,7 @@ class NumberInputDialogTest {
         title: String,
         currentValue: Int,
         minValue: Int = 1,
+        maxValue: Int = Int.MAX_VALUE,
     ) {
         composeTestRule.setContent {
             MyApplicationTheme {
@@ -197,6 +260,7 @@ class NumberInputDialogTest {
                     onValueConfirm = onValueConfirm,
                     onDismiss = onDismiss,
                     minValue = minValue,
+                    maxValue = maxValue,
                 )
             }
         }


### PR DESCRIPTION
## Summary

- The "Add Cards For Today" dialog let users grant an arbitrarily large boost to today's new-card quota — even with 0 unseen cards available — and that number would be saved and rendered as the day's quota, even though it could never actually be fulfilled.
- Fixed with defense in depth across three layers:
  - **Write-side clamp**: `DayCountersStore.addExtraNewToday` now takes the live unseen count and clamps the boost so `newPerDay + extraNewToday - newShown` can never exceed it (also fixes repeated adds accumulating past capacity).
  - **Display cap**: `DojoViewModel`'s "N new" counter is now capped at the real unseen total via a new reactive `VocabularyDao.observeNewTotalCount()`, so an already-persisted oversized value can't be displayed either.
  - **UI guard**: `NumberInputDialog` gained a `maxValue` bound; the Add Cards For Today dialog now passes the actual remaining capacity, disabling OK entirely when nothing can be added.
- Also covered a related edge case: `New Cards Per Day` itself set higher than the number of unseen cards.

## Test plan

- Added/updated unit tests: `DayCountersStoreTest`, `SettingsViewModelTest`, `DojoViewModelTest`, `AddCardsForTodayIntegrationTest`, `NumberInputDialogTest`, `SettingsContentTest`.
- `./gradlew testDebugUnitTest` — full suite passes.
- `./gradlew ktlintCheck detekt` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_016BEzWAoMWxL3oJN5fAchVu)_