### PR TITLE
fix: make checkbox colors explicit to fix low-contrast checkmark

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/ui/views/AppsList.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/views/AppsList.kt
@@ -173,6 +173,7 @@ private fun EnableProcrastilearnRow(
                         CheckboxDefaults.colors(
                             checkedColor = colorScheme.onSecondaryContainer,
                             uncheckedColor = colorScheme.onSurfaceVariant,
+                            checkmarkColor = colorScheme.secondaryContainer,
                         ),
                 )
             }
@@ -241,6 +242,8 @@ private fun AppRow(
                 colors =
                     CheckboxDefaults.colors(
                         checkedColor = MaterialTheme.colorScheme.primary,
+                        uncheckedColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        checkmarkColor = MaterialTheme.colorScheme.onPrimary,
                     ),
             )
         }


### PR DESCRIPTION
## Summary
- The "Enable procrastilearn" row's checkbox overrode `checkedColor`/`uncheckedColor` to match its tinted `secondaryContainer` background, but left `checkmarkColor` unset. That falls back to the Material3 default, which is tuned to pair with the *default* `checkedColor` (`primary`), not the custom `onSecondaryContainer` fill used here.
- Combined with the app's Material You dynamic color (`dynamicColor = true`), this could make the checkmark blend into the checkbox fill in dark theme depending on the device's wallpaper-derived palette.
- Fix: explicitly set `checkmarkColor` on that row's checkbox to the contrasting container role (`secondaryContainer`), and make the `AppRow` checkbox's full color set (`checkedColor`, `uncheckedColor`, `checkmarkColor`) explicit too, so neither checkbox relies on implicit Material3 defaults.

## Test plan
- [x] `./gradlew ktlintCheck detekt` passes
- [x] `./gradlew assembleDebug` compiles
- [ ] Manually verify the "Enable procrastilearn" checkbox has clear contrast in both light and dark theme, including under Material You dynamic color

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUQF19WkXKrvbxMbNwVcL)_