### PR TITLE
fix: log swallowed exceptions in bringToFront instead of silently discarding

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
+++ b/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
@@ -8,6 +8,7 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.SystemClock
 import android.provider.Settings
+import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
@@ -38,6 +39,7 @@ import kotlinx.coroutines.launch
 
 class OverlayAccessibilityService : AccessibilityService() {
     private companion object {
+        const val TAG = "OverlayAccessibilityService"
         const val SECONDS_PER_MINUTE = 60
         const val MILLIS_PER_SECOND = 1000L
     }
@@ -352,7 +354,6 @@ class OverlayAccessibilityService : AccessibilityService() {
         lifecycleOwner = null
     }
 
-    @Suppress("SwallowedException")
     private fun bringToFront(pkg: String) {
         try {
             val intent = packageManager.getLaunchIntentForPackage(pkg) ?: return
@@ -360,8 +361,10 @@ class OverlayAccessibilityService : AccessibilityService() {
             startActivity(intent)
         } catch (e: android.content.ActivityNotFoundException) {
             // App may have been uninstalled or launch intent revoked between check and launch
+            Log.w(TAG, "Failed to bring $pkg to front: launch intent not found", e)
         } catch (e: SecurityException) {
             // App may refuse external launch (e.g. exported=false activity)
+            Log.w(TAG, "Failed to bring $pkg to front: launch not permitted", e)
         }
     }
 


### PR DESCRIPTION
## Summary
- `OverlayAccessibilityService.bringToFront` caught `ActivityNotFoundException` and `SecurityException` but discarded them entirely (`@Suppress("SwallowedException")`), so a failed relaunch of the previous app was silently unobservable.
- Log a `Log.w` warning in each catch block with the caught exception, which also lets us drop the `@Suppress("SwallowedException")` annotation since the exceptions are no longer unused — detekt's rule is satisfied without behavior change.

Picked this suppression out of the ~30 in the repo because it's a self-contained, genuine gap (no logging at all) rather than a style/complexity suppression that would need a larger refactor, or one mandated by a framework contract.

## Test plan
- [x] `./gradlew detekt` — passes, no new findings
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew testDebugUnitTest` — passes
- [x] `./gradlew assembleDebug` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018hWe3tFxHK1J6ecvkYRwUk)_