### PR TITLE
chore: enable strict Android Lint checks with baseline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,14 @@ android {
     checkReleaseBuilds = true
     abortOnError = true
     error += setOf("MissingTranslation", "ExtraTranslation")
+    checkDependencies = true
+    checkTestSources = true
+    checkAllWarnings = true
+    textReport = true
+    htmlReport = true
+    warningsAsErrors = true
+    sarifReport = true
+    baseline = file("lint-baseline.xml")
   }
 }
 

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,1784 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.2.1" type="baseline" client="gradle" dependencies="true" name="AGP (9.2.1)" variant="all" version="9.2.1">
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 33 (current min is 30): `android.content.pm.PackageManager#queryIntentActivities`"
+        errorLine1="            packageManager.queryIntentActivities("
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/AppRepositoryImplTest.kt"
+            line="122"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
+        errorLine1="    targetSdk = 36"
+        errorLine2="    ~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="23"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `localeConfig` is only used in API level 33 and higher (current min is 30)"
+        errorLine1="        android:localeConfig=&quot;@xml/locales_config&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="16"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        coEvery { getVocabularyItemByWordUseCase.invoke(any()) } returns null"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt"
+            line="109"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt"
+            line="163"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        coEvery { getVocabularyItemByWordUseCase.invoke(any()) } returns null"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="117"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="694"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="719"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="743"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="773"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="845"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="869"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="888"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } throws IllegalStateException(&quot;db error&quot;)"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="908"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="928"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coVerify(exactly = 0) { getVocabularyItemByWordUseCase.invoke(any()) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="956"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coVerify(exactly = 0) { getVocabularyItemByWordUseCase.invoke(any()) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="970"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="979"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1004"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1038"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1061"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1098"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1120"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1143"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1169"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1202"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1229"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1256"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1284"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1295"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1311"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1320"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1339"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1361"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1388"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1421"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1445"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1468"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1491"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } throws IllegalStateException(&quot;db error&quot;)"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1511"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1533"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1557"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coVerify(exactly = 0) { getVocabularyItemByWordUseCase.invoke(any()) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1590"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt"
+            line="1751"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`cancel` is defined both as a member in class `kotlinx.coroutines.Job` and an extension in package `kotlinx.coroutines`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        intervalTimerJob?.cancel()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="279"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`cancel` is defined both as a member in class `kotlinx.coroutines.Job` and an extension in package `kotlinx.coroutines`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        intervalTimerJob?.cancel()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="324"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt"
+            line="45"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns existing"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt"
+            line="62"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt"
+            line="77"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt"
+            line="91"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt"
+            line="106"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Fail&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt"
+            line="121"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="            coEvery { getVocabularyItemByWordUseCase.invoke(&quot;Haus&quot;) } returns null"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/sync/PendingWordSyncManagerTest.kt"
+            line="122"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`invoke` is defined both as a member in class `kotlin.Function1` and an extension in package `io.mockk`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        verify(exactly = 1) { onValueConfirm.invoke(&quot;new value&quot;) }"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/screens/settings/components/StringInputDialogTest.kt"
+            line="118"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`encodeToString` is defined both as a member in class `kotlinx.serialization.json.Json` and an extension in package `kotlinx.serialization`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        val encoded = json.encodeToString(envelope)"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/VocabularyExportEnvelopeTest.kt"
+            line="42"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`encodeToString` is defined both as a member in class `kotlinx.serialization.json.Json` and an extension in package `kotlinx.serialization`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        val encoded = json.encodeToString(envelope)"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/VocabularyExportEnvelopeTest.kt"
+            line="78"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="MemberExtensionConflict"
+        message="`encodeToString` is defined both as a member in class `kotlinx.serialization.json.Json` and an extension in package `kotlinx.serialization`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
+        errorLine1="        return json.encodeToString(envelope)"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/export/VocabularyExportSerializer.kt"
+            line="35"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of Gradle than 9.4.1 is available: 9.6.1"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/wrapper/gradle-wrapper.properties"
+            line="4"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 8.12.0 is available: 9.3.1. (There is also a newer version of 8.12.𝑥 available, if upgrading to 9.3.1 is difficult: 8.12.3)"
+        errorLine1="agp = &quot;8.12.0&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="2"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appfunctions:appfunctions than 1.0.0-alpha09 is available: 1.0.0-alpha10"
+        errorLine1="appfunctions = &quot;1.0.0-alpha09&quot;"
+        errorLine2="               ~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appfunctions:appfunctions-compiler than 1.0.0-alpha09 is available: 1.0.0-alpha10"
+        errorLine1="appfunctions = &quot;1.0.0-alpha09&quot;"
+        errorLine2="               ~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.datastore:datastore-preferences than 1.1.7 is available: 1.2.1"
+        errorLine1="datastorePreferences = &quot;1.1.7&quot;"
+        errorLine2="                       ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="4"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.hilt:hilt-navigation-compose than 1.2.0 is available: 1.4.0"
+        errorLine1="hiltNavigationCompose = &quot;1.2.0&quot;"
+        errorLine2="                        ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="8"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.10.1 is available: 1.19.0"
+        errorLine1="coreKtx = &quot;1.10.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.ext:junit than 1.1.5 is available: 1.3.0"
+        errorLine1="junitVersion = &quot;1.1.5&quot;"
+        errorLine2="               ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="12"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.6.1 is available: 2.11.0"
+        errorLine1="lifecycleRuntimeKtx = &quot;2.6.1&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="14"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.8.0 is available: 1.13.0"
+        errorLine1="activityCompose = &quot;1.8.0&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="15"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2025.05.01 is available: 2026.06.01"
+        errorLine1="composeBom = &quot;2025.05.01&quot;"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="16"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.uiautomator:uiautomator than 2.3.0 is available: 2.4.0"
+        errorLine1="uiAutomator = &quot;2.3.0&quot;"
+        errorLine2="              ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="23"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:core than 1.5.0 is available: 1.7.0"
+        errorLine1="androidxTestCore = &quot;1.5.0&quot;"
+        errorLine2="                   ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="26"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:runner than 1.5.2 is available: 1.7.0"
+        errorLine1="androidxTestRunner = &quot;1.5.2&quot;"
+        errorLine2="                     ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="27"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jlleitschuh.gradle.ktlint than 13.1.0 is available: 14.2.0"
+        errorLine1="  id(&quot;org.jlleitschuh.gradle.ktlint&quot;) version &quot;13.1.0&quot;"
+        errorLine2="                                              ~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="7"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.google.dagger:hilt-android than 2.59.2 is available: 2.60.1"
+        errorLine1="hiltCompiler = &quot;2.59.2&quot;"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="7"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.google.dagger:hilt-compiler than 2.59.2 is available: 2.60.1"
+        errorLine1="hiltCompiler = &quot;2.59.2&quot;"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="7"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.android than 2.0.21 is available: 2.4.10"
+        errorLine1="kotlin = &quot;2.0.21&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="9"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.compose than 2.0.21 is available: 2.4.10"
+        errorLine1="kotlin = &quot;2.0.21&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="9"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-serialization-json than 1.8.1 is available: 1.11.0"
+        errorLine1="kotlinxSerializationJson = &quot;1.8.1&quot;"
+        errorLine2="                           ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="17"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.openai:openai-java than 3.4.1 is available: 4.45.0"
+        errorLine1="openaiJava = &quot;3.4.1&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="18"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.github.luben:zstd-jni than 1.5.7-6 is available: 1.5.7-12"
+        errorLine1="zstdJni = &quot;1.5.7-6&quot;"
+        errorLine2="          ~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="24"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-test than 1.7.3 is available: 1.11.0"
+        errorLine1="kotlinxCoroutinesTest = &quot;1.7.3&quot;"
+        errorLine2="                        ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="25"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of io.mockk:mockk than 1.13.8 is available: 1.14.11"
+        errorLine1="mockk = &quot;1.13.8&quot;"
+        errorLine2="        ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="28"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of app.cash.turbine:turbine than 1.0.0 is available: 1.2.1"
+        errorLine1="turbine = &quot;1.0.0&quot;"
+        errorLine2="          ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="29"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.google.truth:truth than 1.1.5 is available: 1.4.5"
+        errorLine1="truth = &quot;1.1.5&quot;"
+        errorLine2="        ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="30"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.robolectric:robolectric than 4.16 is available: 4.16.1"
+        errorLine1="robolectric = &quot;4.16&quot;"
+        errorLine2="              ~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="31"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;cards_count&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="293"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;cards_count&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="293"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;cards_count&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="293"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;es&quot; (Spanish) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;overlay_minutes_interval&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="297"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;fr&quot; (French) the following quantity should also be defined: `many` (e.g. &quot;1000000 de jours&quot;)"
+        errorLine1="    &lt;plurals name=&quot;overlay_minutes_interval&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="297"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;it&quot; (Italian) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;overlay_minutes_interval&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="297"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;cards&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;settings_import_success&quot;>Imported %1$d cards&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="224"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 30. Merge all the resources in this folder into `mipmap-anydpi`.">
+        <location
+            file="src/main/res/mipmap-anydpi-v26"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                Log.d("
+        errorLine2="                ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/parser/anki/AnkiApkgVocabularyParser.kt"
+            line="176"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                Log.d(&quot;OverlayService&quot;, &quot;Blocked packages updated: $blockedPackages&quot;)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="116"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                Log.d(&quot;OverlayService&quot;, &quot;ProcrastiLearn enabled updated: $isProcrastilearnEnabled&quot;)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="132"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                Log.d(&quot;OverlayService&quot;, &quot;Overlay interval updated: $overlayIntervalMinutes minutes&quot;)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="139"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(&quot;OverlayService&quot;, &quot;Event from package: $topPackage&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="161"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                    Log.d(&quot;OverlayService&quot;, &quot;Gate session started for $pkg, overlay shown&quot;)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="258"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d("
+        errorLine2="        ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="280"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                Log.d(&quot;OverlayService&quot;, &quot;Timer started, will fire in $overlayIntervalMinutes minutes ($delayMs ms)&quot;)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="300"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                Log.d(&quot;OverlayService&quot;, &quot;Timer fired! gateActive=$gateActive, gatedPackage=$gatedPackage&quot;)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="304"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                        Log.d(&quot;OverlayService&quot;, &quot;Hiding overlay and bringing $pkg to front&quot;)"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="366"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(&quot;OverlayService&quot;, &quot;Brought $pkg to front&quot;)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="416"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.i(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.i(&quot;OverlayService&quot;, &quot;Audio focus request result: $result&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt"
+            line="445"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.i(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.i(&quot;fsrs&quot;, &quot;$rating selected for $current &quot;)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/overlay/OverlayViewModel.kt"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.i(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        every { Log.i(any(), any()) } returns 0"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/overlay/OverlayViewModelTest.kt"
+            line="39"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(&quot;SettingsAnkiImportE2eTest&quot;, &quot;Using deckUri=$deckUri&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidTest/java/com/procrastilearn/app/e2e/SettingsAnkiImportE2eTest.kt"
+            line="68"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.i(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.i(&quot;Fooi&quot;, actualItems.toString())"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidTest/java/com/procrastilearn/app/e2e/SettingsAnkiImportE2eTest.kt"
+            line="79"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                Log.d("
+        errorLine2="                ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/SettingsViewModel.kt"
+            line="226"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="            Log.d(&quot;SettingsViewModel&quot;, &quot;openInputStream succeeded for uri=$uri&quot;)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/SettingsViewModel.kt"
+            line="282"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d(TAG, &quot;onCreate context=&quot; + (ctx != null ? ctx.getPackageName() : &quot;null&quot;));"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidTest/java/com/procrastilearn/app/e2e/TestAssetFileProvider.java"
+            line="24"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.d(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="        Log.d("
+        errorLine2="        ^">
+        <location
+            file="src/androidTest/java/com/procrastilearn/app/e2e/TestAssetFileProvider.java"
+            line="51"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="LogConditional"
+        message="The log call Log.i(...) should be conditional: surround with `if (Log.isLoggable(...))` or `if (BuildConfig.DEBUG) { ... }`"
+        errorLine1="                    Log.i(&quot;FSRS&quot;, &quot;Reviewed $id ($direction) as $rating; next due at $nextDue&quot;)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt"
+            line="231"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `withBidirectionalCleared` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                    _uiState.value = if (aiModeNowActive) updated.withBidirectionalCleared() else updated"
+        errorLine2="                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="82"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `queuePendingWord` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                    queuePendingWord(queuePendingWordUseCase, _uiState, currentState.word.trim(), currentState.translationDirection, pendingMessage)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="163"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `setBlankTranslationError` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                        setBlankTranslationError(_uiState, context.getString(R.string.add_word_error_translation_required))"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="186"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `lookupExistingItem` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                    lookupExistingItem(getVocabularyItemByWordUseCase, _uiState, word, lookupFailedMessage)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="196"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `setBlankTranslationError` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                    setBlankTranslationError(_uiState, context.getString(R.string.add_word_error_translation_required))"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="213"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `withBidirectionalToggle` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="            _uiState.value = _uiState.value.withBidirectionalToggle(checked)"
+        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="287"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `lookupExistingItem` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                    lookupExistingItem(getVocabularyItemByWordUseCase, _uiState, word, lookupFailedMessage)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="329"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `withBidirectionalCleared` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                _uiState.value"
+        errorLine2="                ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="436"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `resolvePendingTranslation` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                    resolvePendingTranslation("
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="481"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `closeExistingWordDialogWithError` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                        closeExistingWordDialogWithError(_uiState, error.message ?: translationFailedMessage)"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="489"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `withBidirectionalCleared` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                            _uiState.value"
+        errorLine2="                            ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="506"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `closeExistingWordDialogWithError` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                        closeExistingWordDialogWithError("
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="523"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `lookupExistingItem` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                lookupExistingItem("
+        errorLine2="                ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="539"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `isAcknowledgedOverride` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                if (isAcknowledgedOverride(word, acknowledgedOverrideWord)) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="547"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `withBidirectionalCleared` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                        _uiState.value"
+        errorLine2="                        ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="576"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `withBidirectionalCleared` of class `AddWordViewModelKt` requires synthetic accessor"
+        errorLine1="                        _uiState.value"
+        errorLine2="                        ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt"
+            line="649"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `stableRender` of class `ExportCorpusSnapshotTestKt` requires synthetic accessor"
+        errorLine1="            is ImportOutcome.Success -> outcome.items.stableRender()"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/ExportCorpusSnapshotTest.kt"
+            line="48"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `randomItem` of class `ExportRoundTripTestKt` requires synthetic accessor"
+        errorLine1="        val typicalItem = randomItem(Random(FUZZ_SEED), id = 1)"
+        errorLine2="                          ~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/ExportRoundTripTest.kt"
+            line="71"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `typicalItemJson` of class `ExportRoundTripTestKt` requires synthetic accessor"
+        errorLine1="        val fullJson = typicalItemJson(typicalItem)"
+        errorLine2="                       ~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/ExportRoundTripTest.kt"
+            line="72"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `droppableItemFields` of class `ExportRoundTripTestKt` requires synthetic accessor"
+        errorLine1="        val droppableKeys = droppableItemFields()"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/ExportRoundTripTest.kt"
+            line="73"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `randomSubsets` of class `ExportRoundTripTestKt` requires synthetic accessor"
+        errorLine1="            droppableKeys.map { setOf(it) } + randomSubsets(droppableKeys, random)"
+        errorLine2="                                              ~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/ExportRoundTripTest.kt"
+            line="77"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getDataStore` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                    val prefs = ctx.dataStore.data.first()"
+        errorLine2="                                    ~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/MainActivity.kt"
+            line="79"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getDataStore` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                                        ctx.dataStore.edit { it[KEY_ACCESSIBILITY_SKIPPED] = false }"
+        errorLine2="                                            ~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/MainActivity.kt"
+            line="97"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getDataStore` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                                        ctx.dataStore.edit { it[KEY_OVERLAY_SKIPPED] = false }"
+        errorLine2="                                            ~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/MainActivity.kt"
+            line="103"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getDataStore` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                                        ctx.dataStore.edit { it[KEY_ACCESSIBILITY_SKIPPED] = true }"
+        errorLine2="                                            ~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/MainActivity.kt"
+            line="135"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getDataStore` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                                        ctx.dataStore.edit { it[KEY_OVERLAY_SKIPPED] = true }"
+        errorLine2="                                            ~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/MainActivity.kt"
+            line="161"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getDataStore` of class `PreferencesDataStoreKt` requires synthetic accessor"
+        errorLine1="        private val dataStore = context.dataStore"
+        errorLine2="                                        ~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/local/prefs/PreferencesDataStore.kt"
+            line="26"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `getDataStore` of class `PreferencesDataStoreKt` requires synthetic accessor"
+        errorLine1="            context.dataStore.edit { preferences ->"
+        errorLine2="                    ~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/local/prefs/PreferencesDataStore.kt"
+            line="71"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `fingerprint` of class `SchemaFingerprintTestKt` requires synthetic accessor"
+        errorLine1="        VocabularyExportEnvelope.serializer().descriptor.fingerprint()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/data/export/SchemaFingerprintTest.kt"
+            line="54"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `todayStamp` of class `VocabularyRepositoryImplKt` requires synthetic accessor"
+        errorLine1="                            snapshotDay = todayStamp(),"
+        errorLine2="                                          ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt"
+            line="179"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `todayStamp` of class `VocabularyRepositoryImplKt` requires synthetic accessor"
+        errorLine1="                    if (snapshot.snapshotDay == todayStamp()) {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt"
+            line="256"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `todayStamp` of class `VocabularyRepositoryImplKt` requires synthetic accessor"
+        errorLine1="            val today = todayStamp()"
+        errorLine2="                        ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt"
+            line="447"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `@string/action_add`, used in `add_word_icon_add` and `add_word_preview_confirm`"
+        errorLine1="    &lt;string name=&quot;add_word_icon_add&quot;>@string/action_add&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="81"
+            column="5"/>
+        <location
+            file="src/main/res/values-zh/strings.xml"
+            line="230"
+            column="5"
+            message="Duplicates value in `add_word_icon_add`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `@string/action_add`, used in `add_word_icon_add` and `add_word_preview_confirm`"
+        errorLine1="        &lt;string name=&quot;add_word_icon_add&quot;>@string/action_add&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="94"
+            column="9"/>
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="261"
+            column="9"
+            message="Duplicates value in `add_word_icon_add`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `@string/action_add`, used in `add_word_icon_add` and `add_word_preview_confirm`"
+        errorLine1="    &lt;string name=&quot;add_word_icon_add&quot;>@string/action_add&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="96"
+            column="5"/>
+        <location
+            file="src/main/res/values-es/strings.xml"
+            line="255"
+            column="5"
+            message="Duplicates value in `add_word_icon_add`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `@string/action_add`, used in `add_word_icon_add` and `add_word_preview_confirm`"
+        errorLine1="    &lt;string name=&quot;add_word_icon_add&quot;>@string/action_add&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="96"
+            column="5"/>
+        <location
+            file="src/main/res/values-fr/strings.xml"
+            line="255"
+            column="5"
+            message="Duplicates value in `add_word_icon_add`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `@string/action_add`, used in `add_word_icon_add` and `add_word_preview_confirm`"
+        errorLine1="    &lt;string name=&quot;add_word_icon_add&quot;>@string/action_add&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="96"
+            column="5"/>
+        <location
+            file="src/main/res/values-it/strings.xml"
+            line="255"
+            column="5"
+            message="Duplicates value in `add_word_icon_add`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `@string/action_add`, used in `add_word_icon_add` and `add_word_preview_confirm`"
+        errorLine1="    &lt;string name=&quot;add_word_icon_add&quot;>@string/action_add&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-uk/strings.xml"
+            line="96"
+            column="5"/>
+        <location
+            file="src/main/res/values-uk/strings.xml"
+            line="255"
+            column="5"
+            message="Duplicates value in `add_word_icon_add`"/>
+    </issue>
+
+    <issue
+        id="DuplicateStrings"
+        message="Duplicate string value `@string/action_add`, used in `add_word_icon_add` and `add_word_preview_confirm`"
+        errorLine1="    &lt;string name=&quot;add_word_icon_add&quot;>@string/action_add&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="97"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="257"
+            column="5"
+            message="Duplicates value in `add_word_icon_add`"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive icon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive roundIcon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="        Bitmap.createBitmap("
+        errorLine2="        ^">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/views/AppsList.kt"
+            line="270"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Int.toDrawable` instead?"
+        errorLine1="                icon = ColorDrawable(android.graphics.Color.RED),"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/views/AppsListTest.kt"
+            line="56"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Int.toDrawable` instead?"
+        errorLine1="                icon = ColorDrawable(android.graphics.Color.BLUE),"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/procrastilearn/app/ui/views/AppsListTest.kt"
+            line="61"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                                            Uri.parse(&quot;package:$packageName&quot;),"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/MainActivity.kt"
+            line="154"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            Uri.parse(&quot;package:${context.packageName}&quot;),"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/procrastilearn/app/ui/screens/settings/components/OpenSettingsHelpers.kt"
+            line="12"
+            column="13"/>
+    </issue>
+
+</issues>


### PR DESCRIPTION
## Summary

- Enables the stricter lint configuration used to generate the original lint audit this session: `checkDependencies`, `checkTestSources`, `checkAllWarnings`, `warningsAsErrors`, plus `textReport`/`htmlReport`/`sarifReport` output, alongside the existing `checkReleaseBuilds`/`abortOnError`/`MissingTranslation`+`ExtraTranslation`-as-error settings.
- Adds `baseline = file("lint-baseline.xml")` and a generated `app/lint-baseline.xml` capturing the **159 pre-existing findings** that haven't been fixed yet, so CI stays green against the current backlog and only fails on **newly introduced** lint issues going forward.

Baselined categories (all pre-existing, not introduced by this PR): `MemberExtensionConflict` (54), `SyntheticAccessor` (32), `LogConditional` (21), `NewerVersionAvailable` (13), `GradleDependency` (12), `DuplicateStrings` (7 — a residual case where two independently-added `@string` aliases both resolve to `action_add`, unrelated to the categories already fixed this session), `MissingQuantity` (6), `UseKtx` (5), `MonochromeLauncherIcon` (2), `AndroidGradlePluginVersion` (2), `UnusedAttribute` (1), `PluralsCandidate` (1), `OldTargetApi` (1), `ObsoleteSdkInt` (1), `NewApi` (1).

## Test plan
- [x] `./gradlew ktlintCheck` — `BUILD SUCCESSFUL`
- [x] `./gradlew detekt` — `BUILD SUCCESSFUL`
- [x] `./gradlew :app:lintDebug` — `BUILD SUCCESSFUL` ("Lint found no new issues (and 159 errors filtered by baseline)")
- [x] `./gradlew testDebugUnitTest` — `BUILD SUCCESSFUL`

All steps mirror the repo's CI `verify` job and pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEDCQtEgRrRmoJvNpa5php)_