### PR TITLE
feat: add leading LibraryAdd icon to Add Cards For Today row

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/AddCardsForTodaySettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/AddCardsForTodaySettingsItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.LibraryAdd
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -22,6 +23,13 @@ fun AddCardsForTodaySettingsItem(
 ) {
     ListItem(
         headlineContent = { Text(stringResource(R.string.settings_add_cards_for_today_title)) },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.LibraryAdd,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
         trailingContent = {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,


### PR DESCRIPTION
## Summary
- The "Add Cards For Today" row in Settings was the only row without a leading icon; every other row (Study Mode, Review Direction, New Cards Per Day, Reviews Per Day, etc.) has one.
- Added `Icons.AutoMirrored.Filled.LibraryAdd` as the leading icon, following the exact same `ListItem` pattern used by the other settings rows (e.g. `MixModeSettingsItem`).
- Kept the existing trailing `PlaylistAdd` icon as-is.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew detekt` passes
- [ ] Manually verify the icon renders correctly in Settings on device/emulator

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWwkCH4ZSV5W6hzyx2srdX)_