### PR TITLE
fix: remove orphaned translations left behind by unused-resource cleanup

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,7 +15,6 @@
     <string name="action_delete">Eliminar</string>
     <string name="action_edit">Editar</string>
     <string name="action_reset">Restablecer</string>
-    <string name="action_accept">Aceptar</string>
     <string name="action_ok">Aceptar</string>
     <string name="action_cancel">Cancelar</string>
     <string name="action_proceed">@string/action_continue</string>
@@ -104,7 +103,6 @@
     <!-- Helpful validation/toast messages -->
     <string name="add_word_error_word_required">Escribe una palabra.</string>
     <string name="add_word_error_translation_required">Escribe una traducción.</string>
-    <string name="add_word_toast_added">Palabra añadida.</string>
 
     <!-- Add Word: success and error fallback messages -->
     <string name="add_word_success_added">¡Palabra añadida correctamente!</string>
@@ -139,7 +137,6 @@
     <string name="language_selection_subtitle">Elige el idioma que hablas y el que quieres aprender. Puedes cambiarlo más tarde en Ajustes.</string>
     <string name="language_selection_native_label">Hablo</string>
     <string name="language_selection_target_label">Quiero aprender</string>
-    <string name="language_selection_same_language_error">El idioma nativo y el de aprendizaje deben ser diferentes</string>
 
     <!-- ─── Settings ────────────────────────────────────────────────────────── -->
     <string name="settings_title">@string/nav_settings</string>
@@ -277,7 +274,6 @@
     <string name="word_list_delete_confirm_message">
         ¿Eliminar <xliff:g id="word_name">%1$s</xliff:g> de tu lista?
     </string>
-    <string name="word_list_reset">@string/word_list_reset_confirm_title</string>
     <string name="word_list_reset_confirm_title">Restablecer progreso</string>
     <string name="word_list_reset_confirm_message">
         ¿Restablecer el progreso de aprendizaje de <xliff:g id="word_name">%1$s</xliff:g>?
@@ -292,9 +288,6 @@
     <string name="apps_list_error_message">Error: <xliff:g id="error_message">%1$s</xliff:g></string>
 
     <!-- ─── Accessibility content descriptions (for icons) ──────────────────── -->
-    <string name="cd_add_word">Añadir palabra</string>
-    <string name="cd_delete_word">Eliminar palabra</string>
-    <string name="cd_show_translation">Mostrar traducción</string>
 
     <!-- Plurals -->
     <plurals name="cards_count">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -15,7 +15,6 @@
     <string name="action_delete">Supprimer</string>
     <string name="action_edit">Modifier</string>
     <string name="action_reset">Réinitialiser</string>
-    <string name="action_accept">Accepter</string>
     <string name="action_ok">OK</string>
     <string name="action_cancel">Annuler</string>
     <string name="action_proceed">Poursuivre</string>
@@ -104,7 +103,6 @@
     <!-- Helpful validation/toast messages -->
     <string name="add_word_error_word_required">Veuillez saisir un mot.</string>
     <string name="add_word_error_translation_required">Veuillez saisir une traduction.</string>
-    <string name="add_word_toast_added">Mot ajouté.</string>
 
     <!-- Add Word: success and error fallback messages -->
     <string name="add_word_success_added">Mot ajouté avec succès !</string>
@@ -139,7 +137,6 @@
     <string name="language_selection_subtitle">Choisissez la langue que vous parlez et celle que vous souhaitez apprendre. Vous pourrez modifier ce choix plus tard dans les paramètres.</string>
     <string name="language_selection_native_label">Je parle</string>
     <string name="language_selection_target_label">Je veux apprendre</string>
-    <string name="language_selection_same_language_error">La langue maternelle et la langue cible doivent être différentes</string>
 
     <!-- ─── Settings ────────────────────────────────────────────────────────── -->
     <string name="settings_title">@string/nav_settings</string>
@@ -277,7 +274,6 @@
     <string name="word_list_delete_confirm_message">
         Supprimer <xliff:g id="word_name">%1$s</xliff:g> de votre liste ?
     </string>
-    <string name="word_list_reset">@string/word_list_reset_confirm_title</string>
     <string name="word_list_reset_confirm_title">Réinitialiser la progression</string>
     <string name="word_list_reset_confirm_message">
         Réinitialiser la progression d’apprentissage de <xliff:g id="word_name">%1$s</xliff:g> ?
