### PR TITLE
refactor: extract ExistingWordOverrideCoordinator from AddWordViewModel

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordUiStateUpdates.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordUiStateUpdates.kt
@@ -1,0 +1,126 @@
+package com.procrastilearn.app.ui
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Shared [AddWordUiState] mutation shapes for the different ways the add-word flow can end,
+ * split out from [AddWordViewModel] so that file stays under detekt's top-level function
+ * threshold once the existing-word-conflict handling moved into [ExistingWordOverrideCoordinator].
+ */
+internal fun closeExistingWordDialogWithError(
+    uiState: MutableStateFlow<AddWordUiState>,
+    message: String,
+) {
+    uiState.value =
+        uiState.value.copy(
+            isExistingWordDialogVisible = false,
+            isExistingWordDialogLoading = false,
+            existingWordDialogWord = null,
+            errorMessage = message,
+        )
+}
+
+internal fun showExistingWordDialog(
+    uiState: MutableStateFlow<AddWordUiState>,
+    word: String,
+) {
+    uiState.value =
+        uiState.value.copy(
+            isLoading = false,
+            loadingAction = null,
+            errorMessage = null,
+            isExistingWordDialogVisible = true,
+            existingWordDialogWord = word,
+            isExistingWordDialogLoading = false,
+            isPreviewVisible = false,
+        )
+}
+
+internal fun applyLookupFailure(
+    uiState: MutableStateFlow<AddWordUiState>,
+    message: String,
+) {
+    uiState.value =
+        uiState.value.copy(
+            isLoading = false,
+            loadingAction = null,
+            errorMessage = message,
+            isExistingWordDialogVisible = false,
+            isExistingWordDialogLoading = false,
+        )
+}
+
+// Shared by the "brand new word" add and the "user already acknowledged this override" submit -
+// both end the add-word flow the same way, differing only in which success string is shown.
+internal fun applySubmissionSuccess(
+    uiState: MutableStateFlow<AddWordUiState>,
+    successMessage: String,
+) {
+    uiState.value =
+        uiState.value
+            .copy(
+                isLoading = false,
+                errorMessage = null,
+                wordError = null,
+                translationError = null,
+                word = "",
+                translation = "",
+                previewContent = null,
+                isPreviewVisible = false,
+                isSuccess = true,
+                successMessage = successMessage,
+                loadingAction = null,
+                isExistingWordDialogVisible = false,
+                isExistingWordDialogLoading = false,
+                existingWordDialogWord = null,
+            ).withBidirectionalCleared()
+}
+
+internal fun applySubmissionFailure(
+    uiState: MutableStateFlow<AddWordUiState>,
+    message: String,
+    fromPreview: Boolean,
+) {
+    uiState.value =
+        uiState.value.copy(
+            isLoading = false,
+            loadingAction = null,
+            errorMessage = message,
+            isPreviewVisible = fromPreview && uiState.value.previewContent != null,
+        )
+}
+
+// The existing-word dialog's own success shape differs from applySubmissionSuccess: it doesn't
+// touch wordError/translationError, since nothing in the dialog flow can set them.
+internal fun applyExistingWordDialogSuccess(
+    uiState: MutableStateFlow<AddWordUiState>,
+    successMessage: String,
+) {
+    uiState.value =
+        uiState.value
+            .copy(
+                isExistingWordDialogVisible = false,
+                isExistingWordDialogLoading = false,
+                existingWordDialogWord = null,
+                word = "",
+                translation = "",
+                previewContent = null,
+                isPreviewVisible = false,
+                isSuccess = true,
+                successMessage = successMessage,
+                isLoading = false,
+                loadingAction = null,
+            ).withBidirectionalCleared()
+}
+
+internal fun setBlankTranslationError(
+    uiState: MutableStateFlow<AddWordUiState>,
+    message: String,
+) {
+    uiState.value =
+        uiState.value.copy(
+            isLoading = false,
+            translationError = message,
+            loadingAction = null,
+        )
+}

--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordUiStateUpdates.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordUiStateUpdates.kt
@@ -2,11 +2,6 @@ package com.procrastilearn.app.ui
 
 import kotlinx.coroutines.flow.MutableStateFlow
 
-/**
- * Shared [AddWordUiState] mutation shapes for the different ways the add-word flow can end,
- * split out from [AddWordViewModel] so that file stays under detekt's top-level function
- * threshold once the existing-word-conflict handling moved into [ExistingWordOverrideCoordinator].
- */
 internal fun closeExistingWordDialogWithError(
     uiState: MutableStateFlow<AddWordUiState>,
     message: String,
@@ -50,8 +45,6 @@ internal fun applyLookupFailure(
         )
 }
 
-// Shared by the "brand new word" add and the "user already acknowledged this override" submit -
-// both end the add-word flow the same way, differing only in which success string is shown.
 internal fun applySubmissionSuccess(
     uiState: MutableStateFlow<AddWordUiState>,
     successMessage: String,
@@ -90,8 +83,6 @@ internal fun applySubmissionFailure(
         )
 }
 
-// The existing-word dialog's own success shape differs from applySubmissionSuccess: it doesn't
-// touch wordError/translationError, since nothing in the dialog flow can set them.
 internal fun applyExistingWordDialogSuccess(
     uiState: MutableStateFlow<AddWordUiState>,
     successMessage: String,

--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("LargeClass", "TooManyFunctions")
+@Suppress("LongParameterList") // arity from composing already-decomposed collaborators, not an undecomposed monolith
 class AddWordViewModel @Inject
     constructor(
         private val vocabularyEntryUseCases: VocabularyEntryUseCases,
@@ -37,11 +37,10 @@ class AddWordViewModel @Inject
         private val generateAiTranslationUseCase: GenerateAiTranslationUseCase,
         private val connectivityObserver: NetworkConnectivityObserver,
         @ApplicationContext private val context: Context,
+        private val existingWordOverrideCoordinator: ExistingWordOverrideCoordinator,
         private val processTextEventBus: ProcessTextEventBus = ProcessTextEventBus(),
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(AddWordUiState())
-        private var pendingOverride: PendingOverrideSubmission? = null
-        private var acknowledgedOverrideWord: String? = null
         val uiState: StateFlow<AddWordUiState> = _uiState.asStateFlow()
 
         init {
@@ -96,8 +95,7 @@ class AddWordViewModel @Inject
                     if (!text.isNullOrBlank()) {
                         val prefill = resolveProcessTextPrefill(translationPreferences.openAiStore, text)
                         if (prefill != null) {
-                            acknowledgedOverrideWord = null
-                            pendingOverride = null
+                            existingWordOverrideCoordinator.resetForNewWord()
                             _uiState.value =
                                 _uiState.value.copy(
                                     word = prefill.word,
@@ -123,7 +121,7 @@ class AddWordViewModel @Inject
         }
 
         fun onWordChange(word: String) {
-            acknowledgedOverrideWord = null
+            existingWordOverrideCoordinator.clearAcknowledgement()
             _uiState.value =
                 _uiState.value.copy(
                     word = word,
@@ -184,23 +182,22 @@ class AddWordViewModel @Inject
                 }
 
                 // AI mode: check for a duplicate before spending an AI request.
-                val lookupFailedMessage = context.getString(R.string.add_word_error_lookup_failed)
-                val existingItem =
-                    lookupExistingItem(vocabularyEntryUseCases.getByWord, _uiState, word, lookupFailedMessage)
-                        .getOrElse { return@launch }
-
-                if (existingItem != null) {
-                    promptExistingWordOverride(
-                        existingItem = existingItem,
-                        word = word,
-                        translation = null,
-                        direction = currentState.translationDirection,
-                        fromPreview = false,
-                    )
-                    return@launch
+                when (
+                    val preflight =
+                        existingWordOverrideCoordinator.checkBeforeAiTranslationRequest(word, currentState.translationDirection)
+                ) {
+                    is ExistingWordPreflight.LookupFailed -> {
+                        applyLookupFailure(_uiState, preflight.error.message ?: context.getString(R.string.add_word_error_lookup_failed))
+                        return@launch
+                    }
+                    is ExistingWordPreflight.ConfirmationRequired -> {
+                        showExistingWordDialog(_uiState, preflight.word)
+                        return@launch
+                    }
+                    ExistingWordPreflight.NoConflict -> Unit
                 }
 
-                val finalTranslation = resolveTranslationForAdd(currentState)
+                val finalTranslation = resolveTranslationForAdd(_uiState, generateAiTranslationUseCase, currentState)
 
                 if (finalTranslation.isBlank()) {
                     setBlankTranslationError(_uiState, context.getString(R.string.add_word_error_translation_required))
@@ -208,27 +205,6 @@ class AddWordViewModel @Inject
                 }
 
                 submitNewVocabularyItem(word, finalTranslation.trim(), fromPreview = false)
-            }
-        }
-
-        private suspend fun resolveTranslationForAdd(currentState: AddWordUiState): String {
-            val aiTranslation: String? =
-                if (currentState.aiModeActive) {
-                    runCatching {
-                        generateAiTranslationUseCase(
-                            currentState.word,
-                            currentState.translationDirection,
-                        )
-                    }.getOrNull()
-                } else {
-                    null
-                }
-
-            return if (!aiTranslation.isNullOrBlank()) {
-                _uiState.value = _uiState.value.copy(translation = aiTranslation)
-                aiTranslation
-            } else {
-                currentState.translation
             }
         }
 
@@ -247,34 +223,34 @@ class AddWordViewModel @Inject
                 )
         }
 
-    fun onUseAiToggle(checked: Boolean) {
-        acknowledgedOverrideWord = null
-        viewModelScope.launch { translationPreferences.openAiStore.setUseAiForTranslation(checked) }
-        _uiState.value =
-            _uiState.value.copy(
-                useAiForTranslation = checked,
-                previewContent = null,
-                isPreviewVisible = false,
-            )
-    }
+        fun onUseAiToggle(checked: Boolean) {
+            existingWordOverrideCoordinator.clearAcknowledgement()
+            viewModelScope.launch { translationPreferences.openAiStore.setUseAiForTranslation(checked) }
+            _uiState.value =
+                _uiState.value.copy(
+                    useAiForTranslation = checked,
+                    previewContent = null,
+                    isPreviewVisible = false,
+                )
+        }
 
-    fun onTranslationDirectionToggle() {
-        acknowledgedOverrideWord = null
-        val current = _uiState.value.translationDirection
-        val next =
-            if (current == AiTranslationDirection.TARGET_TO_NATIVE) {
-                AiTranslationDirection.NATIVE_TO_TARGET
-            } else {
-                AiTranslationDirection.TARGET_TO_NATIVE
-            }
-        viewModelScope.launch { translationPreferences.openAiStore.setAiTranslationDirection(next) }
-        _uiState.value =
-            _uiState.value.copy(
-                translationDirection = next,
-                previewContent = null,
-                isPreviewVisible = false,
-            )
-    }
+        fun onTranslationDirectionToggle() {
+            existingWordOverrideCoordinator.clearAcknowledgement()
+            val current = _uiState.value.translationDirection
+            val next =
+                if (current == AiTranslationDirection.TARGET_TO_NATIVE) {
+                    AiTranslationDirection.NATIVE_TO_TARGET
+                } else {
+                    AiTranslationDirection.TARGET_TO_NATIVE
+                }
+            viewModelScope.launch { translationPreferences.openAiStore.setAiTranslationDirection(next) }
+            _uiState.value =
+                _uiState.value.copy(
+                    translationDirection = next,
+                    previewContent = null,
+                    isPreviewVisible = false,
+                )
+        }
 
         fun onBidirectionalToggle(checked: Boolean) {
             _uiState.value = _uiState.value.withBidirectionalToggle(checked)
@@ -292,7 +268,7 @@ class AddWordViewModel @Inject
             _uiState.value = _uiState.value.copy(backwardAnswerOverride = value)
         }
 
-    fun onPreviewClick() {
+        fun onPreviewClick() {
             val currentState = _uiState.value
             if (currentState.word.isBlank()) {
                 _uiState.value = _uiState.value.copy(wordError = context.getString(R.string.add_word_error_word_required))
@@ -339,9 +315,10 @@ class AddWordViewModel @Inject
                     return@launch
                 }
 
+                val blankTranslationMessage = context.getString(R.string.add_word_error_translation_required)
                 runCatching { generateAiTranslationUseCase(word, currentState.translationDirection) }.fold(
                     onSuccess = { translation ->
-                        handlePreviewTranslationSuccess(word, translation, isStoredTranslation = false)
+                        handlePreviewTranslationSuccess(_uiState, word, translation, isStoredTranslation = false, blankTranslationMessage)
                     },
                     onFailure = { error ->
                         _uiState.value =
@@ -373,8 +350,14 @@ class AddWordViewModel @Inject
                     generateAiTranslationUseCase(preview.word, currentState.translationDirection)
                 }.fold(
                     onSuccess = { translation ->
-                        acknowledgedOverrideWord = preview.word
-                        handlePreviewTranslationSuccess(preview.word, translation, isStoredTranslation = false)
+                        existingWordOverrideCoordinator.acknowledge(preview.word)
+                        handlePreviewTranslationSuccess(
+                            _uiState,
+                            preview.word,
+                            translation,
+                            isStoredTranslation = false,
+                            blankTranslationMessage = context.getString(R.string.add_word_error_translation_required),
+                        )
                     },
                     onFailure = { error ->
                         _uiState.value =
@@ -390,41 +373,8 @@ class AddWordViewModel @Inject
             }
         }
 
-        private fun handlePreviewTranslationSuccess(
-            word: String,
-            translation: String,
-            isStoredTranslation: Boolean,
-        ) {
-            val sanitizedTranslation = translation.trim()
-            if (sanitizedTranslation.isBlank()) {
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = false,
-                        translationError = context.getString(R.string.add_word_error_translation_required),
-                        loadingAction = null,
-                        previewContent = null,
-                        isPreviewVisible = false,
-                    )
-            } else {
-                _uiState.value =
-                    _uiState.value.copy(
-                        isLoading = false,
-                        translation = sanitizedTranslation,
-                        previewContent =
-                            AddWordPreviewContent(
-                                word = word.trim(),
-                                translation = sanitizedTranslation,
-                                isStoredTranslation = isStoredTranslation,
-                            ),
-                        isPreviewVisible = true,
-                        loadingAction = null,
-                    )
-            }
-        }
-
         fun onPreviewCancel() {
-            pendingOverride = null
-            acknowledgedOverrideWord = null
+            existingWordOverrideCoordinator.resetForNewWord()
             _uiState.value =
                 _uiState.value
                     .copy(
@@ -446,9 +396,8 @@ class AddWordViewModel @Inject
         }
 
         fun onExistingWordDialogCancel() {
-            val pending = pendingOverride
-            pendingOverride = null
-            val restorePreview = pending?.fromPreview == true && _uiState.value.previewContent != null
+            val fromPreview = existingWordOverrideCoordinator.cancelPendingOverride()
+            val restorePreview = fromPreview && _uiState.value.previewContent != null
             _uiState.value =
                 _uiState.value.copy(
                     isExistingWordDialogVisible = false,
@@ -458,9 +407,8 @@ class AddWordViewModel @Inject
                 )
         }
 
-        @Suppress("LongMethod")
         fun onExistingWordDialogProceed() {
-            val pending = pendingOverride ?: return
+            if (!existingWordOverrideCoordinator.hasPendingOverride()) return
             viewModelScope.launch {
                 _uiState.value =
                     _uiState.value.copy(
@@ -469,56 +417,24 @@ class AddWordViewModel @Inject
                         successMessage = null,
                     )
 
-                val translationFailedMessage = context.getString(R.string.add_word_error_translation_failed)
-                val translation =
-                    resolvePendingTranslation(
-                        generateAiTranslationUseCase,
-                        pending.word,
-                        pending.translation,
-                        pending.direction,
-                        translationFailedMessage,
-                    ).getOrElse { error ->
-                        pendingOverride = null
-                        closeExistingWordDialogWithError(_uiState, error.message ?: translationFailedMessage)
-                        return@launch
-                    }
-
-                val currentState = _uiState.value
-                vocabularyEntryUseCases.override(
-                    existingItem = pending.existingItem,
-                    newWord = pending.word,
-                    newTranslation = translation,
-                    bidirectional = currentState.bidirectional,
-                    backwardPromptOverride = currentState.backwardPromptOverride.ifBlank { null },
-                    backwardAnswerOverride = currentState.backwardAnswerOverride.ifBlank { null },
-                ).fold(
-                    onSuccess = {
-                        pendingOverride = null
-                        acknowledgedOverrideWord = null
-                        _uiState.value =
-                            _uiState.value
-                                .copy(
-                                    isExistingWordDialogVisible = false,
-                                    isExistingWordDialogLoading = false,
-                                    existingWordDialogWord = null,
-                                    word = "",
-                                    translation = "",
-                                    previewContent = null,
-                                    isPreviewVisible = false,
-                                    isSuccess = true,
-                                    successMessage = context.getString(R.string.add_word_success_updated),
-                                    isLoading = false,
-                                    loadingAction = null,
-                                ).withBidirectionalCleared()
-                    },
-                    onFailure = { error ->
-                        pendingOverride = null
+                when (
+                    val result =
+                        existingWordOverrideCoordinator.proceedWithPendingOverride { _uiState.value.toCardOptions() }
+                ) {
+                    OverrideProceedResult.NoPendingOverride -> Unit
+                    is OverrideProceedResult.TranslationFailed ->
                         closeExistingWordDialogWithError(
                             _uiState,
-                            error.message ?: context.getString(R.string.add_word_error_update_failed),
+                            result.error.message ?: context.getString(R.string.add_word_error_translation_failed),
                         )
-                    },
-                )
+                    is OverrideProceedResult.OverrideFailed ->
+                        closeExistingWordDialogWithError(
+                            _uiState,
+                            result.error.message ?: context.getString(R.string.add_word_error_update_failed),
+                        )
+                    OverrideProceedResult.Overridden ->
+                        applyExistingWordDialogSuccess(_uiState, context.getString(R.string.add_word_success_updated))
+                }
             }
         }
 
@@ -528,100 +444,27 @@ class AddWordViewModel @Inject
             fromPreview: Boolean,
         ) {
             val direction = _uiState.value.translationDirection
-            val existingItem =
-                lookupExistingItem(
-                    vocabularyEntryUseCases.getByWord,
-                    _uiState,
-                    word,
-                    context.getString(R.string.add_word_error_lookup_failed),
-                ).getOrElse { return }
-
-            if (existingItem != null) {
-                if (isAcknowledgedOverride(word, acknowledgedOverrideWord)) {
-                    submitAcknowledgedOverride(existingItem, word, translation, fromPreview)
-                } else {
-                    promptExistingWordOverride(existingItem, word, translation, direction, fromPreview)
-                }
-                return
+            when (
+                val resolution =
+                    existingWordOverrideCoordinator.resolveForSubmission(word, translation, direction, fromPreview) {
+                        _uiState.value.toCardOptions()
+                    }
+            ) {
+                is SubmissionResolution.LookupFailed ->
+                    applyLookupFailure(_uiState, resolution.error.message ?: context.getString(R.string.add_word_error_lookup_failed))
+                is SubmissionResolution.ConfirmationRequired ->
+                    showExistingWordDialog(_uiState, resolution.word)
+                is SubmissionResolution.Overridden ->
+                    applySubmissionSuccess(_uiState, context.getString(R.string.add_word_success_updated))
+                is SubmissionResolution.OverrideFailed ->
+                    applySubmissionFailure(
+                        _uiState,
+                        resolution.error.message ?: context.getString(R.string.add_word_error_update_failed),
+                        resolution.fromPreview,
+                    )
+                SubmissionResolution.NoConflict ->
+                    submitNewVocabularyItem(word, translation, fromPreview)
             }
-
-            submitNewVocabularyItem(word, translation, fromPreview)
-        }
-
-        private suspend fun submitAcknowledgedOverride(
-            existingItem: VocabularyItem,
-            word: String,
-            translation: String,
-            fromPreview: Boolean,
-        ) {
-            val currentState = _uiState.value
-            vocabularyEntryUseCases.override(
-                existingItem = existingItem,
-                newWord = word,
-                newTranslation = translation,
-                bidirectional = currentState.bidirectional,
-                backwardPromptOverride = currentState.backwardPromptOverride.ifBlank { null },
-                backwardAnswerOverride = currentState.backwardAnswerOverride.ifBlank { null },
-            ).fold(
-                onSuccess = {
-                    acknowledgedOverrideWord = null
-                    _uiState.value =
-                        _uiState.value
-                            .copy(
-                                isLoading = false,
-                                errorMessage = null,
-                                wordError = null,
-                                translationError = null,
-                                word = "",
-                                translation = "",
-                                previewContent = null,
-                                isPreviewVisible = false,
-                                isSuccess = true,
-                                successMessage = context.getString(R.string.add_word_success_updated),
-                                loadingAction = null,
-                                isExistingWordDialogVisible = false,
-                                isExistingWordDialogLoading = false,
-                                existingWordDialogWord = null,
-                            ).withBidirectionalCleared()
-                },
-                onFailure = { error ->
-                    acknowledgedOverrideWord = null
-                    _uiState.value =
-                        _uiState.value.copy(
-                            isLoading = false,
-                            loadingAction = null,
-                            errorMessage = error.message ?: context.getString(R.string.add_word_error_update_failed),
-                            isPreviewVisible = fromPreview && _uiState.value.previewContent != null,
-                        )
-                },
-            )
-        }
-
-        private fun promptExistingWordOverride(
-            existingItem: VocabularyItem,
-            word: String,
-            translation: String?,
-            direction: AiTranslationDirection,
-            fromPreview: Boolean,
-        ) {
-            pendingOverride =
-                PendingOverrideSubmission(
-                    existingItem = existingItem,
-                    word = word,
-                    translation = translation,
-                    direction = direction,
-                    fromPreview = fromPreview,
-                )
-            _uiState.value =
-                _uiState.value.copy(
-                    isLoading = false,
-                    loadingAction = null,
-                    errorMessage = null,
-                    isExistingWordDialogVisible = true,
-                    existingWordDialogWord = word,
-                    isExistingWordDialogLoading = false,
-                    isPreviewVisible = false,
-                )
         }
 
         private suspend fun submitNewVocabularyItem(
@@ -638,33 +481,10 @@ class AddWordViewModel @Inject
                 backwardAnswerOverride = currentState.backwardAnswerOverride.ifBlank { null },
             ).fold(
                 onSuccess = {
-                    _uiState.value =
-                        _uiState.value
-                            .copy(
-                                isLoading = false,
-                                errorMessage = null,
-                                wordError = null,
-                                translationError = null,
-                                word = "",
-                                translation = "",
-                                previewContent = null,
-                                isPreviewVisible = false,
-                                isSuccess = true,
-                                successMessage = context.getString(R.string.add_word_success_added),
-                                loadingAction = null,
-                                isExistingWordDialogVisible = false,
-                                isExistingWordDialogLoading = false,
-                                existingWordDialogWord = null,
-                            ).withBidirectionalCleared()
+                    applySubmissionSuccess(_uiState, context.getString(R.string.add_word_success_added))
                 },
                 onFailure = { error ->
-                    _uiState.value =
-                        _uiState.value.copy(
-                            isLoading = false,
-                            errorMessage = error.message ?: context.getString(R.string.add_word_error_add_failed),
-                            loadingAction = null,
-                            isPreviewVisible = fromPreview && _uiState.value.previewContent != null,
-                        )
+                    applySubmissionFailure(_uiState, error.message ?: context.getString(R.string.add_word_error_add_failed), fromPreview)
                 },
             )
         }
@@ -675,14 +495,6 @@ class AddWordViewModel @Inject
             val direction: AiTranslationDirection,
             val nativeLanguage: Language,
             val targetLanguage: Language,
-        )
-
-        private data class PendingOverrideSubmission(
-            val existingItem: VocabularyItem,
-            val word: String,
-            val translation: String?,
-            val direction: AiTranslationDirection,
-            val fromPreview: Boolean,
         )
 
         fun onPreviewConfirmAdd() {
@@ -758,6 +570,13 @@ internal fun AddWordUiState.withBidirectionalToggle(checked: Boolean): AddWordUi
         backwardAnswerOverride = if (checked) backwardAnswerOverride else "",
     )
 
+internal fun AddWordUiState.toCardOptions(): BidirectionalCardOptions =
+    BidirectionalCardOptions(
+        bidirectional = bidirectional,
+        backwardPromptOverride = backwardPromptOverride.ifBlank { null },
+        backwardAnswerOverride = backwardAnswerOverride.ifBlank { null },
+    )
+
 data class AddWordPreviewContent(
     val word: String,
     val translation: String,
@@ -774,36 +593,6 @@ enum class AddWordLoadingAction {
     PREVIEW,
     PREVIEW_CONFIRM,
     PREVIEW_REGENERATE,
-}
-
-internal fun isAcknowledgedOverride(
-    word: String,
-    acknowledgedWord: String?,
-): Boolean = acknowledgedWord?.equals(word, ignoreCase = true) == true
-
-internal fun closeExistingWordDialogWithError(
-    uiState: MutableStateFlow<AddWordUiState>,
-    message: String,
-) {
-    uiState.value =
-        uiState.value.copy(
-            isExistingWordDialogVisible = false,
-            isExistingWordDialogLoading = false,
-            existingWordDialogWord = null,
-            errorMessage = message,
-        )
-}
-
-internal fun setBlankTranslationError(
-    uiState: MutableStateFlow<AddWordUiState>,
-    message: String,
-) {
-    uiState.value =
-        uiState.value.copy(
-            isLoading = false,
-            translationError = message,
-            loadingAction = null,
-        )
 }
 
 internal suspend fun queuePendingWord(
@@ -835,30 +624,66 @@ internal suspend fun lookupExistingItem(
     failureMessage: String,
 ): Result<VocabularyItem?> =
     runCatching { getVocabularyItemByWordUseCase(word) }
-        .onFailure { error ->
-            uiState.value =
-                uiState.value.copy(
-                    isLoading = false,
-                    loadingAction = null,
-                    errorMessage = error.message ?: failureMessage,
-                    isExistingWordDialogVisible = false,
-                    isExistingWordDialogLoading = false,
+        .onFailure { error -> applyLookupFailure(uiState, error.message ?: failureMessage) }
+
+internal suspend fun resolveTranslationForAdd(
+    uiState: MutableStateFlow<AddWordUiState>,
+    generateAiTranslationUseCase: GenerateAiTranslationUseCase,
+    currentState: AddWordUiState,
+): String {
+    val aiTranslation: String? =
+        if (currentState.aiModeActive) {
+            runCatching {
+                generateAiTranslationUseCase(
+                    currentState.word,
+                    currentState.translationDirection,
                 )
+            }.getOrNull()
+        } else {
+            null
         }
 
-internal suspend fun resolvePendingTranslation(
-    generateAiTranslationUseCase: GenerateAiTranslationUseCase,
-    word: String,
-    translation: String?,
-    direction: AiTranslationDirection,
-    blankResultMessage: String,
-): Result<String> =
-    if (translation != null) {
-        Result.success(translation)
+    return if (!aiTranslation.isNullOrBlank()) {
+        uiState.value = uiState.value.copy(translation = aiTranslation)
+        aiTranslation
     } else {
-        runCatching { generateAiTranslationUseCase(word, direction) }
-            .mapCatching { generated -> generated.trim().ifBlank { error(blankResultMessage) } }
+        currentState.translation
     }
+}
+
+internal fun handlePreviewTranslationSuccess(
+    uiState: MutableStateFlow<AddWordUiState>,
+    word: String,
+    translation: String,
+    isStoredTranslation: Boolean,
+    blankTranslationMessage: String,
+) {
+    val sanitizedTranslation = translation.trim()
+    if (sanitizedTranslation.isBlank()) {
+        uiState.value =
+            uiState.value.copy(
+                isLoading = false,
+                translationError = blankTranslationMessage,
+                loadingAction = null,
+                previewContent = null,
+                isPreviewVisible = false,
+            )
+    } else {
+        uiState.value =
+            uiState.value.copy(
+                isLoading = false,
+                translation = sanitizedTranslation,
+                previewContent =
+                    AddWordPreviewContent(
+                        word = word.trim(),
+                        translation = sanitizedTranslation,
+                        isStoredTranslation = isStoredTranslation,
+                    ),
+                isPreviewVisible = true,
+                loadingAction = null,
+            )
+    }
+}
 
 internal data class ProcessTextPrefill(
     val word: String,

--- a/app/src/main/java/com/procrastilearn/app/ui/ExistingWordOverrideCoordinator.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/ExistingWordOverrideCoordinator.kt
@@ -1,0 +1,206 @@
+package com.procrastilearn.app.ui
+
+import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.VocabularyItem
+import com.procrastilearn.app.domain.usecase.GenerateAiTranslationUseCase
+import com.procrastilearn.app.domain.usecase.VocabularyEntryUseCases
+import javax.inject.Inject
+
+data class BidirectionalCardOptions(
+    val bidirectional: Boolean,
+    val backwardPromptOverride: String?,
+    val backwardAnswerOverride: String?,
+)
+
+sealed interface ExistingWordPreflight {
+    data object NoConflict : ExistingWordPreflight
+
+    data class ConfirmationRequired(val word: String) : ExistingWordPreflight
+
+    data class LookupFailed(val error: Throwable) : ExistingWordPreflight
+}
+
+sealed interface SubmissionResolution {
+    data object NoConflict : SubmissionResolution
+
+    data class ConfirmationRequired(val word: String) : SubmissionResolution
+
+    data class Overridden(val fromPreview: Boolean) : SubmissionResolution
+
+    data class OverrideFailed(val error: Throwable, val fromPreview: Boolean) : SubmissionResolution
+
+    data class LookupFailed(val error: Throwable) : SubmissionResolution
+}
+
+sealed interface OverrideProceedResult {
+    data object NoPendingOverride : OverrideProceedResult
+
+    data object Overridden : OverrideProceedResult
+
+    data class TranslationFailed(val error: Throwable) : OverrideProceedResult
+
+    data class OverrideFailed(val error: Throwable) : OverrideProceedResult
+}
+
+/**
+ * Owns the "word already exists" conflict flow for the add-word screen: deciding whether to
+ * silently re-apply an override the user already acknowledged this session, or to pause and
+ * wait for the user to confirm via the existing-word dialog.
+ */
+class ExistingWordOverrideCoordinator
+    @Inject
+    constructor(
+        private val vocabularyEntryUseCases: VocabularyEntryUseCases,
+        private val generateAiTranslationUseCase: GenerateAiTranslationUseCase,
+    ) {
+        private data class PendingOverrideSubmission(
+            val existingItem: VocabularyItem,
+            val word: String,
+            val translation: String?,
+            val direction: AiTranslationDirection,
+            val fromPreview: Boolean,
+        )
+
+        private var pendingOverride: PendingOverrideSubmission? = null
+        private var acknowledgedOverrideWord: String? = null
+
+        fun hasPendingOverride(): Boolean = pendingOverride != null
+
+        fun resetForNewWord() {
+            pendingOverride = null
+            acknowledgedOverrideWord = null
+        }
+
+        fun clearAcknowledgement() {
+            acknowledgedOverrideWord = null
+        }
+
+        fun acknowledge(word: String) {
+            acknowledgedOverrideWord = word
+        }
+
+        /** Clears any pending override and reports whether it originated from the preview flow. */
+        fun cancelPendingOverride(): Boolean {
+            val fromPreview = pendingOverride?.fromPreview == true
+            pendingOverride = null
+            return fromPreview
+        }
+
+        /**
+         * Duplicate check used only by the AI-mode "Add" pre-flight, ahead of spending an AI
+         * translation request. Intentionally does not honor [acknowledge] - unlike
+         * [resolveForSubmission], this path always re-confirms with the user on conflict, matching
+         * this screen's existing behavior.
+         */
+        suspend fun checkBeforeAiTranslationRequest(
+            word: String,
+            direction: AiTranslationDirection,
+        ): ExistingWordPreflight {
+            val existingItem =
+                runCatching { vocabularyEntryUseCases.getByWord(word) }
+                    .getOrElse { return ExistingWordPreflight.LookupFailed(it) }
+                    ?: return ExistingWordPreflight.NoConflict
+
+            pendingOverride =
+                PendingOverrideSubmission(
+                    existingItem = existingItem,
+                    word = word,
+                    translation = null,
+                    direction = direction,
+                    fromPreview = false,
+                )
+            return ExistingWordPreflight.ConfirmationRequired(word)
+        }
+
+        /**
+         * [resolveCardOptions] is a supplier, not a plain value, and is only invoked once an
+         * override is actually about to be applied - after the (suspending) duplicate lookup
+         * completes - so it reflects the freshest bidirectional-card state, matching this
+         * screen's existing behavior of re-reading `uiState` right before submitting rather than
+         * using a value captured before the lookup started.
+         */
+        suspend fun resolveForSubmission(
+            word: String,
+            translation: String,
+            direction: AiTranslationDirection,
+            fromPreview: Boolean,
+            resolveCardOptions: () -> BidirectionalCardOptions,
+        ): SubmissionResolution =
+            runCatching { vocabularyEntryUseCases.getByWord(word) }.fold(
+                onSuccess = { existingItem ->
+                    when {
+                        existingItem == null -> SubmissionResolution.NoConflict
+                        acknowledgedOverrideWord?.equals(word, ignoreCase = true) != true -> {
+                            pendingOverride =
+                                PendingOverrideSubmission(
+                                    existingItem = existingItem,
+                                    word = word,
+                                    translation = translation,
+                                    direction = direction,
+                                    fromPreview = fromPreview,
+                                )
+                            SubmissionResolution.ConfirmationRequired(word)
+                        }
+                        else ->
+                            applyOverride(existingItem, word, translation, resolveCardOptions())
+                                .also { acknowledgedOverrideWord = null }
+                                .fold(
+                                    onSuccess = { SubmissionResolution.Overridden(fromPreview) },
+                                    onFailure = { error -> SubmissionResolution.OverrideFailed(error, fromPreview) },
+                                )
+                    }
+                },
+                onFailure = { SubmissionResolution.LookupFailed(it) },
+            )
+
+        suspend fun proceedWithPendingOverride(resolveCardOptions: () -> BidirectionalCardOptions): OverrideProceedResult {
+            val pending = pendingOverride ?: return OverrideProceedResult.NoPendingOverride
+
+            val translation =
+                resolvePendingTranslation(pending).getOrElse { error ->
+                    pendingOverride = null
+                    return OverrideProceedResult.TranslationFailed(error)
+                }
+
+            return applyOverride(pending.existingItem, pending.word, translation, resolveCardOptions()).fold(
+                onSuccess = {
+                    pendingOverride = null
+                    acknowledgedOverrideWord = null
+                    OverrideProceedResult.Overridden
+                },
+                onFailure = { error ->
+                    pendingOverride = null
+                    OverrideProceedResult.OverrideFailed(error)
+                },
+            )
+        }
+
+        /**
+         * Message-less on purpose: the ViewModel falls back to a localized string via
+         * `error.message ?: context.getString(...)` for every failure this coordinator reports, so
+         * a synthetic "blank AI result" failure must leave `message` null to let that fallback apply
+         * - unlike a real thrown exception from [generateAiTranslationUseCase], whose message (e.g.
+         * "Missing OpenAI API key") should surface as-is.
+         */
+        private class BlankAiTranslationException : Exception()
+
+        private suspend fun resolvePendingTranslation(pending: PendingOverrideSubmission): Result<String> =
+            pending.translation?.let { Result.success(it) }
+                ?: runCatching { generateAiTranslationUseCase(pending.word, pending.direction) }
+                    .mapCatching { generated -> generated.trim().ifBlank { throw BlankAiTranslationException() } }
+
+        private suspend fun applyOverride(
+            existingItem: VocabularyItem,
+            word: String,
+            translation: String,
+            cardOptions: BidirectionalCardOptions,
+        ): Result<Unit> =
+            vocabularyEntryUseCases.override(
+                existingItem = existingItem,
+                newWord = word,
+                newTranslation = translation,
+                bidirectional = cardOptions.bidirectional,
+                backwardPromptOverride = cardOptions.backwardPromptOverride,
+                backwardAnswerOverride = cardOptions.backwardAnswerOverride,
+            )
+    }

--- a/app/src/main/java/com/procrastilearn/app/ui/ExistingWordOverrideCoordinator.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/ExistingWordOverrideCoordinator.kt
@@ -79,19 +79,12 @@ class ExistingWordOverrideCoordinator
             acknowledgedOverrideWord = word
         }
 
-        /** Clears any pending override and reports whether it originated from the preview flow. */
         fun cancelPendingOverride(): Boolean {
             val fromPreview = pendingOverride?.fromPreview == true
             pendingOverride = null
             return fromPreview
         }
 
-        /**
-         * Duplicate check used only by the AI-mode "Add" pre-flight, ahead of spending an AI
-         * translation request. Intentionally does not honor [acknowledge] - unlike
-         * [resolveForSubmission], this path always re-confirms with the user on conflict, matching
-         * this screen's existing behavior.
-         */
         suspend fun checkBeforeAiTranslationRequest(
             word: String,
             direction: AiTranslationDirection,
@@ -112,13 +105,6 @@ class ExistingWordOverrideCoordinator
             return ExistingWordPreflight.ConfirmationRequired(word)
         }
 
-        /**
-         * [resolveCardOptions] is a supplier, not a plain value, and is only invoked once an
-         * override is actually about to be applied - after the (suspending) duplicate lookup
-         * completes - so it reflects the freshest bidirectional-card state, matching this
-         * screen's existing behavior of re-reading `uiState` right before submitting rather than
-         * using a value captured before the lookup started.
-         */
         suspend fun resolveForSubmission(
             word: String,
             translation: String,
@@ -175,13 +161,6 @@ class ExistingWordOverrideCoordinator
             )
         }
 
-        /**
-         * Message-less on purpose: the ViewModel falls back to a localized string via
-         * `error.message ?: context.getString(...)` for every failure this coordinator reports, so
-         * a synthetic "blank AI result" failure must leave `message` null to let that fallback apply
-         * - unlike a real thrown exception from [generateAiTranslationUseCase], whose message (e.g.
-         * "Missing OpenAI API key") should surface as-is.
-         */
         private class BlankAiTranslationException : Exception()
 
         private suspend fun resolvePendingTranslation(pending: PendingOverrideSubmission): Result<String> =

--- a/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelProcessTextTest.kt
@@ -120,16 +120,20 @@ class AddWordViewModelProcessTextTest {
         clearAllMocks()
     }
 
-    private fun buildViewModel(): AddWordViewModel =
-        AddWordViewModel(
-            VocabularyEntryUseCases(addVocabularyItemUseCase, getVocabularyItemByWordUseCase, overrideVocabularyItemUseCase),
+    private fun buildViewModel(): AddWordViewModel {
+        val vocabularyEntryUseCases =
+            VocabularyEntryUseCases(addVocabularyItemUseCase, getVocabularyItemByWordUseCase, overrideVocabularyItemUseCase)
+        return AddWordViewModel(
+            vocabularyEntryUseCases,
             PendingWordUseCases(queuePendingWordUseCase, observePendingWordsUseCase, deletePendingWordUseCase),
             TranslationPreferences(openAiStore, languagePreferencesStore),
             generateAiTranslationUseCase,
             connectivityObserver,
             context,
+            ExistingWordOverrideCoordinator(vocabularyEntryUseCases, generateAiTranslationUseCase),
             processTextEventBus,
         )
+    }
 
     @Test
     fun `process text event with AI active prefills word and triggers preview`() =

--- a/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt
@@ -129,15 +129,19 @@ class AddWordViewModelTest {
         clearAllMocks()
     }
 
-    private fun buildViewModel(): AddWordViewModel =
-        AddWordViewModel(
-            VocabularyEntryUseCases(addVocabularyItemUseCase, getVocabularyItemByWordUseCase, overrideVocabularyItemUseCase),
+    private fun buildViewModel(): AddWordViewModel {
+        val vocabularyEntryUseCases =
+            VocabularyEntryUseCases(addVocabularyItemUseCase, getVocabularyItemByWordUseCase, overrideVocabularyItemUseCase)
+        return AddWordViewModel(
+            vocabularyEntryUseCases,
             PendingWordUseCases(queuePendingWordUseCase, observePendingWordsUseCase, deletePendingWordUseCase),
             TranslationPreferences(openAiStore, languagePreferencesStore),
             generateAiTranslationUseCase,
             connectivityObserver,
             context,
+            ExistingWordOverrideCoordinator(vocabularyEntryUseCases, generateAiTranslationUseCase),
         )
+    }
 
     @Test
     fun `init updates AI flags from preferences`() =

--- a/app/src/test/java/com/procrastilearn/app/ui/ExistingWordOverrideCoordinatorTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/ExistingWordOverrideCoordinatorTest.kt
@@ -1,0 +1,342 @@
+package com.procrastilearn.app.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.VocabularyItem
+import com.procrastilearn.app.domain.usecase.AddVocabularyItemUseCase
+import com.procrastilearn.app.domain.usecase.GenerateAiTranslationUseCase
+import com.procrastilearn.app.domain.usecase.GetVocabularyItemByWordUseCase
+import com.procrastilearn.app.domain.usecase.OverrideVocabularyItemUseCase
+import com.procrastilearn.app.domain.usecase.VocabularyEntryUseCases
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class ExistingWordOverrideCoordinatorTest {
+    private lateinit var getVocabularyItemByWordUseCase: GetVocabularyItemByWordUseCase
+    private lateinit var overrideVocabularyItemUseCase: OverrideVocabularyItemUseCase
+    private lateinit var generateAiTranslationUseCase: GenerateAiTranslationUseCase
+    private lateinit var vocabularyEntryUseCases: VocabularyEntryUseCases
+    private lateinit var coordinator: ExistingWordOverrideCoordinator
+
+    private val existingItem = VocabularyItem(id = 1L, word = "Haus", translation = "House", isNew = false)
+    private val cardOptions = BidirectionalCardOptions(bidirectional = false, backwardPromptOverride = null, backwardAnswerOverride = null)
+
+    @Before
+    fun setUp() {
+        getVocabularyItemByWordUseCase = mockk()
+        overrideVocabularyItemUseCase = mockk()
+        generateAiTranslationUseCase = mockk()
+        vocabularyEntryUseCases = VocabularyEntryUseCases(mockk<AddVocabularyItemUseCase>(), getVocabularyItemByWordUseCase, overrideVocabularyItemUseCase)
+        coordinator = ExistingWordOverrideCoordinator(vocabularyEntryUseCases, generateAiTranslationUseCase)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `resolveForSubmission returns NoConflict when word is not taken`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+
+            val resolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.NoConflict)
+        }
+
+    @Test
+    fun `resolveForSubmission returns ConfirmationRequired on first conflict`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+
+            val resolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.ConfirmationRequired("Haus"))
+        }
+
+    @Test
+    fun `resolveForSubmission applies override and returns Overridden once acknowledged`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "Haus", "House", any(), any(), any()) } returns Result.success(Unit)
+            coordinator.acknowledge("Haus")
+
+            val resolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = true) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.Overridden(fromPreview = true))
+        }
+
+    @Test
+    fun `resolveForSubmission returns OverrideFailed when override fails`() =
+        runTest {
+            val error = IllegalStateException("db down")
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "Haus", "House", any(), any(), any()) } returns Result.failure(error)
+            coordinator.acknowledge("Haus")
+
+            val resolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.OverrideFailed(error, fromPreview = false))
+        }
+
+    @Test
+    fun `resolveForSubmission returns LookupFailed when lookup throws`() =
+        runTest {
+            val error = IllegalStateException("db down")
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } throws error
+
+            val resolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.LookupFailed(error))
+        }
+
+    @Test
+    fun `resolveForSubmission acknowledgment is case-insensitive`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("HAUS") } returns existingItem
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "HAUS", "House", any(), any(), any()) } returns Result.success(Unit)
+            coordinator.acknowledge("haus")
+
+            val resolution =
+                coordinator.resolveForSubmission("HAUS", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.Overridden(fromPreview = false))
+        }
+
+    @Test
+    fun `resolveForSubmission does not honor an acknowledgment for a different word`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.acknowledge("Wohnung")
+
+            val resolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.ConfirmationRequired("Haus"))
+            coVerify(exactly = 0) { overrideVocabularyItemUseCase.invoke(any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `resolveForSubmission consumes the acknowledgment after a successful override`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "Haus", "House", any(), any(), any()) } returns Result.success(Unit)
+            coordinator.acknowledge("Haus")
+            coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            val secondResolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(secondResolution).isEqualTo(SubmissionResolution.ConfirmationRequired("Haus"))
+        }
+
+    @Test
+    fun `resolveForSubmission consumes the acknowledgment even when the override fails`() =
+        runTest {
+            val error = IllegalStateException("db down")
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "Haus", "House", any(), any(), any()) } returns Result.failure(error)
+            coordinator.acknowledge("Haus")
+            coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            val secondResolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(secondResolution).isEqualTo(SubmissionResolution.ConfirmationRequired("Haus"))
+        }
+
+    @Test
+    fun `resolveForSubmission passes the resolved bidirectional card options through to the override`() =
+        runTest {
+            val capturedBidirectional = slot<Boolean>()
+            val capturedBackwardPrompt = slot<String>()
+            val capturedBackwardAnswer = slot<String>()
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coEvery {
+                overrideVocabularyItemUseCase.invoke(
+                    existingItem,
+                    "Haus",
+                    "House",
+                    capture(capturedBidirectional),
+                    capture(capturedBackwardPrompt),
+                    capture(capturedBackwardAnswer),
+                )
+            } returns Result.success(Unit)
+            coordinator.acknowledge("Haus")
+            val customOptions = BidirectionalCardOptions(bidirectional = true, backwardPromptOverride = "prompt", backwardAnswerOverride = "answer")
+
+            coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { customOptions }
+
+            assertThat(capturedBidirectional.captured).isTrue()
+            assertThat(capturedBackwardPrompt.captured).isEqualTo("prompt")
+            assertThat(capturedBackwardAnswer.captured).isEqualTo("answer")
+        }
+
+    @Test
+    fun `checkBeforeAiTranslationRequest prompts even when the word was already acknowledged`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.acknowledge("Haus")
+
+            val preflight = coordinator.checkBeforeAiTranslationRequest("Haus", AiTranslationDirection.TARGET_TO_NATIVE)
+
+            assertThat(preflight).isEqualTo(ExistingWordPreflight.ConfirmationRequired("Haus"))
+        }
+
+    @Test
+    fun `checkBeforeAiTranslationRequest returns NoConflict when word is not taken`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns null
+
+            val preflight = coordinator.checkBeforeAiTranslationRequest("Haus", AiTranslationDirection.TARGET_TO_NATIVE)
+
+            assertThat(preflight).isEqualTo(ExistingWordPreflight.NoConflict)
+            assertThat(coordinator.hasPendingOverride()).isFalse()
+        }
+
+    @Test
+    fun `checkBeforeAiTranslationRequest returns LookupFailed when lookup throws`() =
+        runTest {
+            val error = IllegalStateException("db down")
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } throws error
+
+            val preflight = coordinator.checkBeforeAiTranslationRequest("Haus", AiTranslationDirection.TARGET_TO_NATIVE)
+
+            assertThat(preflight).isEqualTo(ExistingWordPreflight.LookupFailed(error))
+        }
+
+    @Test
+    fun `clearAcknowledgement does not clear a pending override`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            coordinator.clearAcknowledgement()
+
+            assertThat(coordinator.hasPendingOverride()).isTrue()
+        }
+
+    @Test
+    fun `resetForNewWord clears an acknowledgment so submission prompts again`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.acknowledge("Haus")
+
+            coordinator.resetForNewWord()
+            val resolution =
+                coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+
+            assertThat(resolution).isEqualTo(SubmissionResolution.ConfirmationRequired("Haus"))
+        }
+
+    @Test
+    fun `resetForNewWord clears a pending override`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+            assertThat(coordinator.hasPendingOverride()).isTrue()
+
+            coordinator.resetForNewWord()
+
+            assertThat(coordinator.hasPendingOverride()).isFalse()
+        }
+
+    @Test
+    fun `proceedWithPendingOverride returns NoPendingOverride when nothing is pending`() =
+        runTest {
+            val result = coordinator.proceedWithPendingOverride { cardOptions }
+
+            assertThat(result).isEqualTo(OverrideProceedResult.NoPendingOverride)
+        }
+
+    @Test
+    fun `proceedWithPendingOverride resolves an AI translation when none was captured`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.checkBeforeAiTranslationRequest("Haus", AiTranslationDirection.TARGET_TO_NATIVE)
+            coEvery { generateAiTranslationUseCase.invoke("Haus", AiTranslationDirection.TARGET_TO_NATIVE) } returns "House"
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "Haus", "House", any(), any(), any()) } returns Result.success(Unit)
+
+            val result = coordinator.proceedWithPendingOverride { cardOptions }
+
+            assertThat(result).isEqualTo(OverrideProceedResult.Overridden)
+            coVerify(exactly = 1) { generateAiTranslationUseCase.invoke("Haus", AiTranslationDirection.TARGET_TO_NATIVE) }
+        }
+
+    @Test
+    fun `proceedWithPendingOverride uses an already-known translation without calling AI`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.resolveForSubmission("Haus", "Home", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "Haus", "Home", any(), any(), any()) } returns Result.success(Unit)
+
+            val result = coordinator.proceedWithPendingOverride { cardOptions }
+
+            assertThat(result).isEqualTo(OverrideProceedResult.Overridden)
+            coVerify(exactly = 0) { generateAiTranslationUseCase.invoke(any(), any()) }
+        }
+
+    @Test
+    fun `proceedWithPendingOverride returns TranslationFailed when AI resolution is blank`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.checkBeforeAiTranslationRequest("Haus", AiTranslationDirection.TARGET_TO_NATIVE)
+            coEvery { generateAiTranslationUseCase.invoke("Haus", AiTranslationDirection.TARGET_TO_NATIVE) } returns "   "
+
+            val result = coordinator.proceedWithPendingOverride { cardOptions }
+
+            assertThat(result).isInstanceOf(OverrideProceedResult.TranslationFailed::class.java)
+            assertThat((result as OverrideProceedResult.TranslationFailed).error.message).isNull()
+        }
+
+    @Test
+    fun `proceedWithPendingOverride returns OverrideFailed when applying the override fails`() =
+        runTest {
+            val error = IllegalStateException("db down")
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = false) { cardOptions }
+            coEvery { overrideVocabularyItemUseCase.invoke(existingItem, "Haus", "House", any(), any(), any()) } returns Result.failure(error)
+
+            val result = coordinator.proceedWithPendingOverride { cardOptions }
+
+            assertThat(result).isEqualTo(OverrideProceedResult.OverrideFailed(error))
+            assertThat(coordinator.hasPendingOverride()).isFalse()
+        }
+
+    @Test
+    fun `hasPendingOverride is false before any interaction`() {
+        assertThat(coordinator.hasPendingOverride()).isFalse()
+    }
+
+    @Test
+    fun `cancelPendingOverride returns false when nothing is pending`() {
+        val fromPreview = coordinator.cancelPendingOverride()
+
+        assertThat(fromPreview).isFalse()
+    }
+
+    @Test
+    fun `cancelPendingOverride reports whether the pending override came from preview`() =
+        runTest {
+            coEvery { getVocabularyItemByWordUseCase.invoke("Haus") } returns existingItem
+            coordinator.resolveForSubmission("Haus", "House", AiTranslationDirection.TARGET_TO_NATIVE, fromPreview = true) { cardOptions }
+
+            val fromPreview = coordinator.cancelPendingOverride()
+
+            assertThat(fromPreview).isTrue()
+            assertThat(coordinator.hasPendingOverride()).isFalse()
+        }
+}


### PR DESCRIPTION
## Summary

- `AddWordViewModel` carried `@Suppress("LargeClass", "TooManyFunctions")` (23 member functions, ~677-line class body) mixing four concerns: prefs/connectivity/pending-word observation, the add-word submission flow, the AI preview flow, and an "existing word" conflict/override dialog flow.
- Extracts the conflict/override-dialog concern into a new, Hilt-injectable `ExistingWordOverrideCoordinator` with a UI-framework-agnostic API (no `Context`, no `MutableStateFlow<AddWordUiState>` — returns typed sealed outcomes instead), independently unit-tested with 24 new tests covering acknowledgment matching (case-insensitivity, mismatched words, one-shot consumption), lookup/translation/override failure paths, and the AI-preview pre-check's intentional non-acknowledgment quirk.
- Moves two unrelated state-update helper groups out of `AddWordViewModel.kt` into a new `AddWordUiStateUpdates.kt`, since relocating everything into one file would have tripped detekt's file-level `TooManyFunctions` threshold even though the class-level count was fine.
- `AddWordViewModel` now has 19 member functions with no class-size suppressions; its constructor picked up one more collaborator, so it needs a narrow `@Suppress("LongParameterList")` — arity from composing already-decomposed collaborators, not an undecomposed monolith.

## Behavior

No behavior change. The pre-existing 1788-line `AddWordViewModelTest` suite and `AddWordViewModelProcessTextTest` pass unmodified except for a one-line `buildViewModel()` update to construct the new collaborator from the same mocked use cases.

## Test plan

- [x] `./gradlew testDebugUnitTest` — full suite passes (110+ tests across the touched files, including 24 new coordinator tests)
- [x] `./gradlew detekt` — clean, both suppressions removed from `AddWordViewModel`
- [x] `./gradlew lintDebug` — clean
- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyks58ZySLsbwu7V7gT5L7)_