### PR TITLE
fix: log swallowed exception in hideOverlay instead of silently discarding

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
+++ b/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
@@ -339,13 +339,12 @@ class OverlayAccessibilityService : AccessibilityService() {
         requestAudioFocus()
     }
 
-    @Suppress("SwallowedException")
     private fun hideOverlay() {
         overlayView?.let {
             try {
                 windowManager?.removeView(it)
             } catch (e: IllegalArgumentException) {
-                // View not attached to window or already removed
+                Log.w(TAG, "Failed to remove overlay view: not attached or already removed", e)
             }
         }
         releaseAudioFocus()


### PR DESCRIPTION
## Summary
- `OverlayAccessibilityService.hideOverlay()` caught `IllegalArgumentException` from `windowManager.removeView()` and discarded it silently, needing `@Suppress("SwallowedException")`.
- The neighboring `bringToFront()` method already handles its analogous failure by logging via `Log.w(TAG, ...)` (fixed in a prior PR).
- Aligned `hideOverlay()` with that pattern — log a warning instead of swallowing the exception — and removed the now-unnecessary `@Suppress` annotation.

## Test plan
- [x] `./gradlew ktlintCheck detekt` passes
- [x] `./gradlew :app:compileDebugKotlin` builds successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01NshddUPK46AFK6gbJARnY3)_