### PR TITLE
fix: correct language order in AI prompt edit dialog titles

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
@@ -481,8 +481,8 @@ internal fun SettingsContent(
                 title =
                     stringResource(
                         R.string.settings_openai_prompt_dialog_title,
-                        nativeLanguage.code.uppercase(),
                         targetLanguage.code.uppercase(),
+                        nativeLanguage.code.uppercase(),
                     ),
                 currentValue = openAiPrompt,
                 onValueConfirm = {
@@ -501,8 +501,8 @@ internal fun SettingsContent(
                 title =
                     stringResource(
                         R.string.settings_openai_reverse_prompt_dialog_title,
-                        targetLanguage.code.uppercase(),
                         nativeLanguage.code.uppercase(),
+                        targetLanguage.code.uppercase(),
                     ),
                 currentValue = openAiReversePrompt,
                 onValueConfirm = {

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/settings/SettingsContentTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/settings/SettingsContentTest.kt
@@ -358,6 +358,34 @@ class SettingsContentTest {
     }
 
     @Test
+    fun `AI prompt dialog title matches its translation direction`() {
+        setContent(nativeLanguage = Language.GERMAN, targetLanguage = Language.FRENCH)
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.settings_openai_prompt_title, "FR", "DE"))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.settings_openai_prompt_dialog_title, "FR", "DE"))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+    }
+
+    @Test
+    fun `AI reverse prompt dialog title matches its translation direction`() {
+        setContent(nativeLanguage = Language.GERMAN, targetLanguage = Language.FRENCH)
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.settings_openai_reverse_prompt_title, "DE", "FR"))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.settings_openai_reverse_prompt_dialog_title, "DE", "FR"))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+    }
+
+    @Test
     fun `about us item shows dialog`() {
         setContent()
 


### PR DESCRIPTION
## Summary
- The "Edit AI prompt" modal titles had native/target languages swapped relative to the settings list item and the actual translation direction of each prompt.
  - Forward prompt (translates target → native) dialog was showing `native->target` instead of `target->native`.
  - Reverse prompt (translates native → target) dialog was showing `target->native` instead of `native->target`.
- Fixed the argument order passed to `settings_openai_prompt_dialog_title` / `settings_openai_reverse_prompt_dialog_title` in `SettingsScreen.kt` so the dialog headings match the settings list items and the prompts' actual `ROLE:` direction.

## Test plan
- [x] Added `SettingsContentTest` cases asserting each dialog's title text matches its correct translation direction.
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew testDebugUnitTest --tests "com.procrastilearn.app.ui.screens.settings.SettingsContentTest"`


---
_Generated by [Claude Code](https://claude.ai/code/session_017LXDdHqpp8tcJYMag4KpNa)_