### PR TITLE
fix: avoid swallowed exception in OverlayAccessibilityService.hideOverlay

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
+++ b/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
@@ -337,13 +337,10 @@ class OverlayAccessibilityService : AccessibilityService() {
         requestAudioFocus()
     }
 
-    @Suppress("SwallowedException")
     private fun hideOverlay() {
         overlayView?.let {
-            try {
+            if (it.isAttachedToWindow) {
                 windowManager?.removeView(it)
-            } catch (e: IllegalArgumentException) {
-                // View not attached to window or already removed
             }
         }
         releaseAudioFocus()


### PR DESCRIPTION
## Summary
- `hideOverlay()` had `@Suppress("SwallowedException")` because `windowManager.removeView(view)` throws `IllegalArgumentException` when the view is already detached, and the catch block silently discarded it.
- Replaced the try/catch with a `View.isAttachedToWindow` guard before calling `removeView`, so the "already removed" case is checked up front instead of being handled via a caught-and-ignored exception.
- This preserves the original behavior (no-op if already detached, no crash) while removing both the swallowed exception and the now-unnecessary `@Suppress` annotation.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [ ] `./gradlew detekt` / `./gradlew :app:compileDebugKotlin` — could not run in this sandbox; the environment only has a JDK 21 toolchain and these tasks require a JDK 17 toolchain with no auto-provisioning configured. This is a pre-existing environment limitation unrelated to this change.
- [x] Manual review: `View.isAttachedToWindow` (API 19+) reflects the same attachment state `WindowManagerGlobal` checks before throwing, and the project's `minSdk` is 30, so this is safe to use.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JyP4xcEVNYN4qaDvyf5chZ)_