### PR TITLE
fix: replace generic and duplicated icons across nav and settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
   implementation(libs.androidx.ui.graphics)
   implementation(libs.androidx.ui.tooling.preview)
   implementation(libs.androidx.material3)
+  implementation(libs.androidx.material.icons.extended)
   implementation("${libs.zstd.jni.get()}@aar")
   testImplementation(libs.zstd.jni)
   testImplementation(libs.junit)

--- a/app/src/main/java/com/procrastilearn/app/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/procrastilearn/app/navigation/BottomNavigationBar.kt
@@ -1,9 +1,9 @@
 package com.procrastilearn.app.navigation
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.AppRegistration
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -29,7 +29,7 @@ private val bottomNavItems =
     listOf(
         BottomNavItem(
             screen = Screen.Apps,
-            icon = Icons.Default.Edit,
+            icon = Icons.Default.AppRegistration,
             label = "nav_apps",
         ),
         BottomNavItem(
@@ -39,7 +39,7 @@ private val bottomNavItems =
         ),
         BottomNavItem(
             screen = Screen.Dojo,
-            icon = Icons.Default.List,
+            icon = Icons.AutoMirrored.Filled.MenuBook,
             label = "nav_dojo",
         ),
         BottomNavItem(

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeader.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/components/DojoStatsHeader.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -46,7 +46,7 @@ fun DojoStatsHeader(
             modifier = Modifier.align(Alignment.CenterStart),
         ) {
             Icon(
-                imageVector = Icons.Filled.Refresh,
+                imageVector = Icons.AutoMirrored.Filled.Undo,
                 contentDescription = stringResource(R.string.dojo_undo_content_description),
                 tint = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.alpha(if (canUndo) 1f else DISABLED_ALPHA),

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/AddCardsForTodaySettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/AddCardsForTodaySettingsItem.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -24,7 +24,7 @@ fun AddCardsForTodaySettingsItem(
         headlineContent = { Text(stringResource(R.string.settings_add_cards_for_today_title)) },
         trailingContent = {
             Icon(
-                imageVector = Icons.Default.Add,
+                imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ExportSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ExportSettingsItem.kt
@@ -4,7 +4,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -28,9 +29,16 @@ fun ExportSettingsItem(
                 style = MaterialTheme.typography.bodySmall,
             )
         },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.FileUpload,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
         trailingContent = {
             Icon(
-                imageVector = Icons.Default.ArrowDropDown,
+                imageVector = Icons.Default.ExpandMore,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ImportSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ImportSettingsItem.kt
@@ -6,7 +6,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -45,9 +46,16 @@ fun ImportSettingsItem(
                     style = MaterialTheme.typography.bodySmall,
                 )
             },
+            leadingContent = {
+                Icon(
+                    imageVector = Icons.Default.FileDownload,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
             trailingContent = {
                 Icon(
-                    imageVector = Icons.Filled.KeyboardArrowDown,
+                    imageVector = Icons.Filled.ExpandMore,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/LanguagePairSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/LanguagePairSettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +36,13 @@ fun LanguagePairSettingsItem(
                     stringResource(targetLanguage.displayNameRes),
                 ),
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.Translate,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/MixModeSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/MixModeSettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +36,13 @@ fun MixModeSettingsItem(
             Text(
                 modeText,
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.Shuffle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/NewPerDaySettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/NewPerDaySettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Style
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -28,6 +29,13 @@ fun NewPerDaySettingsItem(
             Text(
                 pluralStringResource(R.plurals.cards_count, value, value),
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.Style,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/OpenAiApiKeySettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/OpenAiApiKeySettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.VpnKey
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +35,13 @@ fun OpenAiApiKeySettingsItem(
             Text(
                 supporting,
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.VpnKey,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/OpenAiPromptSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/OpenAiPromptSettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -39,6 +40,13 @@ fun OpenAiPromptSettingsItem(
             Text(
                 supporting,
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.SmartToy,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/OpenAiReversePromptSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/OpenAiReversePromptSettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +48,13 @@ fun OpenAiReversePromptSettingsItem(
             Text(
                 supporting,
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.SmartToy,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ReviewPerDaySettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ReviewPerDaySettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -28,6 +29,13 @@ fun ReviewPerDaySettingsItem(
             Text(
                 pluralStringResource(R.plurals.cards_count, value, value),
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.Repeat,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ShowOverlayIntervalSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/ShowOverlayIntervalSettingsItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -28,6 +29,13 @@ fun ShowOverlayIntervalSettingsItem(
             Text(
                 pluralStringResource(R.plurals.overlay_minutes_interval, value, value),
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.Timer,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/StudyDirectionSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/StudyDirectionSettingsItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.CompareArrows
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -35,6 +36,13 @@ fun StudyDirectionSettingsItem(
             Text(
                 modeText,
                 style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.CompareArrows,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 openai-java = { module = "com.openai:openai-java", version.ref = "openaiJava" }
 androidx-test-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiAutomator" }


### PR DESCRIPTION
## Summary

- Several icons were reused for unrelated meanings across the app: `Edit` (pencil) appeared on the bottom-nav **Apps** tab and 6 different Settings rows, `List` appeared on the **Dojo** tab, the "view word list" button, and the WordList empty state, and `Refresh` was used for both "reset word progress" and "undo last review" (a genuine mismatch — undo looked like refresh).
- Gave each nav tab/row a purpose-built icon instead: Apps → `AppRegistration`, Dojo → `MenuBook`, Dojo undo → `Undo`, plus new leading icons on Settings rows (`Translate`, `Shuffle`, `CompareArrows`, `Style`, `Repeat`, `Timer`, `VpnKey`, `SmartToy`, `PlaylistAdd`) so each row is visually distinct instead of relying only on a shared trailing chevron/pencil.
- Standardized the Import/Export row expand icons (previously `KeyboardArrowDown` vs `ArrowDropDown` for the same action) on `ExpandMore`, with distinct `FileDownload`/`FileUpload` leading icons.
- Added the `androidx.compose.material:material-icons-extended` dependency (via the existing Compose BOM) since most of the more accurate icons aren't in the small core icon set bundled with `material3`.

## Test plan

- [x] `./gradlew compileDebugKotlin` — verifies all new icon references resolve
- [x] `./gradlew ktlintCheck detekt` — no style/static-analysis regressions
- [x] `./gradlew testDebugUnitTest` — all unit tests pass
- [ ] Manual click-through on a device/emulator (bottom nav, Settings screen, Add Word/Word List/Dojo screens) to visually confirm icon changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6ae6cnGgJxhXr2xrSzLEm)_