### PR TITLE
fix: declare missing locales in localeConfig resource

### DIFF
--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
     <locale android:name="en"/>
+    <locale android:name="es"/>
+    <locale android:name="fr"/>
+    <locale android:name="it"/>
     <locale android:name="ru"/>
+    <locale android:name="uk"/>
+    <locale android:name="zh"/>
 </locale-config>


### PR DESCRIPTION
## Summary
- Lint's `UnusedTranslation` check flagged 5 languages (es, fr, it, uk, zh) that have translated `strings.xml` resources under `values-*/` but were missing from `app/src/main/res/xml/locales_config.xml`, the resource referenced by `android:localeConfig` in `AndroidManifest.xml`.
- Added `<locale android:name="..."/>` entries for `es`, `fr`, `it`, `uk`, and `zh`, matching the existing format used for `en`/`ru`, so every translated locale in the project is now declared.

## Test plan
- [x] Confirmed every `app/src/main/res/values-*` directory with a `strings.xml` (es, fr, it, ru, uk, zh) now has a matching `<locale>` entry in `locales_config.xml`.
- [ ] Full `./gradlew lintDebug` not run locally (long-running); change is a minimal, verified resource addition.

Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEDCQtEgRrRmoJvNpa5php)_