### PR TITLE
ci: publish JaCoCo coverage via GitHub code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  code-quality: write
 
 jobs:
   verify:
@@ -33,6 +34,25 @@ jobs:
 
       - name: Unit tests
         run: ./gradlew testDebugUnitTest --no-daemon
+
+      - name: Generate JaCoCo coverage report
+        run: ./gradlew jacocoTestReport --no-daemon
+
+      - name: Convert coverage report to Cobertura format
+        run: |
+          curl -sSL -o cover2cover.py \
+            https://raw.githubusercontent.com/rix0rrr/cover2cover/3f78052d0e7c1aab2874fc000c2f1eada088fe85/cover2cover.py
+          python3 cover2cover.py \
+            app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml \
+            app/src/main/java > app/build/reports/jacoco/jacocoTestReport/cobertura.xml
+
+      - name: Upload coverage report
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: app/build/reports/jacoco/jacocoTestReport/cobertura.xml
+          language: Java
+          label: code-coverage/jacoco
 
       - name: Upload test reports
         if: failure()


### PR DESCRIPTION
## Summary

Wires the CI workflow into GitHub's built-in [code coverage](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage) reporting, so coverage from the existing JaCoCo setup (added in #13) is published on pull requests instead of only sitting in local build output.

- Generate the JaCoCo XML report for debug unit tests (`jacocoTestReport`) after the existing unit test step.
- Convert the JaCoCo XML to Cobertura XML with `cover2cover.py` (pinned to a specific upstream commit SHA for reproducibility), since GitHub's coverage upload action currently consumes Cobertura-format reports.
- Upload the Cobertura report with `actions/upload-code-coverage@v1`, skipping the upload for pull requests from forks (no write access to secrets/permissions in that context).
- Add the `code-quality: write` permission the upload action requires.

## Requirements to actually see results

- The "Code Quality" feature must be enabled for this repository (Settings → Code security).
- Once enabled, the `github-code-quality[bot]` will comment on PRs with aggregate + per-file coverage compared against `master`.

## Test plan

- [ ] Confirm the `CI` workflow run on this PR completes and the coverage steps succeed
- [ ] Enable Code Quality in repository settings (one-time, manual)
- [ ] Verify `github-code-quality[bot]` posts a coverage comparison comment on a subsequent PR


---
_Generated by [Claude Code](https://claude.ai/code/session_014bbZeWBc1NBD9CMERhjZu6)_