### PR TITLE
Group settings into labeled sections

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
@@ -16,9 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -60,6 +58,7 @@ import com.procrastilearn.app.ui.screens.settings.components.OpenAiPromptSetting
 import com.procrastilearn.app.ui.screens.settings.components.OpenAiReversePromptSettingsItem
 import com.procrastilearn.app.ui.screens.settings.components.OverlayPermissionItem
 import com.procrastilearn.app.ui.screens.settings.components.ReviewPerDaySettingsItem
+import com.procrastilearn.app.ui.screens.settings.components.SettingsSectionHeader
 import com.procrastilearn.app.ui.screens.settings.components.ShowOverlayIntervalSettingsItem
 import com.procrastilearn.app.ui.screens.settings.components.StringInputDialog
 import com.procrastilearn.app.ui.screens.settings.components.openAccessibilitySettings
@@ -240,6 +239,11 @@ internal fun SettingsContent(
                     .padding(vertical = 8.dp)
                     .verticalScroll(rememberScrollState()),
         ) {
+            SettingsSectionHeader(
+                title = stringResource(R.string.settings_section_study_reviews),
+                showDivider = false,
+            )
+
             MixModeSettingsItem(
                 mixMode = mixMode,
                 onClick = { dialogState = DialogState.MixMode },
@@ -275,7 +279,7 @@ internal fun SettingsContent(
                 onClick = { dialogState = DialogState.OverlayInterval },
             )
 
-            Spacer(Modifier.height(4.dp))
+            SettingsSectionHeader(title = stringResource(R.string.settings_section_ai_features))
 
             OpenAiApiKeySettingsItem(
                 apiKey = openAiApiKey,
@@ -289,12 +293,9 @@ internal fun SettingsContent(
                 prompt = openAiReversePrompt,
                 onClick = { dialogState = DialogState.OpenAiReversePrompt },
             )
-            Divider(
-                modifier = Modifier.padding(vertical = 8.dp),
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
-            )
 
-            // Permission settings
+            SettingsSectionHeader(title = stringResource(R.string.settings_section_permissions))
+
             OverlayPermissionItem(
                 isGranted = overlayGranted,
                 onClick = onOverlayClick,
@@ -307,13 +308,7 @@ internal fun SettingsContent(
                 onClick = onA11yClick,
             )
 
-            Spacer(Modifier.height(4.dp))
-
-            AboutUsSettingsItem(
-                onClick = { dialogState = DialogState.AboutUs },
-            )
-
-            Spacer(Modifier.height(4.dp))
+            SettingsSectionHeader(title = stringResource(R.string.settings_section_data_about))
 
             if (importOptions.isNotEmpty()) {
                 ImportSettingsItem(
@@ -325,6 +320,12 @@ internal fun SettingsContent(
             }
 
             ExportSettingsItem(onClick = onExportClick)
+
+            Spacer(Modifier.height(4.dp))
+
+            AboutUsSettingsItem(
+                onClick = { dialogState = DialogState.AboutUs },
+            )
         }
     }
 

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/SettingsSectionHeader.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/SettingsSectionHeader.kt
@@ -1,0 +1,38 @@
+package com.procrastilearn.app.ui.screens.settings.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsSectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (showDivider) {
+            Divider(
+                modifier = Modifier.padding(top = 8.dp),
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+            )
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 4.dp),
+        )
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -121,6 +121,12 @@
         <!-- ─── Settings ────────────────────────────────────────────────────────── -->
         <string name="settings_title">Настройки</string>
 
+        <!-- Section headers -->
+        <string name="settings_section_study_reviews">Обучение и повторы</string>
+        <string name="settings_section_ai_features">ИИ-функции (нужен API-ключ)</string>
+        <string name="settings_section_permissions">Разрешения</string>
+        <string name="settings_section_data_about">Данные и о приложении</string>
+
         <!-- Study mode -->
         <string name="settings_study_mode_title">Режим обучения</string>
         <string name="settings_study_mode_mixed">Смешанный</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,12 @@
     <!-- ─── Settings ────────────────────────────────────────────────────────── -->
     <string name="settings_title">Settings</string>
 
+    <!-- Section headers -->
+    <string name="settings_section_study_reviews">Study &amp; Reviews</string>
+    <string name="settings_section_ai_features">AI Features (API key required)</string>
+    <string name="settings_section_permissions">Permissions</string>
+    <string name="settings_section_data_about">Data &amp; About</string>
+
     <!-- Study mode -->
     <string name="settings_study_mode_title">Study Mode</string>
     <string name="settings_study_mode_mixed">Mixed</string>


### PR DESCRIPTION
## Summary
- Add labeled section subtitles to the Settings screen: **Study & Reviews**, **AI Features (API key required)**, **Permissions**, **Data & About**
- Reuse the existing horizontal dividers as section separators, with the subtitle rendered right below each divider
- Reorder the Data & About group so **About us** comes last, after Import and Export
- No other settings were renamed or reordered

## Test plan
- [x] `./gradlew ktlintCheck detekt` — passed
- [x] `./gradlew assembleDebug` — passed
- [ ] Manual verification on-device/emulator (section headers display, spacing looks good)