### PR TITLE
Enable strict compiler warnings and modernize Material icons

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,10 @@ android {
     arg("appfunctions:aggregateAppFunctions", "true")
   }
   sourceSets {
-    getByName("androidTest").assets.setSrcDirs(listOf("$projectDir/schemas", "src/androidTest/assets"))
+    getByName("androidTest").assets.directories.apply {
+      clear()
+      addAll(listOf("$projectDir/schemas", "src/androidTest/assets"))
+    }
   }
 
   buildTypes {
@@ -80,6 +83,9 @@ android {
 
 kotlin {
   jvmToolchain(21)
+  compilerOptions {
+    allWarningsAsErrors = true
+  }
 }
 
 dependencies {

--- a/app/src/main/java/com/procrastilearn/app/data/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/AppRepositoryImpl.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 @Singleton
 class AppRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : AppRepository {
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override suspend fun loadLaunchableApps(): List<AppInfo> =

--- a/app/src/main/java/com/procrastilearn/app/data/connectivity/AndroidNetworkConnectivityObserver.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/connectivity/AndroidNetworkConnectivityObserver.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
 class AndroidNetworkConnectivityObserver
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
+        @param:ApplicationContext private val context: Context,
     ) : NetworkConnectivityObserver {
         private val connectivityManager =
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager

--- a/app/src/main/java/com/procrastilearn/app/data/local/prefs/PreferencesDataStore.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/prefs/PreferencesDataStore.kt
@@ -21,7 +21,7 @@ internal val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 class PreferencesDataStore
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
+        @param:ApplicationContext private val context: Context,
     ) {
         private val dataStore = context.dataStore
 

--- a/app/src/main/java/com/procrastilearn/app/domain/model/Language.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/model/Language.kt
@@ -6,7 +6,7 @@ import com.procrastilearn.app.R
 enum class Language(
     val code: String,
     val englishName: String,
-    @StringRes val displayNameRes: Int,
+    @param:StringRes val displayNameRes: Int,
 ) {
     ENGLISH("en", "English", R.string.language_name_english),
     RUSSIAN("ru", "Russian", R.string.language_name_russian),

--- a/app/src/main/java/com/procrastilearn/app/domain/parser/VocabularyImportOption.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/parser/VocabularyImportOption.kt
@@ -4,8 +4,8 @@ import androidx.annotation.StringRes
 
 data class VocabularyImportOption(
     val id: String,
-    @StringRes val titleResId: Int,
-    @StringRes val descriptionResId: Int? = null,
+    @param:StringRes val titleResId: Int,
+    @param:StringRes val descriptionResId: Int? = null,
     val mimeTypes: List<String>,
     val extensions: Set<String>,
 )

--- a/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
+++ b/app/src/main/java/com/procrastilearn/app/service/OverlayAccessibilityService.kt
@@ -296,6 +296,7 @@ class OverlayAccessibilityService : AccessibilityService() {
 
     private fun isIgnorableSystem(pkg: String): Boolean = pkg in ignoredPackages
 
+    @Suppress("DEPRECATION") // SOFT_INPUT_ADJUST_RESIZE has no WindowInsets-based equivalent for this overlay
     private fun showOverlay(initialItem: VocabularyItem) {
         if (!isProcrastilearnEnabled) {
             return

--- a/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/AddWordViewModel.kt
@@ -36,7 +36,7 @@ class AddWordViewModel @Inject
         private val translationPreferences: TranslationPreferences,
         private val generateAiTranslationUseCase: GenerateAiTranslationUseCase,
         private val connectivityObserver: NetworkConnectivityObserver,
-        @ApplicationContext private val context: Context,
+        @param:ApplicationContext private val context: Context,
         private val existingWordOverrideCoordinator: ExistingWordOverrideCoordinator,
         private val processTextEventBus: ProcessTextEventBus = ProcessTextEventBus(),
     ) : ViewModel() {

--- a/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/dojo/DojoScreen.kt
@@ -41,6 +41,7 @@ import com.procrastilearn.app.ui.dojo.components.DojoStatsHeader
 import com.procrastilearn.app.ui.theme.MyApplicationTheme
 import io.github.openspacedrepetition.Rating
 
+@Suppress("DEPRECATION") // replacement androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel is not yet published
 @Composable
 fun DojoScreen(viewModel: DojoViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsState()
@@ -157,7 +158,6 @@ private fun ratingLabel(rating: Rating): String =
         Rating.HARD -> stringResource(R.string.rating_hard)
         Rating.GOOD -> stringResource(R.string.rating_good)
         Rating.EASY -> stringResource(R.string.rating_easy)
-        else -> rating.name
     }
 
 @Composable

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/AddWordScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/AddWordScreen.kt
@@ -37,7 +37,8 @@ import com.procrastilearn.app.ui.AddWordViewModel
 import com.procrastilearn.app.ui.PendingWordUi
 import kotlinx.coroutines.delay
 
-@Suppress("MagicNumber")
+// DEPRECATION: androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel replacement isn't published yet
+@Suppress("MagicNumber", "DEPRECATION")
 @Composable
 fun AddWordScreen(
     viewModel: AddWordViewModel = hiltViewModel(),

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/AppsListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/AppsListScreen.kt
@@ -11,6 +11,7 @@ import com.procrastilearn.app.ui.AppsViewModel
 import com.procrastilearn.app.ui.theme.MyApplicationTheme
 import com.procrastilearn.app.ui.views.AppsList
 
+@Suppress("DEPRECATION") // replacement androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel is not yet published
 @Composable
 fun AppsListScreen() {
     val vm: AppsViewModel = hiltViewModel()

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
@@ -69,6 +69,7 @@ import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
 import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
 import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
 
+@Suppress("DEPRECATION") // replacement androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel is not yet published
 @Composable
 fun WordListScreen(
     onNavigateBack: () -> Unit = {},

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
@@ -99,6 +99,7 @@ sealed interface DialogState {
     object LanguageSelection : DialogState
 }
 
+@Suppress("DEPRECATION") // replacement androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel is not yet published
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/LanguagePairSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/LanguagePairSettingsItem.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -47,7 +47,7 @@ fun LanguagePairSettingsItem(
         },
         trailingContent = {
             Icon(
-                imageVector = Icons.Default.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/MixModeSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/MixModeSettingsItem.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -47,7 +47,7 @@ fun MixModeSettingsItem(
         },
         trailingContent = {
             Icon(
-                imageVector = Icons.Default.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/SettingsSectionHeader.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/SettingsSectionHeader.kt
@@ -3,7 +3,7 @@ package com.procrastilearn.app.ui.screens.settings.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,7 +19,7 @@ fun SettingsSectionHeader(
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
         if (showDivider) {
-            Divider(
+            HorizontalDivider(
                 modifier = Modifier.padding(top = 8.dp),
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
             )

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/StudyDirectionSettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/StudyDirectionSettingsItem.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CompareArrows
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -47,7 +47,7 @@ fun StudyDirectionSettingsItem(
         },
         trailingContent = {
             Icon(
-                imageVector = Icons.Default.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/procrastilearn/app/ui/views/MainScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/views/MainScreen.kt
@@ -20,6 +20,7 @@ import com.procrastilearn.app.ui.screens.AppsListScreen
 import com.procrastilearn.app.ui.screens.WordListScreen
 import com.procrastilearn.app.ui.screens.settings.SettingsScreen
 
+@Suppress("DEPRECATION") // replacement androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel is not yet published
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,

--- a/app/src/test/java/com/procrastilearn/app/domain/usecase/GenerateAiTranslationUseCaseTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/domain/usecase/GenerateAiTranslationUseCaseTest.kt
@@ -12,6 +12,7 @@ import com.procrastilearn.app.domain.model.Language
 import com.procrastilearn.app.domain.model.LanguagePair
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -19,6 +20,7 @@ import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class GenerateAiTranslationUseCaseTest {
     private val openAiStore: OpenAiPreferencesStore = mockk()
     private val languagePreferencesStore: LanguagePreferencesStore = mockk()


### PR DESCRIPTION
## Summary
This PR enables strict Kotlin compiler warnings (`allWarningsAsErrors = true`) and addresses all resulting deprecation warnings by modernizing Material icon imports and adding targeted `@Suppress` annotations where necessary.

## Key Changes

- **Compiler strictness**: Enable `allWarningsAsErrors` in Kotlin compiler options to catch issues early
- **Material icon modernization**: Replace deprecated `Icons.Default.KeyboardArrowRight` with `Icons.AutoMirrored.Filled.KeyboardArrowRight` in settings components
- **Deprecated Compose API updates**: Replace `Divider` with `HorizontalDivider` in `SettingsSectionHeader`
- **Annotation target fixes**: Add `@param:` prefix to `@StringRes` and `@ApplicationContext` annotations on constructor parameters to suppress compiler warnings about incorrect annotation targets
- **Deprecation suppressions**: Add `@Suppress("DEPRECATION")` comments to screens using `hiltViewModel()` (which is deprecated pending androidx replacement) and to `OverlayAccessibilityService.showOverlay()` for `SOFT_INPUT_ADJUST_RESIZE`
- **Build configuration**: Refactor `androidTest` assets configuration to use `directories.apply` pattern for clarity
- **Test API opt-in**: Add `@OptIn(ExperimentalCoroutinesApi::class)` to `GenerateAiTranslationUseCaseTest` to suppress experimental API warning
- **Exhaustive when**: Remove unreachable `else` branch in `ratingLabel()` function to satisfy exhaustiveness check

All changes maintain backward compatibility and improve code quality without altering functionality.

https://claude.ai/code/session_01RSW2S8KxE4NTtGkMPV4JaV