### PR TITLE
fix: remove untranslatable string overrides from locale files

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,7 +5,6 @@
     <string name="app_function_description">Añade palabras de vocabulario con traducciones generadas por IA para el aprendizaje con repetición espaciada</string>
 
     <!-- ─── App / Brand ─────────────────────────────────────────────────────── -->
-    <string name="app_name" translatable="false">ProcrastiLearn</string>
 
     <!-- ─── Common actions (reuse everywhere) ───────────────────────────────── -->
     <string name="action_open_settings">Abrir ajustes</string>
@@ -100,7 +99,6 @@
     <string name="edit_word_title">Editar palabra</string>
 
     <!-- Prefer using a proper icon. Keep these for compatibility. -->
-    <string name="add_word_success_icon" translatable="false">✓</string>
     <string name="add_word_success_default">¡Listo!</string>
 
     <!-- Helpful validation/toast messages -->
@@ -216,7 +214,6 @@
     <string name="settings_about_us_contact_title">Contacto</string>
     <string name="settings_about_us_contact_body">Si tienes preguntas o comentarios, escríbenos a: Apocalypse_232@proton.me</string>
     <string name="settings_about_us_privacy">Política de privacidad</string>
-    <string name="settings_privacy_policy_url" translatable="false">https://gist.github.com/Vladyslav-Soldatenko/adb5953ce000b9e8515d3dcd87773aef</string>
 
     <!-- Import -->
     <string name="settings_import_row">Importar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -5,7 +5,6 @@
     <string name="app_function_description">Ajoutez des mots de vocabulaire avec des traductions générées par IA pour un apprentissage par répétition espacée</string>
 
     <!-- ─── App / Brand ─────────────────────────────────────────────────────── -->
-    <string name="app_name" translatable="false">ProcrastiLearn</string>
 
     <!-- ─── Common actions (reuse everywhere) ───────────────────────────────── -->
     <string name="action_open_settings">Ouvrir les paramètres</string>
@@ -100,7 +99,6 @@
     <string name="edit_word_title">Modifier le mot</string>
 
     <!-- Prefer using a proper icon. Keep these for compatibility. -->
-    <string name="add_word_success_icon" translatable="false">✓</string>
     <string name="add_word_success_default">Succès !</string>
 
     <!-- Helpful validation/toast messages -->
@@ -216,7 +214,6 @@
     <string name="settings_about_us_contact_title">Contact</string>
     <string name="settings_about_us_contact_body">Pour toute question ou suggestion, contactez-nous à : Apocalypse_232@proton.me</string>
     <string name="settings_about_us_privacy">Politique de confidentialité</string>
-    <string name="settings_privacy_policy_url" translatable="false">https://gist.github.com/Vladyslav-Soldatenko/adb5953ce000b9e8515d3dcd87773aef</string>
 
     <!-- Import -->
     <string name="settings_import_row">Importer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,7 +5,6 @@
     <string name="app_function_description">Aggiungi parole di vocabolario con traduzioni generate dall\'IA per l\'apprendimento con ripetizione dilazionata</string>
 
     <!-- ─── App / Brand ─────────────────────────────────────────────────────── -->
-    <string name="app_name" translatable="false">ProcrastiLearn</string>
 
     <!-- ─── Common actions (reuse everywhere) ───────────────────────────────── -->
     <string name="action_open_settings">Apri impostazioni</string>
@@ -100,7 +99,6 @@
     <string name="edit_word_title">Modifica parola</string>
 
     <!-- Prefer using a proper icon. Keep these for compatibility. -->
-    <string name="add_word_success_icon" translatable="false">✓</string>
     <string name="add_word_success_default">Fatto!</string>
 
     <!-- Helpful validation/toast messages -->
@@ -216,7 +214,6 @@
     <string name="settings_about_us_contact_title">Contatti</string>
     <string name="settings_about_us_contact_body">Per domande o suggerimenti, scrivici a: Apocalypse_232@proton.me</string>
     <string name="settings_about_us_privacy">Informativa sulla privacy</string>
-    <string name="settings_privacy_policy_url" translatable="false">https://gist.github.com/Vladyslav-Soldatenko/adb5953ce000b9e8515d3dcd87773aef</string>
 
     <!-- Import -->
     <string name="settings_import_row">Importa</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2,7 +2,6 @@
 
 <string name="app_function_description">Добавляйте слова с переводами, сгенерированными ИИ, для обучения с интервальным повторением</string>
 
-<string name="app_name" translatable="false">ProcrastiLearn</string>
 
         <!-- ─── Common actions (reuse everywhere) ───────────────────────────────── -->
         <string name="action_open_settings">Открыть настройки</string>
@@ -97,7 +96,6 @@
          <string name="edit_word_title">Редактировать слово</string>
 
         <!-- Prefer using a proper icon. Keep these for compatibility. -->
-        <string name="add_word_success_icon" translatable="false">✓</string>
         <string name="add_word_success_default">Готово!</string>
 
         <!-- Helpful validation/toast messages -->
@@ -220,7 +218,6 @@
         <string name="settings_about_us_contact_title">Контакты</string>
         <string name="settings_about_us_contact_body">Если у вас есть вопросы или обратная связь, пишите на: Apocalypse_232@proton.me</string>
         <string name="settings_about_us_privacy">Политика конфиденциальности</string>
-        <string name="settings_privacy_policy_url" translatable="false">https://gist.github.com/Vladyslav-Soldatenko/adb5953ce000b9e8515d3dcd87773aef</string>
 
         <!-- Import -->
         <string name="settings_import_row">Импорт</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -5,7 +5,6 @@
     <string name="app_function_description">Додавайте слова з перекладами, згенерованими ШІ, для навчання за методом інтервального повторення</string>
 
     <!-- ─── App / Brand ─────────────────────────────────────────────────────── -->
-    <string name="app_name" translatable="false">ProcrastiLearn</string>
 
     <!-- ─── Common actions (reuse everywhere) ───────────────────────────────── -->
     <string name="action_open_settings">Відкрити налаштування</string>
@@ -100,7 +99,6 @@
     <string name="edit_word_title">Редагувати слово</string>
 
     <!-- Prefer using a proper icon. Keep these for compatibility. -->
-    <string name="add_word_success_icon" translatable="false">✓</string>
     <string name="add_word_success_default">Готово!</string>
 
     <!-- Helpful validation/toast messages -->
@@ -216,7 +214,6 @@
     <string name="settings_about_us_contact_title">Контакти</string>
     <string name="settings_about_us_contact_body">Якщо у вас є запитання чи відгуки, звертайтеся: Apocalypse_232@proton.me</string>
     <string name="settings_about_us_privacy">Політика конфіденційності</string>
-    <string name="settings_privacy_policy_url" translatable="false">https://gist.github.com/Vladyslav-Soldatenko/adb5953ce000b9e8515d3dcd87773aef</string>
 
     <!-- Import -->
     <string name="settings_import_row">Імпорт</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -5,7 +5,6 @@
     <string name="app_function_description">添加生词，通过 AI 生成翻译，用于间隔重复学习</string>
 
     <!-- ─── App / Brand ─────────────────────────────────────────────────────── -->
-    <string name="app_name" translatable="false">ProcrastiLearn</string>
 
     <!-- ─── Common actions (reuse everywhere) ───────────────────────────────── -->
     <string name="action_open_settings">打开设置</string>
@@ -85,7 +84,6 @@
     <string name="edit_word_title">编辑单词</string>
 
     <!-- Prefer using a proper icon. Keep these for compatibility. -->
-    <string name="add_word_success_icon" translatable="false">✓</string>
     <string name="add_word_success_default">成功！</string>
 
     <!-- Helpful validation/toast messages -->
@@ -191,7 +189,6 @@
     <string name="settings_about_us_contact_title">联系我们</string>
     <string name="settings_about_us_contact_body">如有问题或反馈，请联系：Apocalypse_232@proton.me</string>
     <string name="settings_about_us_privacy">隐私政策</string>
-    <string name="settings_privacy_policy_url" translatable="false">https://gist.github.com/Vladyslav-Soldatenko/adb5953ce000b9e8515d3dcd87773aef</string>
 
     <!-- Import -->
     <string name="settings_import_row">导入</string>


### PR DESCRIPTION
## Summary
- Removes redundant `app_name`, `add_word_success_icon`, and `settings_privacy_policy_url` entries from `values-ru`, `values-es`, `values-fr`, `values-it`, `values-uk`, and `values-zh` `strings.xml` files.
- These three strings are marked `translatable="false"` in the base `values/strings.xml`, so locale-specific copies are redundant and were flagged by lint's Untranslatable check (18 instances).
- Android resource resolution automatically falls back to the base (non-translatable) value once the locale overrides are removed, so no behavior changes.

## Test plan
- [x] Verified all edited `strings.xml` files remain well-formed XML
- [x] Grepped all `values-*/strings.xml` files to confirm zero remaining matches for `app_name`, `add_word_success_icon`, `settings_privacy_policy_url`
- [x] Confirmed diff only removes the exact flagged lines, no unrelated changes

Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEDCQtEgRrRmoJvNpa5php)_