### PR TITLE
fix: update tests to reference R.string.action_add

### DIFF
--- a/app/src/test/java/com/procrastilearn/app/ui/screens/AddWordDialogsTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/AddWordDialogsTest.kt
@@ -64,7 +64,7 @@ class AddWordDialogsTest {
         setPreviewDialogContent(isConfirmLoading = false)
 
         composeTestRule.onNodeWithText(string(R.string.add_word_preview_cancel)).assertIsDisplayed()
-        composeTestRule.onNodeWithText(string(R.string.add_word_preview_confirm)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.action_add)).assertIsDisplayed()
     }
 
     @Test
@@ -81,7 +81,7 @@ class AddWordDialogsTest {
     fun `preview dialog clicking confirm invokes onConfirm`() {
         setPreviewDialogContent()
 
-        composeTestRule.onNodeWithText(string(R.string.add_word_preview_confirm)).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_add)).performClick()
 
         verify(exactly = 1) { onConfirm.invoke() }
         verify { onCancel wasNot called }
@@ -91,7 +91,7 @@ class AddWordDialogsTest {
     fun `preview dialog hides confirm text and disables buttons while confirm loading`() {
         setPreviewDialogContent(isConfirmLoading = true)
 
-        composeTestRule.onNodeWithText(string(R.string.add_word_preview_confirm)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(string(R.string.action_add)).assertDoesNotExist()
         composeTestRule.onNodeWithText(string(R.string.add_word_preview_cancel)).assertIsNotEnabled()
     }
 
@@ -129,7 +129,7 @@ class AddWordDialogsTest {
         composeTestRule.onNodeWithText(string(R.string.add_word_preview_stored_title)).assertIsDisplayed()
         composeTestRule.onNodeWithText(string(R.string.add_word_preview_regenerate)).assertIsDisplayed()
         composeTestRule.onNodeWithText(string(R.string.add_word_preview_title)).assertDoesNotExist()
-        composeTestRule.onNodeWithText(string(R.string.add_word_preview_confirm)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(string(R.string.action_add)).assertDoesNotExist()
     }
 
     @Test

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/AddWordScreenContentTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/AddWordScreenContentTest.kt
@@ -358,7 +358,7 @@ class AddWordScreenContentTest {
 
         // The preview dialog's confirm label shares text ("Add") with the screen's Add
         // button, which stays composed underneath the dialog; target the last match.
-        val confirmButtons = composeTestRule.onAllNodesWithText(string(R.string.add_word_preview_confirm))
+        val confirmButtons = composeTestRule.onAllNodesWithText(string(R.string.action_add))
         confirmButtons[confirmButtons.fetchSemanticsNodes().size - 1].performClick()
 
         verify(exactly = 1) { onPreviewConfirmAdd.invoke() }


### PR DESCRIPTION
AddWordDialogs.kt was changed to use R.string.action_add directly
instead of the now-removed add_word_preview_confirm alias, but the
tests still referenced the deleted resource, breaking compilation
of the unit test sources on CI.