### PR TITLE
style: fix typographic apostrophes flagged by lint

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,7 +49,7 @@
     <string name="dojo_empty_title">¡Todo listo por hoy!</string>
     <string name="dojo_empty_message">Has completado todas las palabras disponibles por hoy. Vuelve más tarde o ajusta tus límites diarios en Ajustes.</string>
     <string name="dojo_undo_content_description">Deshacer última calificación</string>
-    <string name="dojo_undo_confirmation">Se deshizo %1$s para \"%2$s\"</string>
+    <string name="dojo_undo_confirmation">Se deshizo %1$s para “%2$s”</string>
 
     <!-- ─── Overlay permission ──────────────────────────────────────────────── -->
     <string name="overlay_permission_title">Permitir superposición</string>
@@ -172,7 +172,7 @@
     <string name="settings_review_direction_bidirectional">Bidireccional</string>
     <string name="settings_review_direction_forward_desc">Muestra la palabra y pide la traducción</string>
     <string name="settings_review_direction_backward_desc">Muestra la traducción y pide la palabra</string>
-    <string name="settings_review_direction_bidirectional_desc">Combina ambas direcciones para las tarjetas marcadas como \"Practicar en ambos sentidos\"</string>
+    <string name="settings_review_direction_bidirectional_desc">Combina ambas direcciones para las tarjetas marcadas como “Practicar en ambos sentidos”</string>
 
     <!-- Daily limits -->
     <string name="settings_add_cards_for_today_title">Añadir tarjetas para hoy</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -46,29 +46,29 @@
     <string name="dojo_stats_new_remaining">nouveaux</string>
     <string name="dojo_stats_reviews_due">à réviser</string>
     <string name="dojo_stats_skipped">ignorés</string>
-    <string name="dojo_empty_title">Tout est fait pour l\'instant !</string>
-    <string name="dojo_empty_message">Vous avez terminé tous les mots disponibles pour aujourd\'hui. Revenez plus tard ou ajustez vos limites quotidiennes dans les paramètres.</string>
+    <string name="dojo_empty_title">Tout est fait pour l’instant !</string>
+    <string name="dojo_empty_message">Vous avez terminé tous les mots disponibles pour aujourd’hui. Revenez plus tard ou ajustez vos limites quotidiennes dans les paramètres.</string>
     <string name="dojo_undo_content_description">Annuler la dernière évaluation</string>
     <string name="dojo_undo_confirmation">Évaluation « %1$s » annulée pour « %2$s »</string>
 
     <!-- ─── Overlay permission ──────────────────────────────────────────────── -->
-    <string name="overlay_permission_title">Autoriser l\'affichage en superposition</string>
+    <string name="overlay_permission_title">Autoriser l’affichage en superposition</string>
     <string name="overlay_permission_message">
-        Cette application a besoin de l\'autorisation d\'afficher une superposition par-dessus les autres applications.
+        Cette application a besoin de l’autorisation d’afficher une superposition par-dessus les autres applications.
     </string>
 
     <!-- ─── Accessibility disclosure (A11y) ─────────────────────────────────── -->
-    <string name="a11y_disclosure_title">Pourquoi nous avons besoin de l\'accessibilité</string>
+    <string name="a11y_disclosure_title">Pourquoi nous avons besoin de l’accessibilité</string>
     <string name="a11y_disclosure_description">
-        Cette application utilise l\'autorisation du service d\'accessibilité Android pour détecter quand vous ouvrez les applications sélectionnées
-        (par exemple TikTok, Reddit ou toute autre application de votre choix) afin d\'afficher un court exercice d\'apprentissage avant de continuer.
+        Cette application utilise l’autorisation du service d’accessibilité Android pour détecter quand vous ouvrez les applications sélectionnées
+        (par exemple TikTok, Reddit ou toute autre application de votre choix) afin d’afficher un court exercice d’apprentissage avant de continuer.
     </string>
 
     <string name="a11y_disclosure_section_access">Ce à quoi nous accédons</string>
 
     <string name="a11y_disclosure_access_details">
-        • Quelle application est actuellement à l\'écran.\n
-        • Nous ne lisons PAS vos mots de passe, messages ou texte affiché à l\'écran.\n
+        • Quelle application est actuellement à l’écran.\n
+        • Nous ne lisons PAS vos mots de passe, messages ou texte affiché à l’écran.\n
         • Vos données ne quittent jamais votre appareil et ne sont ni vendues ni partagées.
     </string>
 
@@ -76,13 +76,13 @@
 
     <!-- Original paragraph -->
     <string name="a11y_disclosure_usage_details">
-        Uniquement pour déclencher la superposition d\'apprentissage pour les applications que vous avez sélectionnées.
+        Uniquement pour déclencher la superposition d’apprentissage pour les applications que vous avez sélectionnées.
         Vous pouvez désactiver cette fonction à tout moment dans les paramètres. Nous ne vendons ni ne partageons ces données,
         elles ne quittent jamais votre appareil.
     </string>
 
     <string name="a11y_disclosure_checkbox">
-        Je comprends et j\'accepte que cette application utilise l\'autorisation du service d\'accessibilité à cette fin.
+        Je comprends et j’accepte que cette application utilise l’autorisation du service d’accessibilité à cette fin.
     </string>
     <string name="a11y_disclosure_accept">Accepter &amp; continuer</string>
     <string name="a11y_disclosure_decline">@string/action_not_now</string>
@@ -112,10 +112,10 @@
     <string name="add_word_success_added">Mot ajouté avec succès !</string>
     <string name="add_word_success_updated">Mot mis à jour et progression réinitialisée !</string>
     <string name="add_word_success_pending">Enregistré. La traduction sera générée dès que vous serez de nouveau en ligne.</string>
-    <string name="add_word_error_preview_failed">Échec de la génération de l\'aperçu</string>
+    <string name="add_word_error_preview_failed">Échec de la génération de l’aperçu</string>
     <string name="add_word_error_translation_failed">Échec de la génération de la traduction</string>
     <string name="add_word_error_update_failed">Échec de la mise à jour du mot</string>
-    <string name="add_word_error_add_failed">Échec de l\'ajout du mot</string>
+    <string name="add_word_error_add_failed">Échec de l’ajout du mot</string>
     <string name="add_word_error_lookup_failed">Échec de la vérification des mots existants</string>
 
     <!-- Bidirectional review -->
@@ -157,10 +157,10 @@
     <string name="settings_language_pair_desc">%1$s → %2$s</string>
 
     <!-- Study mode -->
-    <string name="settings_study_mode_title">Mode d\'étude</string>
+    <string name="settings_study_mode_title">Mode d’étude</string>
     <string name="settings_study_mode_mixed">Mixte</string>
-    <string name="settings_study_mode_reviews_first">Révisions d\'abord</string>
-    <string name="settings_study_mode_new_first">Nouveaux d\'abord</string>
+    <string name="settings_study_mode_reviews_first">Révisions d’abord</string>
+    <string name="settings_study_mode_new_first">Nouveaux d’abord</string>
     <string name="settings_study_mode_mixed_desc">Mélanger nouvelles cartes et révisions</string>
     <string name="settings_study_mode_reviews_first_desc">Afficher toutes les révisions avant les nouvelles cartes</string>
     <string name="settings_study_mode_new_first_desc">Afficher les nouvelles cartes avant les révisions</string>
@@ -175,40 +175,40 @@
     <string name="settings_review_direction_bidirectional_desc">Mélanger les deux sens pour les cartes marquées « Tester dans les deux sens »</string>
 
     <!-- Daily limits -->
-    <string name="settings_add_cards_for_today_title">Ajouter des cartes pour aujourd\'hui</string>
-    <string name="settings_add_cards_for_today_dialog_title">Ajouter des cartes pour aujourd\'hui (nouvelles disponibles : %1$d)</string>
+    <string name="settings_add_cards_for_today_title">Ajouter des cartes pour aujourd’hui</string>
+    <string name="settings_add_cards_for_today_dialog_title">Ajouter des cartes pour aujourd’hui (nouvelles disponibles : %1$d)</string>
     <string name="settings_new_cards_per_day_title">Nouvelles cartes par jour</string>
     <string name="settings_new_cards_per_day_dialog_title">Nouvelles cartes par jour (nouvelles disponibles : %1$d)</string>
     <string name="settings_reviews_per_day_title">Révisions par jour</string>
 
     <!-- Overlay interval -->
     <string name="settings_overlay_interval_title">Afficher la superposition toutes les X minutes</string>
-    <string name="settings_overlay_interval_headline">Afficher la superposition toutes les X minutes tant que l\'application bloquée est ouverte</string>
+    <string name="settings_overlay_interval_headline">Afficher la superposition toutes les X minutes tant que l’application bloquée est ouverte</string>
 
     <string name="settings_overlay_headline">Autorisation de superposition</string>
     <string name="settings_overlay_support">
-        Nécessaire pour afficher la carte d\'apprentissage par-dessus les applications sélectionnées.
+        Nécessaire pour afficher la carte d’apprentissage par-dessus les applications sélectionnées.
     </string>
 
-    <string name="settings_a11y_headline">Verrou d\'apprentissage (Accessibilité)</string>
+    <string name="settings_a11y_headline">Verrou d’apprentissage (Accessibilité)</string>
     <string name="settings_a11y_support">
-        Détecte les applications sélectionnées au premier plan pour déclencher la carte d\'apprentissage.
+        Détecte les applications sélectionnées au premier plan pour déclencher la carte d’apprentissage.
     </string>
 
     <!-- About Us -->
     <string name="settings_about_us_row">À propos de nous</string>
-    <string name="settings_about_us_row_desc">En savoir plus sur l\'application</string>
+    <string name="settings_about_us_row_desc">En savoir plus sur l’application</string>
     <string name="settings_about_us_title">@string/settings_about_us_row</string>
     <string name="settings_about_us_intro">
-        ProcrastiLearn transforme vos moments de distraction en occasions d\'apprendre. Lorsque vous essayez d\'ouvrir une application sélectionnée, nous vous proposons d\'abord un petit défi de vocabulaire. Ainsi, vous enrichissez vos connaissances tout en gardant vos distractions sous contrôle.
+        ProcrastiLearn transforme vos moments de distraction en occasions d’apprendre. Lorsque vous essayez d’ouvrir une application sélectionnée, nous vous proposons d’abord un petit défi de vocabulaire. Ainsi, vous enrichissez vos connaissances tout en gardant vos distractions sous contrôle.
     </string>
     <string name="settings_about_us_mission_title">Notre mission</string>
     <string name="settings_about_us_mission_body">
-        Nous voulons aider chacun à reprendre le contrôle de son temps et de son attention en transformant les habitudes quotidiennes en occasions d\'apprendre quelque chose de nouveau.
+        Nous voulons aider chacun à reprendre le contrôle de son temps et de son attention en transformant les habitudes quotidiennes en occasions d’apprendre quelque chose de nouveau.
     </string>
     <string name="settings_about_us_who_title">Qui sommes-nous</string>
     <string name="settings_about_us_who_body">
-        ProcrastiLearn est conçu et maintenu par un développeur indépendant passionné de productivité et d\'apprentissage des langues.
+        ProcrastiLearn est conçu et maintenu par un développeur indépendant passionné de productivité et d’apprentissage des langues.
     </string>
     <string name="settings_about_us_values_title">Nos valeurs</string>
     <string name="settings_about_us_values_simplicity">Simplicité : un design épuré, sans distraction.</string>
@@ -226,15 +226,15 @@
     <string name="settings_import_option_json">Export JSON (.json)</string>
     <string name="settings_import_option_json_desc">Importer un export complet de ProcrastiLearn</string>
     <string name="settings_import_success">%1$d cartes importées</string>
-    <string name="settings_import_failure_generic">Échec de l\'importation</string>
-    <string name="settings_import_failure_format">Ce format n\'est pas encore pris en charge</string>
-    <string name="settings_import_failure_schema_version">Ce fichier a été créé par une version plus récente de ProcrastiLearn. Veuillez mettre à jour l\'application.</string>
+    <string name="settings_import_failure_generic">Échec de l’importation</string>
+    <string name="settings_import_failure_format">Ce format n’est pas encore pris en charge</string>
+    <string name="settings_import_failure_schema_version">Ce fichier a été créé par une version plus récente de ProcrastiLearn. Veuillez mettre à jour l’application.</string>
 
     <!-- Export -->
     <string name="settings_export_row">Exporter</string>
     <string name="settings_export_row_desc">Exporter tout le vocabulaire dans un fichier JSON</string>
     <string name="settings_export_success">Exportation terminée</string>
-    <string name="settings_export_failure">Échec de l\'exportation</string>
+    <string name="settings_export_failure">Échec de l’exportation</string>
 
     <!-- OpenAI API Key -->
     <string name="settings_openai_api_key_title">Clé API OpenAI</string>
@@ -249,10 +249,10 @@
     <string name="settings_openai_reverse_prompt_dialog_title">@string/settings_openai_prompt_dialog_title</string>
     <string name="settings_openai_reverse_prompt_default">@string/settings_openai_prompt_default</string>
     <string name="settings_openai_reverse_prompt_custom">@string/settings_openai_prompt_custom</string>
-    <string name="settings_openai_prompt_placeholder_hint">Utilisez {{NATIVE_LANGUAGE}} et {{TARGET_LANGUAGE}} comme espaces réservés — ils sont automatiquement remplacés par les langues que vous avez sélectionnées lors de la génération d\'une traduction.</string>
+    <string name="settings_openai_prompt_placeholder_hint">Utilisez {{NATIVE_LANGUAGE}} et {{TARGET_LANGUAGE}} comme espaces réservés — ils sont automatiquement remplacés par les langues que vous avez sélectionnées lors de la génération d’une traduction.</string>
 
     <!-- Add Word: AI translation toggle -->
-    <string name="add_word_use_ai_toggle">utiliser l\'IA pour générer la traduction</string>
+    <string name="add_word_use_ai_toggle">utiliser l’IA pour générer la traduction</string>
     <string name="add_word_toggle_direction">Inverser le sens de traduction</string>
     <string name="add_word_button_preview">Aperçu</string>
     <string name="add_word_preview_title">Aperçu IA</string>
@@ -274,7 +274,7 @@
 
     <!-- ─── Vocabulary list ─────────────────────────────────────────────────── -->
     <string name="word_list_title">Mon vocabulaire</string>
-    <string name="word_list_navigate_back">Retour à l\'ajout de mot</string>
+    <string name="word_list_navigate_back">Retour à l’ajout de mot</string>
     <string name="word_list_empty">Aucun mot ajouté pour le moment</string>
     <string name="word_list_delete_confirm_title">Supprimer le mot</string>
     <string name="word_list_delete_confirm_message">
@@ -283,9 +283,9 @@
     <string name="word_list_reset">@string/word_list_reset_confirm_title</string>
     <string name="word_list_reset_confirm_title">Réinitialiser la progression</string>
     <string name="word_list_reset_confirm_message">
-        Réinitialiser la progression d\'apprentissage de <xliff:g id="word_name">%1$s</xliff:g> ?
+        Réinitialiser la progression d’apprentissage de <xliff:g id="word_name">%1$s</xliff:g> ?
     </string>
-    <string name="word_list_more_actions">Plus d\'actions</string>
+    <string name="word_list_more_actions">Plus d’actions</string>
     <string name="word_list_search_label">Rechercher</string>
     <string name="word_list_search_placeholder">Rechercher des mots</string>
     <string name="word_list_search_no_results">Aucun résultat trouvé</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2,7 +2,7 @@
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <!-- ─── AppFunctions ────────────────────────────────────────────────────── -->
-    <string name="app_function_description">Aggiungi parole di vocabolario con traduzioni generate dall\'IA per l\'apprendimento con ripetizione dilazionata</string>
+    <string name="app_function_description">Aggiungi parole di vocabolario con traduzioni generate dall’IA per l’apprendimento con ripetizione dilazionata</string>
 
     <!-- ─── App / Brand ─────────────────────────────────────────────────────── -->
     <string name="app_name" translatable="false">ProcrastiLearn</string>
@@ -48,8 +48,8 @@
     <string name="dojo_stats_skipped">saltate</string>
     <string name="dojo_empty_title">Tutto fatto per ora!</string>
     <string name="dojo_empty_message">Hai completato tutte le parole disponibili per oggi. Torna più tardi oppure modifica i tuoi limiti giornalieri nelle Impostazioni.</string>
-    <string name="dojo_undo_content_description">Annulla l\'ultima valutazione</string>
-    <string name="dojo_undo_confirmation">Annullato \"%1$s\" per \"%2$s\"</string>
+    <string name="dojo_undo_content_description">Annulla l’ultima valutazione</string>
+    <string name="dojo_undo_confirmation">Annullato “%1$s” per “%2$s”</string>
 
     <!-- ─── Overlay permission ──────────────────────────────────────────────── -->
     <string name="overlay_permission_title">Consenti la visualizzazione in overlay</string>
@@ -58,7 +58,7 @@
     </string>
 
     <!-- ─── Accessibility disclosure (A11y) ─────────────────────────────────── -->
-    <string name="a11y_disclosure_title">Perché ci serve l\'Accessibilità</string>
+    <string name="a11y_disclosure_title">Perché ci serve l’Accessibilità</string>
     <string name="a11y_disclosure_description">
         Questa app utilizza il permesso del Servizio di Accessibilità di Android per rilevare quando apri le app selezionate
         (ad es. TikTok, Reddit o qualsiasi altra app tu scelga), così da mostrarti un breve messaggio di apprendimento prima di continuare.
@@ -76,7 +76,7 @@
 
     <!-- Original paragraph -->
     <string name="a11y_disclosure_usage_details">
-        Solo per attivare l\'overlay di apprendimento per le app che hai selezionato.
+        Solo per attivare l’overlay di apprendimento per le app che hai selezionato.
         Puoi disattivarlo in qualsiasi momento dalle Impostazioni. Non vendiamo né condividiamo questi dati,
         che non lasciano mai il dispositivo.
     </string>
@@ -112,7 +112,7 @@
     <string name="add_word_success_added">Parola aggiunta con successo!</string>
     <string name="add_word_success_updated">Parola aggiornata e progressi reimpostati!</string>
     <string name="add_word_success_pending">Salvato. La traduzione verrà generata non appena tornerai online.</string>
-    <string name="add_word_error_preview_failed">Impossibile generare l\'anteprima</string>
+    <string name="add_word_error_preview_failed">Impossibile generare l’anteprima</string>
     <string name="add_word_error_translation_failed">Impossibile generare la traduzione</string>
     <string name="add_word_error_update_failed">Impossibile aggiornare la parola</string>
     <string name="add_word_error_add_failed">Impossibile aggiungere la parola</string>
@@ -172,7 +172,7 @@
     <string name="settings_review_direction_bidirectional">Bidirezionale</string>
     <string name="settings_review_direction_forward_desc">Mostra la parola, chiede la traduzione</string>
     <string name="settings_review_direction_backward_desc">Mostra la traduzione, chiede la parola</string>
-    <string name="settings_review_direction_bidirectional_desc">Alterna entrambe le direzioni per le carte contrassegnate come \"Verifica in entrambe le direzioni\"</string>
+    <string name="settings_review_direction_bidirectional_desc">Alterna entrambe le direzioni per le carte contrassegnate come “Verifica in entrambe le direzioni”</string>
 
     <!-- Daily limits -->
     <string name="settings_add_cards_for_today_title">Aggiungi carte per oggi</string>
@@ -182,8 +182,8 @@
     <string name="settings_reviews_per_day_title">Ripassi al giorno</string>
 
     <!-- Overlay interval -->
-    <string name="settings_overlay_interval_title">Mostra l\'overlay ogni X minuti</string>
-    <string name="settings_overlay_interval_headline">Mostra l\'overlay ogni X minuti mentre l\'app bloccata è aperta</string>
+    <string name="settings_overlay_interval_title">Mostra l’overlay ogni X minuti</string>
+    <string name="settings_overlay_interval_headline">Mostra l’overlay ogni X minuti mentre l’app bloccata è aperta</string>
 
     <string name="settings_overlay_headline">Permesso overlay</string>
     <string name="settings_overlay_support">
@@ -197,16 +197,16 @@
 
     <!-- About Us -->
     <string name="settings_about_us_row">Chi siamo</string>
-    <string name="settings_about_us_row_desc">Scopri di più sull\'app</string>
+    <string name="settings_about_us_row_desc">Scopri di più sull’app</string>
     <string name="settings_about_us_title">@string/settings_about_us_row</string>
     <string name="settings_about_us_intro">
-        ProcrastiLearn trasforma i momenti di distrazione in occasioni per imparare. Quando provi ad aprire un\'app selezionata, ti mostriamo prima una rapida sfida di vocabolario. Così impari qualcosa di nuovo tenendo a bada le distrazioni.
+        ProcrastiLearn trasforma i momenti di distrazione in occasioni per imparare. Quando provi ad aprire un’app selezionata, ti mostriamo prima una rapida sfida di vocabolario. Così impari qualcosa di nuovo tenendo a bada le distrazioni.
     </string>
     <string name="settings_about_us_mission_title">La nostra missione</string>
     <string name="settings_about_us_mission_body">
         Vogliamo aiutare le persone a riprendersi il proprio tempo e la propria attenzione, trasformando le abitudini quotidiane in occasioni per imparare qualcosa di nuovo.
     </string>
-    <string name="settings_about_us_who_title">Il team dietro l\'app</string>
+    <string name="settings_about_us_who_title">Il team dietro l’app</string>
     <string name="settings_about_us_who_body">
         ProcrastiLearn è sviluppata e mantenuta da uno sviluppatore indipendente appassionato di produttività e apprendimento delle lingue.
     </string>
@@ -220,15 +220,15 @@
 
     <!-- Import -->
     <string name="settings_import_row">Importa</string>
-    <string name="settings_import_row_desc">Aggiungi vocabolario da un\'altra app</string>
+    <string name="settings_import_row_desc">Aggiungi vocabolario da un’altra app</string>
     <string name="settings_import_option_anki_apkg">Mazzo Anki (.apkg)</string>
     <string name="settings_import_option_anki_apkg_desc">Analizza le carte esportate da Anki</string>
     <string name="settings_import_option_json">Esportazione JSON (.json)</string>
-    <string name="settings_import_option_json_desc">Importa un\'esportazione completa di ProcrastiLearn</string>
+    <string name="settings_import_option_json_desc">Importa un’esportazione completa di ProcrastiLearn</string>
     <string name="settings_import_success">Importate %1$d carte</string>
     <string name="settings_import_failure_generic">Importazione non riuscita</string>
     <string name="settings_import_failure_format">Questo formato non è ancora supportato</string>
-    <string name="settings_import_failure_schema_version">Questo file è stato creato con una versione più recente di ProcrastiLearn. Aggiorna l\'app.</string>
+    <string name="settings_import_failure_schema_version">Questo file è stato creato con una versione più recente di ProcrastiLearn. Aggiorna l’app.</string>
 
     <!-- Export -->
     <string name="settings_export_row">Esporta</string>
@@ -252,7 +252,7 @@
     <string name="settings_openai_prompt_placeholder_hint">Usa {{NATIVE_LANGUAGE}} e {{TARGET_LANGUAGE}} come segnaposto: vengono sostituiti automaticamente con le lingue selezionate quando viene generata una traduzione.</string>
 
     <!-- Add Word: AI translation toggle -->
-    <string name="add_word_use_ai_toggle">usa l\'IA per generare la traduzione</string>
+    <string name="add_word_use_ai_toggle">usa l’IA per generare la traduzione</string>
     <string name="add_word_toggle_direction">Inverti direzione della traduzione</string>
     <string name="add_word_button_preview">Anteprima</string>
     <string name="add_word_preview_title">Anteprima IA</string>
@@ -262,7 +262,7 @@
     <string name="add_word_preview_regenerate">Rigenera</string>
     <string name="add_word_existing_title">Parola già esistente</string>
     <string name="add_word_existing_message">
-        Hai già aggiunto questa parola. Se procedi, i progressi verranno reimpostati e verrà salvata la nuova traduzione. Se vuoi solo modificarla, puoi farlo dall\'elenco delle parole
+        Hai già aggiunto questa parola. Se procedi, i progressi verranno reimpostati e verrà salvata la nuova traduzione. Se vuoi solo modificarla, puoi farlo dall’elenco delle parole
     </string>
     <string name="add_word_existing_cancel">@string/action_cancel</string>
     <string name="add_word_existing_proceed">@string/action_proceed</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -46,7 +46,7 @@
         <string name="dojo_empty_title">На сегодня всё готово!</string>
         <string name="dojo_empty_message">Вы прошли все доступные слова на сегодня. Возвращайтесь позже или измените дневные лимиты в настройках.</string>
         <string name="dojo_undo_content_description">Отменить последнюю оценку</string>
-        <string name="dojo_undo_confirmation">Отменено «%1$s» для \"%2$s\"</string>
+        <string name="dojo_undo_confirmation">Отменено «%1$s» для “%2$s”</string>
 
         <!-- ─── Overlay permission ──────────────────────────────────────────────── -->
         <string name="overlay_permission_title">Разрешить отображение поверх других окон</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,9 +46,9 @@
     <string name="dojo_stats_reviews_due">due</string>
     <string name="dojo_stats_skipped">skipped</string>
     <string name="dojo_empty_title">All done for now!</string>
-    <string name="dojo_empty_message">You\'ve completed all available words for today. Come back later or adjust your daily limits in Settings.</string>
+    <string name="dojo_empty_message">You’ve completed all available words for today. Come back later or adjust your daily limits in Settings.</string>
     <string name="dojo_undo_content_description">Undo last rating</string>
-    <string name="dojo_undo_confirmation">Undid %1$s for \"%2$s\"</string>
+    <string name="dojo_undo_confirmation">Undid %1$s for “%2$s”</string>
 
     <!-- ─── Overlay permission ──────────────────────────────────────────────── -->
     <string name="overlay_permission_title">Allow overlay display</string>
@@ -108,7 +108,7 @@
     <!-- Add Word: success and error fallback messages -->
     <string name="add_word_success_added">Word added successfully!</string>
     <string name="add_word_success_updated">Word updated and progress reset!</string>
-    <string name="add_word_success_pending">Saved. Translation will be generated once you\'re back online.</string>
+    <string name="add_word_success_pending">Saved. Translation will be generated once you’re back online.</string>
     <string name="add_word_error_preview_failed">Failed to generate preview</string>
     <string name="add_word_error_translation_failed">Failed to generate translation</string>
     <string name="add_word_error_update_failed">Failed to update word</string>
@@ -168,7 +168,7 @@
     <string name="settings_review_direction_bidirectional">Bidirectional</string>
     <string name="settings_review_direction_forward_desc">Show word, ask for translation</string>
     <string name="settings_review_direction_backward_desc">Show translation, ask for word</string>
-    <string name="settings_review_direction_bidirectional_desc">Mix both directions for cards flagged \"Test both directions\"</string>
+    <string name="settings_review_direction_bidirectional_desc">Mix both directions for cards flagged “Test both directions”</string>
 
     <!-- Daily limits -->
     <string name="settings_add_cards_for_today_title">Add Cards For Today</string>
@@ -258,7 +258,7 @@
     <string name="add_word_preview_regenerate">Re-Generate</string>
     <string name="add_word_existing_title">Word already exists</string>
     <string name="add_word_existing_message">
-        You already have this word added. If you proceed, the word\'s progress will be reset and new translation will be saved. If you just want to edit it - you can do it from word list
+        You already have this word added. If you proceed, the word’s progress will be reset and new translation will be saved. If you just want to edit it - you can do it from word list
     </string>
     <string name="add_word_existing_cancel">@string/action_cancel</string>
     <string name="add_word_existing_proceed">@string/action_proceed</string>


### PR DESCRIPTION
## Summary
- Fixes the `TypographyQuotes` lint findings (58 instances) by replacing straight ASCII apostrophes/quotes with typographic Unicode equivalents (`’`, `“`, `”`) inside translatable string resource *values* only.
- Touched files: `values/strings.xml` (5), `values-fr/strings.xml` (33), `values-it/strings.xml` (17), `values-es/strings.xml` (2), `values-ru/strings.xml` (1).
- `\'` escape sequences are replaced entirely with `’` (no longer need escaping); `\"..\"` quoted phrases become `“…”` pairs.
- No other lint issue categories (DuplicateStrings, Untranslatable, etc.) were touched, and no strings were reworded, reordered, or reformatted beyond the character swap.

## Test plan
- [x] Verified each modified `strings.xml` parses as valid XML
- [x] Grepped each modified file to confirm no remaining `\'` or `\"` escape sequences in string values
- [ ] `./gradlew :app:lintDebug` (could not run locally — no Android SDK in this environment; please confirm TypographyQuotes count drops to 0 in CI)

Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEDCQtEgRrRmoJvNpa5php)_