### PR TITLE
Add bidirectional checkbox and reverse-card fields to Edit Word dialog

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
@@ -84,6 +84,14 @@ class VocabularyRepositoryImpl
             withContext(io) {
                 val existingEntity = vocabularyDao.getVocabularyById(item.id)
                 if (existingEntity != null) {
+                    // Enabling bidirectional on a row that's already past its first-ever review
+                    // won't trigger the natural new-row seed in reviewVocabularyItem (wasRowNew
+                    // requires both directions still unreviewed) - seed the backward due date here
+                    // instead so the newly-enabled reverse card actually becomes reviewable.
+                    val needsBackwardSeed =
+                        item.bidirectional &&
+                            existingEntity.fsrsDueAt != 0L &&
+                            existingEntity.backwardFsrsDueAt == 0L
                     val updatedEntity =
                         existingEntity.copy(
                             word = item.word,
@@ -91,6 +99,8 @@ class VocabularyRepositoryImpl
                             bidirectional = item.bidirectional,
                             backwardPromptOverride = item.backwardPromptOverride,
                             backwardAnswerOverride = item.backwardAnswerOverride,
+                            backwardFsrsDueAt =
+                                if (needsBackwardSeed) System.currentTimeMillis() else existingEntity.backwardFsrsDueAt,
                         )
                     vocabularyDao.updateVocabulary(updatedEntity)
                     undoSnapshotDao.deleteForVocab(item.id)

--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
@@ -597,20 +597,21 @@ internal fun AddWordUiState.withBidirectionalCleared(): AddWordUiState =
         backwardAnswerOverride = "",
     )
 
-internal fun AddWordUiState.withBidirectionalToggle(checked: Boolean): AddWordUiState =
-    copy(
-        bidirectional = checked,
-        isCustomizingBackward = if (checked) isCustomizingBackward else false,
-        backwardPromptOverride = if (checked) backwardPromptOverride else "",
-        backwardAnswerOverride = if (checked) backwardAnswerOverride else "",
+internal fun AddWordUiState.withBidirectionalToggle(checked: Boolean): AddWordUiState {
+    val toggled =
+        BidirectionalFields(bidirectional, isCustomizingBackward, backwardPromptOverride, backwardAnswerOverride)
+            .toggled(checked)
+    return copy(
+        bidirectional = toggled.bidirectional,
+        isCustomizingBackward = toggled.isCustomizingBackward,
+        backwardPromptOverride = toggled.backwardPromptOverride,
+        backwardAnswerOverride = toggled.backwardAnswerOverride,
     )
+}
 
 internal fun AddWordUiState.toCardOptions(): BidirectionalCardOptions =
-    BidirectionalCardOptions(
-        bidirectional = bidirectional,
-        backwardPromptOverride = backwardPromptOverride.ifBlank { null },
-        backwardAnswerOverride = backwardAnswerOverride.ifBlank { null },
-    )
+    BidirectionalFields(bidirectional, isCustomizingBackward, backwardPromptOverride, backwardAnswerOverride)
+        .toCardOptions()
 
 data class AddWordPreviewContent(
     val word: String,

--- a/app/src/main/java/com/procrastilearn/app/ui/BidirectionalFields.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/BidirectionalFields.kt
@@ -1,0 +1,23 @@
+package com.procrastilearn.app.ui
+
+internal data class BidirectionalFields(
+    val bidirectional: Boolean = false,
+    val isCustomizingBackward: Boolean = false,
+    val backwardPromptOverride: String = "",
+    val backwardAnswerOverride: String = "",
+)
+
+internal fun BidirectionalFields.toggled(checked: Boolean): BidirectionalFields =
+    copy(
+        bidirectional = checked,
+        isCustomizingBackward = if (checked) isCustomizingBackward else false,
+        backwardPromptOverride = if (checked) backwardPromptOverride else "",
+        backwardAnswerOverride = if (checked) backwardAnswerOverride else "",
+    )
+
+internal fun BidirectionalFields.toCardOptions(): BidirectionalCardOptions =
+    BidirectionalCardOptions(
+        bidirectional = bidirectional,
+        backwardPromptOverride = backwardPromptOverride.ifBlank { null },
+        backwardAnswerOverride = backwardAnswerOverride.ifBlank { null },
+    )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
@@ -62,9 +64,12 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.procrastilearn.app.R
 import com.procrastilearn.app.domain.model.VocabularyItem
+import com.procrastilearn.app.ui.BidirectionalFields
 import com.procrastilearn.app.ui.WordListViewModel
 import com.procrastilearn.app.ui.WordListViewModel.SelectionState
 import com.procrastilearn.app.ui.theme.MyApplicationTheme
+import com.procrastilearn.app.ui.toCardOptions
+import com.procrastilearn.app.ui.toggled
 import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
 import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
 import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
@@ -520,6 +525,18 @@ private fun EditWordDialog(
 ) {
     var word by remember { mutableStateOf(item.word) }
     var translation by remember { mutableStateOf(item.translation) }
+    var bidirectionalFields by
+        remember {
+            mutableStateOf(
+                BidirectionalFields(
+                    bidirectional = item.bidirectional,
+                    isCustomizingBackward =
+                        !item.backwardPromptOverride.isNullOrBlank() || !item.backwardAnswerOverride.isNullOrBlank(),
+                    backwardPromptOverride = item.backwardPromptOverride ?: "",
+                    backwardAnswerOverride = item.backwardAnswerOverride ?: "",
+                ),
+            )
+        }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -527,7 +544,7 @@ private fun EditWordDialog(
             Text(text = stringResource(R.string.edit_word_title))
         },
         text = {
-            Column {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 OutlinedTextField(
                     value = word,
                     onValueChange = { word = it },
@@ -558,22 +575,50 @@ private fun EditWordDialog(
                             unfocusedBorderColor = MaterialTheme.colorScheme.outline,
                         ),
                 )
+                Spacer(modifier = Modifier.height(8.dp))
+                BidirectionalOptionSection(
+                    visible = true,
+                    bidirectional = bidirectionalFields.bidirectional,
+                    isCustomizing = bidirectionalFields.isCustomizingBackward,
+                    backwardPromptOverride = bidirectionalFields.backwardPromptOverride,
+                    backwardAnswerOverride = bidirectionalFields.backwardAnswerOverride,
+                    onBidirectionalToggle = { checked -> bidirectionalFields = bidirectionalFields.toggled(checked) },
+                    onCustomizeToggle = {
+                        bidirectionalFields =
+                            bidirectionalFields.copy(isCustomizingBackward = !bidirectionalFields.isCustomizingBackward)
+                    },
+                    onBackwardPromptOverrideChange = {
+                        bidirectionalFields = bidirectionalFields.copy(backwardPromptOverride = it)
+                    },
+                    onBackwardAnswerOverrideChange = {
+                        bidirectionalFields = bidirectionalFields.copy(backwardAnswerOverride = it)
+                    },
+                )
             }
         },
         confirmButton = {
             TextButton(
                 onClick = {
                     if (word.isNotBlank() && translation.isNotBlank()) {
-                        onConfirm(item.copy(word = word, translation = translation))
+                        val cardOptions = bidirectionalFields.toCardOptions()
+                        onConfirm(
+                            item.copy(
+                                word = word,
+                                translation = translation,
+                                bidirectional = cardOptions.bidirectional,
+                                backwardPromptOverride = cardOptions.backwardPromptOverride,
+                                backwardAnswerOverride = cardOptions.backwardAnswerOverride,
+                            ),
+                        )
                     }
                 },
             ) {
-                Text("Save")
+                Text(stringResource(R.string.action_save))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
@@ -538,6 +538,17 @@ private fun EditWordDialog(
             )
         }
 
+    fun applyEditedFields(): VocabularyItem {
+        val cardOptions = bidirectionalFields.toCardOptions()
+        return item.copy(
+            word = word,
+            translation = translation,
+            bidirectional = cardOptions.bidirectional,
+            backwardPromptOverride = cardOptions.backwardPromptOverride,
+            backwardAnswerOverride = cardOptions.backwardAnswerOverride,
+        )
+    }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
@@ -600,16 +611,7 @@ private fun EditWordDialog(
             TextButton(
                 onClick = {
                     if (word.isNotBlank() && translation.isNotBlank()) {
-                        val cardOptions = bidirectionalFields.toCardOptions()
-                        onConfirm(
-                            item.copy(
-                                word = word,
-                                translation = translation,
-                                bidirectional = cardOptions.bidirectional,
-                                backwardPromptOverride = cardOptions.backwardPromptOverride,
-                                backwardAnswerOverride = cardOptions.backwardAnswerOverride,
-                            ),
-                        )
+                        onConfirm(applyEditedFields())
                     }
                 },
             ) {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_continue">Continuar</string>
     <string name="action_view_list">Ver lista</string>
     <string name="action_add">Añadir</string>
+    <string name="action_save">Guardar</string>
     <string name="action_delete">Eliminar</string>
     <string name="action_edit">Editar</string>
     <string name="action_reset">Restablecer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_continue">Continuer</string>
     <string name="action_view_list">Voir la liste</string>
     <string name="action_add">Ajouter</string>
+    <string name="action_save">Enregistrer</string>
     <string name="action_delete">Supprimer</string>
     <string name="action_edit">Modifier</string>
     <string name="action_reset">Réinitialiser</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_continue">Continua</string>
     <string name="action_view_list">Visualizza elenco</string>
     <string name="action_add">Aggiungi</string>
+    <string name="action_save">Salva</string>
     <string name="action_delete">Elimina</string>
     <string name="action_edit">Modifica</string>
     <string name="action_reset">Reimposta</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -9,6 +9,7 @@
         <string name="action_continue">Продолжить</string>
         <string name="action_view_list">Просмотреть список</string>
         <string name="action_add">Добавить</string>
+        <string name="action_save">Сохранить</string>
         <string name="action_edit">Редактировать</string>
         <string name="action_ok">ОК</string>
         <string name="action_cancel">Отмена</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_continue">Продовжити</string>
     <string name="action_view_list">Переглянути список</string>
     <string name="action_add">Додати</string>
+    <string name="action_save">Зберегти</string>
     <string name="action_delete">Видалити</string>
     <string name="action_edit">Редагувати</string>
     <string name="action_reset">Скинути</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_continue">继续</string>
     <string name="action_view_list">查看列表</string>
     <string name="action_add">添加</string>
+    <string name="action_save">保存</string>
     <string name="action_delete">删除</string>
     <string name="action_edit">编辑</string>
     <string name="action_reset">重置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_continue">Continue</string>
     <string name="action_view_list">View List</string>
     <string name="action_add">Add</string>
+    <string name="action_save">Save</string>
     <string name="action_delete">Delete</string>
     <string name="action_edit">Edit</string>
     <string name="action_reset">Reset</string>

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryBidirectionalTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryBidirectionalTest.kt
@@ -15,6 +15,7 @@ import com.procrastilearn.app.domain.model.LearningPreferencesConfig
 import com.procrastilearn.app.domain.model.MixMode
 import com.procrastilearn.app.domain.model.StudyDirection
 import com.procrastilearn.app.domain.model.StudyDirectionMode
+import com.procrastilearn.app.domain.model.VocabularyItem
 import io.github.openspacedrepetition.Rating
 import io.github.openspacedrepetition.Scheduler
 import io.mockk.coEvery
@@ -539,7 +540,7 @@ class VocabularyRepositoryBidirectionalTest {
             vocabularyDao.updateVocabulary(entity)
 
             repository.resetVocabularyProgress(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",
@@ -560,7 +561,7 @@ class VocabularyRepositoryBidirectionalTest {
             val id = insertVocabulary("run", bidirectional = true)
 
             repository.resetVocabularyProgress(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",
@@ -583,7 +584,7 @@ class VocabularyRepositoryBidirectionalTest {
             vocabularyDao.updateVocabulary(withOverrides)
 
             repository.resetVocabularyProgress(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",
@@ -602,7 +603,7 @@ class VocabularyRepositoryBidirectionalTest {
             val id = insertVocabulary("run", bidirectional = false, fsrsDueAt = System.currentTimeMillis() + 60_000)
 
             repository.updateVocabularyItem(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",
@@ -625,7 +626,7 @@ class VocabularyRepositoryBidirectionalTest {
             stubCounters()
 
             repository.updateVocabularyItem(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",
@@ -652,7 +653,7 @@ class VocabularyRepositoryBidirectionalTest {
             assertThat(scheduledBackwardDueAt).isGreaterThan(0L)
 
             repository.updateVocabularyItem(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "laufen",
                     translation = "run",
@@ -674,7 +675,7 @@ class VocabularyRepositoryBidirectionalTest {
             assertThat(scheduledBackwardDueAt).isGreaterThan(0L)
 
             repository.updateVocabularyItem(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",
@@ -694,7 +695,7 @@ class VocabularyRepositoryBidirectionalTest {
             val id = insertVocabulary("run", bidirectional = true)
 
             repository.updateVocabularyItem(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",
@@ -709,7 +710,7 @@ class VocabularyRepositoryBidirectionalTest {
             assertThat(withOverrides.backwardAnswerOverride).isEqualTo("laufen")
 
             repository.updateVocabularyItem(
-                com.procrastilearn.app.domain.model.VocabularyItem(
+                VocabularyItem(
                     id = id,
                     word = "run",
                     translation = "run",

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryBidirectionalTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryBidirectionalTest.kt
@@ -595,4 +595,130 @@ class VocabularyRepositoryBidirectionalTest {
             assertThat(entity.backwardPromptOverride).isEqualTo("prompt")
             assertThat(entity.backwardAnswerOverride).isEqualTo("answer")
         }
+
+    @Test
+    fun `enabling bidirectional via updateVocabularyItem on an already-reviewed word seeds backwardFsrsDueAt`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = false, fsrsDueAt = System.currentTimeMillis() + 60_000)
+
+            repository.updateVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "run",
+                    translation = "run",
+                    isNew = false,
+                    bidirectional = true,
+                ),
+            )
+
+            val entity = vocabularyDao.getVocabularyById(id)!!
+            assertThat(entity.bidirectional).isTrue()
+            assertThat(entity.backwardFsrsDueAt).isGreaterThan(0L)
+            assertThat(entity.backwardFsrsDueAt).isAtMost(System.currentTimeMillis())
+        }
+
+    @Test
+    @Suppress("ktlint:standard:max-line-length")
+    fun `enabling bidirectional via updateVocabularyItem on a brand-new word does not eagerly seed backwardFsrsDueAt`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = false)
+            stubCounters()
+
+            repository.updateVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "run",
+                    translation = "run",
+                    isNew = false,
+                    bidirectional = true,
+                ),
+            )
+
+            assertThat(vocabularyDao.getVocabularyById(id)?.backwardFsrsDueAt).isEqualTo(0L)
+
+            // The natural first-review seed path must still work normally after this edit.
+            repository.reviewVocabularyItem(id, Rating.GOOD, StudyDirection.FORWARD)
+
+            assertThat(vocabularyDao.getVocabularyById(id)?.backwardFsrsDueAt).isGreaterThan(0L)
+        }
+
+    @Test
+    fun `updateVocabularyItem does not overwrite an already-scheduled backwardFsrsDueAt`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = true)
+            stubCounters()
+            repository.reviewVocabularyItem(id, Rating.GOOD, StudyDirection.FORWARD)
+            val scheduledBackwardDueAt = vocabularyDao.getVocabularyById(id)!!.backwardFsrsDueAt
+            assertThat(scheduledBackwardDueAt).isGreaterThan(0L)
+
+            repository.updateVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "laufen",
+                    translation = "run",
+                    isNew = false,
+                    bidirectional = true,
+                ),
+            )
+
+            assertThat(vocabularyDao.getVocabularyById(id)?.backwardFsrsDueAt).isEqualTo(scheduledBackwardDueAt)
+        }
+
+    @Test
+    fun `disabling bidirectional via updateVocabularyItem leaves backwardFsrsDueAt untouched`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = true)
+            stubCounters()
+            repository.reviewVocabularyItem(id, Rating.GOOD, StudyDirection.FORWARD)
+            val scheduledBackwardDueAt = vocabularyDao.getVocabularyById(id)!!.backwardFsrsDueAt
+            assertThat(scheduledBackwardDueAt).isGreaterThan(0L)
+
+            repository.updateVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "run",
+                    translation = "run",
+                    isNew = false,
+                    bidirectional = false,
+                ),
+            )
+
+            val entity = vocabularyDao.getVocabularyById(id)!!
+            assertThat(entity.bidirectional).isFalse()
+            assertThat(entity.backwardFsrsDueAt).isEqualTo(scheduledBackwardDueAt)
+        }
+
+    @Test
+    fun `updateVocabularyItem persists and clears the reverse override fields`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = true)
+
+            repository.updateVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "run",
+                    translation = "run",
+                    isNew = false,
+                    bidirectional = true,
+                    backwardPromptOverride = "Run!",
+                    backwardAnswerOverride = "laufen",
+                ),
+            )
+            val withOverrides = vocabularyDao.getVocabularyById(id)!!
+            assertThat(withOverrides.backwardPromptOverride).isEqualTo("Run!")
+            assertThat(withOverrides.backwardAnswerOverride).isEqualTo("laufen")
+
+            repository.updateVocabularyItem(
+                com.procrastilearn.app.domain.model.VocabularyItem(
+                    id = id,
+                    word = "run",
+                    translation = "run",
+                    isNew = false,
+                    bidirectional = false,
+                ),
+            )
+            val cleared = vocabularyDao.getVocabularyById(id)!!
+            assertThat(cleared.backwardPromptOverride).isNull()
+            assertThat(cleared.backwardAnswerOverride).isNull()
+        }
 }

--- a/app/src/test/java/com/procrastilearn/app/ui/BidirectionalFieldsTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/BidirectionalFieldsTest.kt
@@ -1,0 +1,102 @@
+package com.procrastilearn.app.ui
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BidirectionalFieldsTest {
+    @Test
+    fun `toggled true sets bidirectional and preserves existing customize state`() {
+        val fields =
+            BidirectionalFields(
+                bidirectional = false,
+                isCustomizingBackward = true,
+                backwardPromptOverride = "prompt",
+                backwardAnswerOverride = "answer",
+            )
+
+        val result = fields.toggled(true)
+
+        assertThat(result.bidirectional).isTrue()
+        assertThat(result.isCustomizingBackward).isTrue()
+        assertThat(result.backwardPromptOverride).isEqualTo("prompt")
+        assertThat(result.backwardAnswerOverride).isEqualTo("answer")
+    }
+
+    @Test
+    fun `toggled false clears bidirectional customize flag and both overrides`() {
+        val fields =
+            BidirectionalFields(
+                bidirectional = true,
+                isCustomizingBackward = true,
+                backwardPromptOverride = "prompt",
+                backwardAnswerOverride = "answer",
+            )
+
+        val result = fields.toggled(false)
+
+        assertThat(result.bidirectional).isFalse()
+        assertThat(result.isCustomizingBackward).isFalse()
+        assertThat(result.backwardPromptOverride).isEmpty()
+        assertThat(result.backwardAnswerOverride).isEmpty()
+    }
+
+    @Test
+    fun `toggled true after a prior toggled false does not restore previously cleared overrides`() {
+        val fields =
+            BidirectionalFields(
+                bidirectional = true,
+                isCustomizingBackward = true,
+                backwardPromptOverride = "prompt",
+                backwardAnswerOverride = "answer",
+            )
+
+        val result = fields.toggled(false).toggled(true)
+
+        assertThat(result.bidirectional).isTrue()
+        assertThat(result.isCustomizingBackward).isFalse()
+        assertThat(result.backwardPromptOverride).isEmpty()
+        assertThat(result.backwardAnswerOverride).isEmpty()
+    }
+
+    @Test
+    fun `toCardOptions maps a blank prompt override to null`() {
+        val fields = BidirectionalFields(bidirectional = true, backwardPromptOverride = "")
+
+        val options = fields.toCardOptions()
+
+        assertThat(options.backwardPromptOverride).isNull()
+    }
+
+    @Test
+    fun `toCardOptions maps a whitespace-only answer override to null`() {
+        val fields = BidirectionalFields(bidirectional = true, backwardAnswerOverride = "   ")
+
+        val options = fields.toCardOptions()
+
+        assertThat(options.backwardAnswerOverride).isNull()
+    }
+
+    @Test
+    fun `toCardOptions preserves non-blank override text unchanged without trimming`() {
+        val fields =
+            BidirectionalFields(
+                bidirectional = true,
+                backwardPromptOverride = " custom prompt ",
+                backwardAnswerOverride = " custom answer ",
+            )
+
+        val options = fields.toCardOptions()
+
+        assertThat(options.backwardPromptOverride).isEqualTo(" custom prompt ")
+        assertThat(options.backwardAnswerOverride).isEqualTo(" custom answer ")
+    }
+
+    @Test
+    fun `toCardOptions carries bidirectional false through correctly`() {
+        val fields = BidirectionalFields(bidirectional = false)
+
+        val options = fields.toCardOptions()
+
+        assertThat(options.bidirectional).isFalse()
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/EditWordDialogTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/EditWordDialogTest.kt
@@ -1,0 +1,347 @@
+package com.procrastilearn.app.ui.screens
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.procrastilearn.app.R
+import com.procrastilearn.app.domain.model.VocabularyItem
+import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
+import io.mockk.called
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class EditWordDialogTest {
+    private val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val rules: TestRule =
+        RuleChain
+            .outerRule(ComponentActivityRegistrationRule())
+            .around(composeTestRule)
+
+    private lateinit var context: Context
+    private lateinit var onDelete: (VocabularyItem) -> Unit
+    private lateinit var onEdit: (VocabularyItem) -> Unit
+    private lateinit var onReset: (VocabularyItem) -> Unit
+
+    private val words =
+        listOf(
+            VocabularyItem(id = 1, word = "Serendipity", translation = "Happy accident", isNew = true),
+            VocabularyItem(id = 2, word = "Ephemeral", translation = "Short lived", isNew = false),
+            VocabularyItem(id = 3, word = "Peregrinate", translation = "To wander", isNew = false),
+        )
+
+    private val bidirectionalWordWithOverrides =
+        VocabularyItem(
+            id = 4,
+            word = "Laufen",
+            translation = "to run",
+            isNew = false,
+            bidirectional = true,
+            backwardPromptOverride = "Run!",
+            backwardAnswerOverride = "Laufen (verb)",
+        )
+
+    private val bidirectionalWordWithoutOverrides =
+        VocabularyItem(id = 5, word = "Sprechen", translation = "to speak", isNew = false, bidirectional = true)
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        onDelete = mockk(relaxed = true)
+        onEdit = mockk(relaxed = true)
+        onReset = mockk(relaxed = true)
+    }
+
+    private fun string(resId: Int) = context.getString(resId)
+
+    @Test
+    fun `confirming edit dialog with changed fields invokes onEdit with updated item`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        val wordField = composeTestRule.onAllNodes(hasSetTextAction())[1]
+        wordField.performTextClearance()
+        wordField.performTextInput("Updated")
+
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(words[0].copy(word = "Updated"))
+        }
+    }
+
+    @Test
+    fun `edit dialog does not confirm when word is blank`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        val wordField = composeTestRule.onAllNodes(hasSetTextAction())[1]
+        wordField.performTextClearance()
+
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify { onEdit wasNot called }
+        composeTestRule.onNodeWithText(string(R.string.edit_word_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `cancelling edit dialog does not invoke onEdit`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        verify { onEdit wasNot called }
+        composeTestRule.onNodeWithText(string(R.string.edit_word_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `edit dialog shows bidirectional checkbox unchecked for a non-bidirectional word`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).assertIsOff()
+    }
+
+    @Test
+    fun `edit dialog shows bidirectional checkbox checked for a bidirectional word`() {
+        setContent(words = listOf(bidirectionalWordWithoutOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).assertIsOn()
+    }
+
+    @Test
+    fun `customize action hidden in edit dialog until bidirectional is checked`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.add_word_customize_backward_show)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `customize fields start expanded in edit dialog when the word already has reverse overrides`() {
+        setContent(words = listOf(bidirectionalWordWithOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_answer_label))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    @Suppress("ktlint:standard:max-line-length")
+    fun `customize fields start collapsed in edit dialog when bidirectional is on but there are no reverse overrides`() {
+        setContent(words = listOf(bidirectionalWordWithoutOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.add_word_backward_prompt_label)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `checking bidirectional checkbox in edit dialog reveals the customize action`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `unchecking bidirectional checkbox in edit dialog hides the customize action and fields`() {
+        setContent(words = listOf(bidirectionalWordWithOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.add_word_customize_backward_show)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(string(R.string.add_word_backward_prompt_label)).assertDoesNotExist()
+    }
+
+    @Test
+    @Suppress("ktlint:standard:max-line-length")
+    fun `confirming edit dialog with bidirectional checked and no overrides saves bidirectional true with null overrides`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(words[0].copy(bidirectional = true))
+        }
+    }
+
+    @Test
+    fun `confirming edit dialog with customized reverse fields saves the entered override text`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextInput("Run!")
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_answer_label))
+            .performScrollTo()
+            .performTextInput("Laufen")
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(
+                words[0].copy(
+                    bidirectional = true,
+                    backwardPromptOverride = "Run!",
+                    backwardAnswerOverride = "Laufen",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `confirming edit dialog after unchecking bidirectional clears previously saved overrides`() {
+        setContent(words = listOf(bidirectionalWordWithOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(
+                bidirectionalWordWithOverrides.copy(
+                    bidirectional = false,
+                    backwardPromptOverride = null,
+                    backwardAnswerOverride = null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `confirming edit dialog with whitespace-only override fields saves null overrides`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextInput("   ")
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(words[0].copy(bidirectional = true))
+        }
+    }
+
+    @Test
+    fun `re-checking bidirectional in edit dialog after unchecking does not restore previously entered overrides`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextInput("temp")
+        composeTestRule.onNode(isToggleable()).performScrollTo().performClick()
+        composeTestRule.onNode(isToggleable()).performScrollTo().performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(words[0].copy(bidirectional = true))
+        }
+    }
+
+    @Test
+    fun `cancelling edit dialog after toggling bidirectional does not invoke onEdit`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        verify { onEdit wasNot called }
+    }
+
+    private fun openMenuFor() {
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_more_actions))
+            .performClick()
+    }
+
+    private fun setContent(words: List<VocabularyItem>) {
+        composeTestRule.setContent {
+            WordListContent(
+                words = words,
+                searchQuery = "",
+                onSearchQueryChange = {},
+                onDelete = onDelete,
+                onEdit = onEdit,
+                onReset = onReset,
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/EditWordDialogTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/EditWordDialogTest.kt
@@ -162,8 +162,7 @@ class EditWordDialogTest {
     }
 
     @Test
-    @Suppress("ktlint:standard:max-line-length")
-    fun `customize fields start collapsed in edit dialog when bidirectional is on but there are no reverse overrides`() {
+    fun `customize fields start collapsed when bidirectional has no reverse overrides`() {
         setContent(words = listOf(bidirectionalWordWithoutOverrides))
         openMenuFor()
         composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
@@ -202,8 +201,7 @@ class EditWordDialogTest {
     }
 
     @Test
-    @Suppress("ktlint:standard:max-line-length")
-    fun `confirming edit dialog with bidirectional checked and no overrides saves bidirectional true with null overrides`() {
+    fun `confirming edit dialog with bidirectional checked and no overrides saves null overrides`() {
         setContent(words = words.take(1))
         openMenuFor()
         composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
@@ -13,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
@@ -34,6 +36,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@Suppress("LargeClass")
 class WordListScreenTest {
     private val composeTestRule = createComposeRule()
 
@@ -61,6 +64,20 @@ class WordListScreenTest {
             VocabularyItem(id = 2, word = "Ephemeral", translation = "Short lived", isNew = false),
             VocabularyItem(id = 3, word = "Peregrinate", translation = "To wander", isNew = false),
         )
+
+    private val bidirectionalWordWithOverrides =
+        VocabularyItem(
+            id = 4,
+            word = "Laufen",
+            translation = "to run",
+            isNew = false,
+            bidirectional = true,
+            backwardPromptOverride = "Run!",
+            backwardAnswerOverride = "Laufen (verb)",
+        )
+
+    private val bidirectionalWordWithoutOverrides =
+        VocabularyItem(id = 5, word = "Sprechen", translation = "to speak", isNew = false, bidirectional = true)
 
     @Before
     fun setup() {
@@ -166,7 +183,7 @@ class WordListScreenTest {
         wordField.performTextClearance()
         wordField.performTextInput("Updated")
 
-        composeTestRule.onNodeWithText("Save").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
 
         verify(exactly = 1) {
             onEdit(words[0].copy(word = "Updated"))
@@ -182,7 +199,7 @@ class WordListScreenTest {
         val wordField = composeTestRule.onAllNodes(hasSetTextAction())[1]
         wordField.performTextClearance()
 
-        composeTestRule.onNodeWithText("Save").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
 
         verify { onEdit wasNot called }
         composeTestRule.onNodeWithText(string(R.string.edit_word_title)).assertIsDisplayed()
@@ -194,10 +211,218 @@ class WordListScreenTest {
         openMenuFor()
         composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
 
-        composeTestRule.onNodeWithText("Cancel").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
 
         verify { onEdit wasNot called }
         composeTestRule.onNodeWithText(string(R.string.edit_word_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `edit dialog shows bidirectional checkbox unchecked for a non-bidirectional word`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).assertIsOff()
+    }
+
+    @Test
+    fun `edit dialog shows bidirectional checkbox checked for a bidirectional word`() {
+        setContent(words = listOf(bidirectionalWordWithoutOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).assertIsOn()
+    }
+
+    @Test
+    fun `customize action hidden in edit dialog until bidirectional is checked`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.add_word_customize_backward_show)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `customize fields start expanded in edit dialog when the word already has reverse overrides`() {
+        setContent(words = listOf(bidirectionalWordWithOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_answer_label))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    @Suppress("ktlint:standard:max-line-length")
+    fun `customize fields start collapsed in edit dialog when bidirectional is on but there are no reverse overrides`() {
+        setContent(words = listOf(bidirectionalWordWithoutOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.add_word_backward_prompt_label)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `checking bidirectional checkbox in edit dialog reveals the customize action`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `unchecking bidirectional checkbox in edit dialog hides the customize action and fields`() {
+        setContent(words = listOf(bidirectionalWordWithOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.add_word_customize_backward_show)).assertDoesNotExist()
+        composeTestRule.onNodeWithText(string(R.string.add_word_backward_prompt_label)).assertDoesNotExist()
+    }
+
+    @Test
+    @Suppress("ktlint:standard:max-line-length")
+    fun `confirming edit dialog with bidirectional checked and no overrides saves bidirectional true with null overrides`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(words[0].copy(bidirectional = true))
+        }
+    }
+
+    @Test
+    fun `confirming edit dialog with customized reverse fields saves the entered override text`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextInput("Run!")
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_answer_label))
+            .performScrollTo()
+            .performTextInput("Laufen")
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(
+                words[0].copy(
+                    bidirectional = true,
+                    backwardPromptOverride = "Run!",
+                    backwardAnswerOverride = "Laufen",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `confirming edit dialog after unchecking bidirectional clears previously saved overrides`() {
+        setContent(words = listOf(bidirectionalWordWithOverrides))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(
+                bidirectionalWordWithOverrides.copy(
+                    bidirectional = false,
+                    backwardPromptOverride = null,
+                    backwardAnswerOverride = null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `confirming edit dialog with whitespace-only override fields saves null overrides`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextInput("   ")
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(words[0].copy(bidirectional = true))
+        }
+    }
+
+    @Test
+    fun `re-checking bidirectional in edit dialog after unchecking does not restore previously entered overrides`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextInput("temp")
+        composeTestRule.onNode(isToggleable()).performScrollTo().performClick()
+        composeTestRule.onNode(isToggleable()).performScrollTo().performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
+
+        verify(exactly = 1) {
+            onEdit(words[0].copy(bidirectional = true))
+        }
+    }
+
+    @Test
+    fun `cancelling edit dialog after toggling bidirectional does not invoke onEdit`() {
+        setContent(words = words.take(1))
+        openMenuFor()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+
+        composeTestRule.onNode(isToggleable()).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        verify { onEdit wasNot called }
     }
 
     @Test

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
@@ -5,8 +5,6 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
-import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
@@ -14,8 +12,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ApplicationProvider
@@ -36,7 +32,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-@Suppress("LargeClass")
 class WordListScreenTest {
     private val composeTestRule = createComposeRule()
 
@@ -64,20 +59,6 @@ class WordListScreenTest {
             VocabularyItem(id = 2, word = "Ephemeral", translation = "Short lived", isNew = false),
             VocabularyItem(id = 3, word = "Peregrinate", translation = "To wander", isNew = false),
         )
-
-    private val bidirectionalWordWithOverrides =
-        VocabularyItem(
-            id = 4,
-            word = "Laufen",
-            translation = "to run",
-            isNew = false,
-            bidirectional = true,
-            backwardPromptOverride = "Run!",
-            backwardAnswerOverride = "Laufen (verb)",
-        )
-
-    private val bidirectionalWordWithoutOverrides =
-        VocabularyItem(id = 5, word = "Sprechen", translation = "to speak", isNew = false, bidirectional = true)
 
     @Before
     fun setup() {
@@ -171,258 +152,6 @@ class WordListScreenTest {
         composeTestRule.onNodeWithText(string(R.string.action_edit)).assertIsDisplayed()
         composeTestRule.onNodeWithText(string(R.string.action_reset)).assertIsDisplayed()
         composeTestRule.onNodeWithText(string(R.string.action_delete)).assertIsDisplayed()
-    }
-
-    @Test
-    fun `confirming edit dialog with changed fields invokes onEdit with updated item`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        val wordField = composeTestRule.onAllNodes(hasSetTextAction())[1]
-        wordField.performTextClearance()
-        wordField.performTextInput("Updated")
-
-        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
-
-        verify(exactly = 1) {
-            onEdit(words[0].copy(word = "Updated"))
-        }
-    }
-
-    @Test
-    fun `edit dialog does not confirm when word is blank`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        val wordField = composeTestRule.onAllNodes(hasSetTextAction())[1]
-        wordField.performTextClearance()
-
-        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
-
-        verify { onEdit wasNot called }
-        composeTestRule.onNodeWithText(string(R.string.edit_word_title)).assertIsDisplayed()
-    }
-
-    @Test
-    fun `cancelling edit dialog does not invoke onEdit`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
-
-        verify { onEdit wasNot called }
-        composeTestRule.onNodeWithText(string(R.string.edit_word_title)).assertDoesNotExist()
-    }
-
-    @Test
-    fun `edit dialog shows bidirectional checkbox unchecked for a non-bidirectional word`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).assertIsOff()
-    }
-
-    @Test
-    fun `edit dialog shows bidirectional checkbox checked for a bidirectional word`() {
-        setContent(words = listOf(bidirectionalWordWithoutOverrides))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).assertIsOn()
-    }
-
-    @Test
-    fun `customize action hidden in edit dialog until bidirectional is checked`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.add_word_customize_backward_show)).assertDoesNotExist()
-    }
-
-    @Test
-    fun `customize fields start expanded in edit dialog when the word already has reverse overrides`() {
-        setContent(words = listOf(bidirectionalWordWithOverrides))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
-            .performScrollTo()
-            .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_backward_answer_label))
-            .performScrollTo()
-            .assertIsDisplayed()
-    }
-
-    @Test
-    @Suppress("ktlint:standard:max-line-length")
-    fun `customize fields start collapsed in edit dialog when bidirectional is on but there are no reverse overrides`() {
-        setContent(words = listOf(bidirectionalWordWithoutOverrides))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_customize_backward_show))
-            .performScrollTo()
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText(string(R.string.add_word_backward_prompt_label)).assertDoesNotExist()
-    }
-
-    @Test
-    fun `checking bidirectional checkbox in edit dialog reveals the customize action`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_customize_backward_show))
-            .performScrollTo()
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun `unchecking bidirectional checkbox in edit dialog hides the customize action and fields`() {
-        setContent(words = listOf(bidirectionalWordWithOverrides))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.add_word_customize_backward_show)).assertDoesNotExist()
-        composeTestRule.onNodeWithText(string(R.string.add_word_backward_prompt_label)).assertDoesNotExist()
-    }
-
-    @Test
-    @Suppress("ktlint:standard:max-line-length")
-    fun `confirming edit dialog with bidirectional checked and no overrides saves bidirectional true with null overrides`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
-
-        verify(exactly = 1) {
-            onEdit(words[0].copy(bidirectional = true))
-        }
-    }
-
-    @Test
-    fun `confirming edit dialog with customized reverse fields saves the entered override text`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_customize_backward_show))
-            .performScrollTo()
-            .performClick()
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
-            .performScrollTo()
-            .performTextInput("Run!")
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_backward_answer_label))
-            .performScrollTo()
-            .performTextInput("Laufen")
-        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
-
-        verify(exactly = 1) {
-            onEdit(
-                words[0].copy(
-                    bidirectional = true,
-                    backwardPromptOverride = "Run!",
-                    backwardAnswerOverride = "Laufen",
-                ),
-            )
-        }
-    }
-
-    @Test
-    fun `confirming edit dialog after unchecking bidirectional clears previously saved overrides`() {
-        setContent(words = listOf(bidirectionalWordWithOverrides))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
-
-        verify(exactly = 1) {
-            onEdit(
-                bidirectionalWordWithOverrides.copy(
-                    bidirectional = false,
-                    backwardPromptOverride = null,
-                    backwardAnswerOverride = null,
-                ),
-            )
-        }
-    }
-
-    @Test
-    fun `confirming edit dialog with whitespace-only override fields saves null overrides`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_customize_backward_show))
-            .performScrollTo()
-            .performClick()
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
-            .performScrollTo()
-            .performTextInput("   ")
-        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
-
-        verify(exactly = 1) {
-            onEdit(words[0].copy(bidirectional = true))
-        }
-    }
-
-    @Test
-    fun `re-checking bidirectional in edit dialog after unchecking does not restore previously entered overrides`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_customize_backward_show))
-            .performScrollTo()
-            .performClick()
-        composeTestRule
-            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
-            .performScrollTo()
-            .performTextInput("temp")
-        composeTestRule.onNode(isToggleable()).performScrollTo().performClick()
-        composeTestRule.onNode(isToggleable()).performScrollTo().performClick()
-        composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
-
-        verify(exactly = 1) {
-            onEdit(words[0].copy(bidirectional = true))
-        }
-    }
-
-    @Test
-    fun `cancelling edit dialog after toggling bidirectional does not invoke onEdit`() {
-        setContent(words = words.take(1))
-        openMenuFor()
-        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
-
-        composeTestRule.onNode(isToggleable()).performClick()
-        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
-
-        verify { onEdit wasNot called }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `EditWordDialog` now has the same "bidirectional" checkbox + optional "Customize reverse card" fields as the Add Word screen, reusing the existing `BidirectionalOptionSection` composable rather than duplicating it.
- Extracted the shared checkbox toggle/clear-on-uncheck logic and the blank-to-null override mapping into a new `BidirectionalFields` type (`ui/BidirectionalFields.kt`), and refactored `AddWordUiState`'s equivalent functions to delegate to it — same behavior, single source of truth.
- When editing a word that already has non-blank reverse overrides, the customize section now starts expanded so the user sees what's already customized without an extra click.
- **Repository fix**: enabling bidirectional via edit on a word that's already been reviewed forward previously had no way to ever get its backward card scheduled (the natural "first-ever review" seed in `reviewVocabularyItem` can't fire again for such a row). `VocabularyRepositoryImpl.updateVocabularyItem` now seeds `backwardFsrsDueAt` directly in that specific case, without touching already-new rows or already-scheduled backward progress.
- Localized `EditWordDialog`'s Save/Cancel buttons to string resources (`action_save`, `action_cancel`), matching every other dialog in the file; added translations for `action_save` across all supported locales.

Two gaps were investigated and deliberately left out of this change (documented in the plan, not silently dropped): renaming a word via edit to collide with another word's text can throw an uncaught unique-constraint error (pre-existing, unrelated to bidirectional, needs its own duplicate-detection UX like Add-word's).

## Test plan
- [x] New `BidirectionalFieldsTest.kt` — pure unit tests for the shared toggle/clear/`toCardOptions` logic, including whitespace-only overrides and the "uncheck then re-check doesn't restore cleared text" edge case.
- [x] Extended `WordListScreenTest.kt` — Compose UI tests covering checkbox state, customize-section expand/collapse defaults, save/cancel behavior with and without overrides, and whitespace-only override handling.
- [x] Extended `VocabularyRepositoryBidirectionalTest.kt` — repository tests for the new backward-seed-on-edit behavior, confirming it doesn't fire for brand-new rows, doesn't clobber already-scheduled backward progress, and doesn't affect disabling bidirectional.
- [x] `./gradlew check` (ktlint, detekt, lintDebug, unit tests) passes clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PH7k3TXaXXhmKcEd1bs89q)_