@@ -292,9 +288,6 @@
     <string name="apps_list_error_message">Erreur : <xliff:g id="error_message">%1$s</xliff:g></string>
 
     <!-- ─── Accessibility content descriptions (for icons) ──────────────────── -->
-    <string name="cd_add_word">Ajouter un mot</string>
-    <string name="cd_delete_word">Supprimer le mot</string>
-    <string name="cd_show_translation">Afficher la traduction</string>
 
     <!-- Plurals -->
     <plurals name="cards_count">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -15,7 +15,6 @@
     <string name="action_delete">Elimina</string>
     <string name="action_edit">Modifica</string>
     <string name="action_reset">Reimposta</string>
-    <string name="action_accept">Accetta</string>
     <string name="action_ok">OK</string>
     <string name="action_cancel">Annulla</string>
     <string name="action_proceed">Procedi</string>
@@ -104,7 +103,6 @@
     <!-- Helpful validation/toast messages -->
     <string name="add_word_error_word_required">Inserisci una parola.</string>
     <string name="add_word_error_translation_required">Inserisci una traduzione.</string>
-    <string name="add_word_toast_added">Parola aggiunta.</string>
 
     <!-- Add Word: success and error fallback messages -->
     <string name="add_word_success_added">Parola aggiunta con successo!</string>
@@ -139,7 +137,6 @@
     <string name="language_selection_subtitle">Scegli la lingua che parli e quella che vuoi imparare. Potrai cambiarle in seguito dalle Impostazioni.</string>
     <string name="language_selection_native_label">Parlo</string>
     <string name="language_selection_target_label">Voglio imparare</string>
-    <string name="language_selection_same_language_error">La lingua madre e quella da imparare devono essere diverse</string>
 
     <!-- ─── Settings ────────────────────────────────────────────────────────── -->
     <string name="settings_title">@string/nav_settings</string>
@@ -277,7 +274,6 @@
     <string name="word_list_delete_confirm_message">
         Eliminare <xliff:g id="word_name">%1$s</xliff:g> dal tuo elenco?
     </string>
-    <string name="word_list_reset">@string/word_list_reset_confirm_title</string>
     <string name="word_list_reset_confirm_title">Reimposta progressi</string>
     <string name="word_list_reset_confirm_message">
         Reimpostare i progressi di apprendimento per <xliff:g id="word_name">%1$s</xliff:g>?
@@ -292,9 +288,6 @@
     <string name="apps_list_error_message">Errore: <xliff:g id="error_message">%1$s</xliff:g></string>
 
     <!-- ─── Accessibility content descriptions (for icons) ──────────────────── -->
-    <string name="cd_add_word">Aggiungi parola</string>
-    <string name="cd_delete_word">Elimina parola</string>
-    <string name="cd_show_translation">Mostra traduzione</string>
 
     <!-- Plurals -->
     <plurals name="cards_count">

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -15,7 +15,6 @@
     <string name="action_delete">Видалити</string>
     <string name="action_edit">Редагувати</string>
     <string name="action_reset">Скинути</string>
-    <string name="action_accept">Прийняти</string>
     <string name="action_ok">OK</string>
     <string name="action_cancel">Скасувати</string>
     <string name="action_proceed">@string/action_continue</string>
@@ -104,7 +103,6 @@
     <!-- Helpful validation/toast messages -->
     <string name="add_word_error_word_required">Будь ласка, введіть слово.</string>
     <string name="add_word_error_translation_required">Будь ласка, введіть переклад.</string>
-    <string name="add_word_toast_added">Слово додано.</string>
 
     <!-- Add Word: success and error fallback messages -->
     <string name="add_word_success_added">Слово успішно додано!</string>
@@ -139,7 +137,6 @@
     <string name="language_selection_subtitle">Виберіть мову, якою ви розмовляєте, і мову, яку хочете вивчати. Це можна змінити пізніше в налаштуваннях.</string>
     <string name="language_selection_native_label">Я розмовляю</string>
     <string name="language_selection_target_label">Я хочу вивчити</string>
-    <string name="language_selection_same_language_error">Рідна та цільова мови мають відрізнятися</string>
 
     <!-- ─── Settings ────────────────────────────────────────────────────────── -->
     <string name="settings_title">@string/nav_settings</string>
@@ -277,7 +274,6 @@
     <string name="word_list_delete_confirm_message">
         Видалити <xliff:g id="word_name">%1$s</xliff:g> зі списку?
     </string>
-    <string name="word_list_reset">@string/word_list_reset_confirm_title</string>
     <string name="word_list_reset_confirm_title">Скинути прогрес</string>
     <string name="word_list_reset_confirm_message">
         Скинути прогрес вивчення для <xliff:g id="word_name">%1$s</xliff:g>?
@@ -292,9 +288,6 @@
     <string name="apps_list_error_message">Помилка: <xliff:g id="error_message">%1$s</xliff:g></string>
 
     <!-- ─── Accessibility content descriptions (for icons) ──────────────────── -->
-    <string name="cd_add_word">Додати слово</string>
-    <string name="cd_delete_word">Видалити слово</string>
-    <string name="cd_show_translation">Показати переклад</string>
 
     <!-- Plurals -->
     <plurals name="cards_count">

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -15,7 +15,6 @@
     <string name="action_delete">删除</string>
     <string name="action_edit">编辑</string>
     <string name="action_reset">重置</string>
-    <string name="action_accept">接受</string>
     <string name="action_ok">确定</string>
     <string name="action_cancel">取消</string>
     <string name="action_proceed">@string/action_continue</string>
@@ -89,7 +88,6 @@
     <!-- Helpful validation/toast messages -->
     <string name="add_word_error_word_required">请输入单词。</string>
     <string name="add_word_error_translation_required">请输入翻译。</string>
-    <string name="add_word_toast_added">单词已添加。</string>
 
     <!-- Add Word: success and error fallback messages -->
     <string name="add_word_success_added">单词添加成功！</string>
@@ -124,7 +122,6 @@
     <string name="language_selection_subtitle">选择你使用的语言和想学习的语言，之后可在设置中修改。</string>
     <string name="language_selection_native_label">我使用的语言</string>
     <string name="language_selection_target_label">我想学习的语言</string>
-    <string name="language_selection_same_language_error">母语和目标语言不能相同</string>
 
     <!-- ─── Settings ────────────────────────────────────────────────────────── -->
     <string name="settings_title">@string/nav_settings</string>
@@ -248,7 +245,6 @@
     <string name="word_list_empty">还没有添加任何单词</string>
     <string name="word_list_delete_confirm_title">删除单词</string>
     <string name="word_list_delete_confirm_message">确定要从列表中删除「<xliff:g id="word_name">%1$s</xliff:g>」吗？</string>
-    <string name="word_list_reset">@string/word_list_reset_confirm_title</string>
     <string name="word_list_reset_confirm_title">重置进度</string>
     <string name="word_list_reset_confirm_message">确定要重置「<xliff:g id="word_name">%1$s</xliff:g>」的学习进度吗？</string>
     <string name="word_list_more_actions">更多操作</string>
@@ -261,9 +257,6 @@
     <string name="apps_list_error_message">错误：<xliff:g id="error_message">%1$s</xliff:g></string>
 
     <!-- ─── Accessibility content descriptions (for icons) ──────────────────── -->
-    <string name="cd_add_word">添加单词</string>
-    <string name="cd_delete_word">删除单词</string>
-    <string name="cd_show_translation">显示翻译</string>
 
     <!-- Plurals -->
     <plurals name="cards_count">


### PR DESCRIPTION
## Summary

CI on `master` has been failing since #29 merged, with `lintDebug` erroring out on `ExtraTranslation` (configured as a build-breaking error in this project's lint block):

```
values-es/strings.xml:18: Error: "action_accept" is translated here but not found in default locale [ExtraTranslation]
```

#29 (UnusedResources) deleted `action_accept`, `add_word_toast_added`, `language_selection_same_language_error`, `word_list_reset`, `cd_add_word`, `cd_delete_word`, and `cd_show_translation` from the base `values/strings.xml` and `values-ru/strings.xml` as unused, but left them declared in `values-es`, `values-fr`, `values-it`, `values-uk`, and `values-zh`. Once the base declaration is gone, lint flags every remaining translation of that resource as an orphan.

This removes the same 7 resources from the 5 remaining locale files, matching the base file. 35 lines removed total (7 resources × 5 locales), matching the 35 lint errors reported in CI exactly.

## Test plan
- [x] Confirmed via grep that none of the 7 resources are referenced anywhere in Kotlin code or other string aliases before deleting
- [x] Verified all 5 modified `strings.xml` files remain well-formed XML
- [x] Ran `./gradlew :app:lintDebug` locally — `BUILD SUCCESSFUL`, zero `ExtraTranslation`/`MissingTranslation` findings in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEDCQtEgRrRmoJvNpa5php)_