### PR TITLE
Add bulk "Test both directions" / "Test forward only" to word list selection

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
@@ -44,4 +44,25 @@ interface VocabularyDao {
 
     @Query("DELETE FROM vocabulary")
     suspend fun deleteAllVocabulary()
+
+    // Enabling seeds backwardFsrsDueAt only for rows already reviewed forward and never
+    // seeded backward, mirroring the seed rule in VocabularyRepositoryImpl.updateVocabularyItem
+    // so a newly-enabled reverse card actually becomes reviewable instead of staying dormant.
+    @Query(
+        """
+        UPDATE vocabulary
+        SET
+            bidirectional = :bidirectional,
+            backwardFsrsDueAt = CASE
+                WHEN :bidirectional = 1 AND fsrsDueAt != 0 AND backwardFsrsDueAt = 0 THEN :seedDueAt
+                ELSE backwardFsrsDueAt
+            END
+        WHERE id IN (:ids)
+    """,
+    )
+    suspend fun setBidirectional(
+        ids: List<Long>,
+        bidirectional: Boolean,
+        seedDueAt: Long,
+    )
 }

--- a/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
@@ -45,9 +45,6 @@ interface VocabularyDao {
     @Query("DELETE FROM vocabulary")
     suspend fun deleteAllVocabulary()
 
-    // Enabling seeds backwardFsrsDueAt only for rows already reviewed forward and never
-    // seeded backward, mirroring the seed rule in VocabularyRepositoryImpl.updateVocabularyItem
-    // so a newly-enabled reverse card actually becomes reviewable instead of staying dormant.
     @Query(
         """
         UPDATE vocabulary

--- a/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
@@ -470,20 +470,20 @@ class VocabularyRepositoryImpl
                 prefs.resetFor(today)
             }
         }
+    }
 
-        private fun VocabularyEntity.ensureFsrs(direction: StudyDirection): VocabularyEntity =
-            when (direction) {
-                StudyDirection.FORWARD ->
-                    if (fsrsCardJson.isNotBlank()) {
-                        this
-                    } else {
-                        copy(fsrsCardJson = Card.builder().build().toJson(), fsrsDueAt = 0L)
-                    }
-                StudyDirection.BACKWARD ->
-                    if (backwardFsrsCardJson.isNotBlank()) {
-                        this
-                    } else {
-                        copy(backwardFsrsCardJson = Card.builder().build().toJson(), backwardFsrsDueAt = 0L)
-                    }
+internal fun VocabularyEntity.ensureFsrs(direction: StudyDirection): VocabularyEntity =
+    when (direction) {
+        StudyDirection.FORWARD ->
+            if (fsrsCardJson.isNotBlank()) {
+                this
+            } else {
+                copy(fsrsCardJson = Card.builder().build().toJson(), fsrsDueAt = 0L)
+            }
+        StudyDirection.BACKWARD ->
+            if (backwardFsrsCardJson.isNotBlank()) {
+                this
+            } else {
+                copy(backwardFsrsCardJson = Card.builder().build().toJson(), backwardFsrsDueAt = 0L)
             }
     }

--- a/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImpl.kt
@@ -36,6 +36,10 @@ import javax.inject.Singleton
 
 private const val UNDO_STACK_CAP = 3
 
+// SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 on older Android versions; stay
+// comfortably under it when binding id lists for bulk operations.
+private const val MAX_SQLITE_BIND_ARGS = 900
+
 // How far past the first-ever review of a bidirectional card its other direction's due
 // date is seeded, so the just-answered card's opposite direction doesn't immediately
 // re-surface in the very next pick.
@@ -115,6 +119,21 @@ class VocabularyRepositoryImpl
                 appDatabase.withTransaction {
                     vocabularyDao.deleteVocabulary(items.map { it.toEntity() })
                     undoSnapshotDao.deleteForVocabIds(items.map { it.id })
+                }
+            }
+
+        override suspend fun setBidirectional(
+            ids: Set<Long>,
+            bidirectional: Boolean,
+        ): Unit =
+            withContext(io) {
+                if (ids.isEmpty()) return@withContext
+                val seedDueAt = System.currentTimeMillis()
+                appDatabase.withTransaction {
+                    ids.chunked(MAX_SQLITE_BIND_ARGS).forEach { chunk ->
+                        vocabularyDao.setBidirectional(chunk, bidirectional, seedDueAt)
+                        undoSnapshotDao.deleteForVocabIds(chunk)
+                    }
                 }
             }
 
@@ -452,7 +471,6 @@ class VocabularyRepositoryImpl
             }
         }
 
-        // --- existing helpers unchanged ---
         private fun VocabularyEntity.ensureFsrs(direction: StudyDirection): VocabularyEntity =
             when (direction) {
                 StudyDirection.FORWARD ->

--- a/app/src/main/java/com/procrastilearn/app/domain/repository/VocabularyCatalogRepository.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/repository/VocabularyCatalogRepository.kt
@@ -17,4 +17,9 @@ interface VocabularyCatalogRepository {
     suspend fun deleteVocabularyItems(items: List<VocabularyItem>)
 
     suspend fun resetVocabularyProgress(item: VocabularyItem)
+
+    suspend fun setBidirectional(
+        ids: Set<Long>,
+        bidirectional: Boolean,
+    )
 }

--- a/app/src/main/java/com/procrastilearn/app/ui/BidirectionalFields.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/BidirectionalFields.kt
@@ -7,13 +7,7 @@ internal data class BidirectionalFields(
     val backwardAnswerOverride: String = "",
 )
 
-internal fun BidirectionalFields.toggled(checked: Boolean): BidirectionalFields =
-    copy(
-        bidirectional = checked,
-        isCustomizingBackward = if (checked) isCustomizingBackward else false,
-        backwardPromptOverride = if (checked) backwardPromptOverride else "",
-        backwardAnswerOverride = if (checked) backwardAnswerOverride else "",
-    )
+internal fun BidirectionalFields.toggled(checked: Boolean): BidirectionalFields = copy(bidirectional = checked)
 
 internal fun BidirectionalFields.toCardOptions(): BidirectionalCardOptions =
     BidirectionalCardOptions(

--- a/app/src/main/java/com/procrastilearn/app/ui/WordListViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/WordListViewModel.kt
@@ -88,4 +88,21 @@ class WordListViewModel
                 exitSelectionMode()
             }
         }
+
+        fun setSelectedWordsBidirectional(bidirectional: Boolean) {
+            val ids = selectedIdsNeedingChange(bidirectional)
+            if (ids.isEmpty()) return
+            viewModelScope.launch {
+                repository.setBidirectional(ids, bidirectional)
+                exitSelectionMode()
+            }
+        }
+
+        private fun selectedIdsNeedingChange(bidirectional: Boolean): Set<Long> {
+            val selected = _selectionState.value.selectedIds
+            return words.value
+                .filter { it.id in selected && it.bidirectional != bidirectional }
+                .map { it.id }
+                .toSet()
+        }
     }

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
@@ -97,6 +97,7 @@ fun WordListScreen(
         onDeselectAll = viewModel::deselectAll,
         onExitSelectionMode = viewModel::exitSelectionMode,
         onDeleteSelected = viewModel::deleteSelectedWords,
+        onSetSelectedBidirectional = viewModel::setSelectedWordsBidirectional,
         onNavigateBack = onNavigateBack,
     )
 }
@@ -118,6 +119,7 @@ internal fun WordListContent(
     onDeselectAll: () -> Unit = {},
     onExitSelectionMode: () -> Unit = {},
     onDeleteSelected: () -> Unit = {},
+    onSetSelectedBidirectional: (Boolean) -> Unit = {},
     onNavigateBack: () -> Unit = {},
 ) {
     val normalizedQuery = searchQuery.trim()
@@ -130,8 +132,13 @@ internal fun WordListContent(
 
     var showSelectionMenu by remember { mutableStateOf(false) }
     var showBulkDeleteDialog by remember { mutableStateOf(false) }
+    var showForwardOnlyDialog by remember { mutableStateOf(false) }
     val allDisplayedSelected =
         displayedWords.isNotEmpty() && displayedWords.all { it.id in selectionState.selectedIds }
+    val selectedWords = words.filter { it.id in selectionState.selectedIds }
+    val canEnableBidirectional = selectedWords.any { !it.bidirectional }
+    val canDisableBidirectional = selectedWords.any { it.bidirectional }
+    val bidirectionalSelectedCount = selectedWords.count { it.bidirectional }
 
     BackHandler(enabled = selectionState.isActive) {
         onExitSelectionMode()
@@ -185,40 +192,35 @@ internal fun WordListContent(
                             tint = MaterialTheme.colorScheme.primary,
                         )
                     }
-                    DropdownMenu(
+                    WordListSelectionMenu(
                         expanded = showSelectionMenu,
+                        allDisplayedSelected = allDisplayedSelected,
+                        canSelectAll = displayedWords.isNotEmpty(),
+                        canEnableBidirectional = canEnableBidirectional,
+                        canDisableBidirectional = canDisableBidirectional,
+                        canDelete = selectionState.selectedIds.isNotEmpty(),
                         onDismissRequest = { showSelectionMenu = false },
-                    ) {
-                        DropdownMenuItem(
-                            text = {
-                                Text(
-                                    text =
-                                        stringResource(
-                                            if (allDisplayedSelected) {
-                                                R.string.action_deselect_all
-                                            } else {
-                                                R.string.action_select_all
-                                            },
-                                        ),
-                                )
-                            },
-                            onClick = {
-                                showSelectionMenu = false
-                                if (allDisplayedSelected) {
-                                    onDeselectAll()
-                                } else {
-                                    onSelectAll(displayedWords.map { it.id })
-                                }
-                            },
-                        )
-                        DropdownMenuItem(
-                            text = { Text(text = stringResource(R.string.action_delete)) },
-                            onClick = {
-                                showSelectionMenu = false
-                                showBulkDeleteDialog = true
-                            },
-                        )
-                    }
+                        onToggleSelectAll = {
+                            showSelectionMenu = false
+                            if (allDisplayedSelected) {
+                                onDeselectAll()
+                            } else {
+                                onSelectAll(displayedWords.map { it.id })
+                            }
+                        },
+                        onEnableBidirectional = {
+                            showSelectionMenu = false
+                            onSetSelectedBidirectional(true)
+                        },
+                        onDisableBidirectional = {
+                            showSelectionMenu = false
+                            showForwardOnlyDialog = true
+                        },
+                        onDelete = {
+                            showSelectionMenu = false
+                            showBulkDeleteDialog = true
+                        },
+                    )
                 }
             }
         }
@@ -340,6 +342,17 @@ internal fun WordListContent(
             onConfirm = {
                 onDeleteSelected()
                 showBulkDeleteDialog = false
+            },
+        )
+    }
+
+    if (showForwardOnlyDialog) {
+        ForwardOnlyConfirmDialog(
+            count = bidirectionalSelectedCount,
+            onDismiss = { showForwardOnlyDialog = false },
+            onConfirm = {
+                onSetSelectedBidirectional(false)
+                showForwardOnlyDialog = false
             },
         )
     }

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListSelectionMenu.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListSelectionMenu.kt
@@ -1,0 +1,92 @@
+package com.procrastilearn.app.ui.screens
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import com.procrastilearn.app.R
+
+@Composable
+internal fun WordListSelectionMenu(
+    expanded: Boolean,
+    allDisplayedSelected: Boolean,
+    canSelectAll: Boolean,
+    canEnableBidirectional: Boolean,
+    canDisableBidirectional: Boolean,
+    canDelete: Boolean,
+    onDismissRequest: () -> Unit,
+    onToggleSelectAll: () -> Unit,
+    onEnableBidirectional: () -> Unit,
+    onDisableBidirectional: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+    ) {
+        DropdownMenuItem(
+            text = {
+                Text(
+                    text =
+                        stringResource(
+                            if (allDisplayedSelected) {
+                                R.string.action_deselect_all
+                            } else {
+                                R.string.action_select_all
+                            },
+                        ),
+                )
+            },
+            enabled = canSelectAll,
+            onClick = onToggleSelectAll,
+        )
+        DropdownMenuItem(
+            text = { Text(text = stringResource(R.string.word_list_bulk_bidirectional_enable)) },
+            enabled = canEnableBidirectional,
+            onClick = onEnableBidirectional,
+        )
+        DropdownMenuItem(
+            text = { Text(text = stringResource(R.string.word_list_bulk_bidirectional_disable)) },
+            enabled = canDisableBidirectional,
+            onClick = onDisableBidirectional,
+        )
+        DropdownMenuItem(
+            text = { Text(text = stringResource(R.string.action_delete)) },
+            enabled = canDelete,
+            onClick = onDelete,
+        )
+    }
+}
+
+@Composable
+internal fun ForwardOnlyConfirmDialog(
+    count: Int,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = stringResource(R.string.word_list_bulk_forward_only_confirm_title))
+        },
+        text = {
+            Text(
+                text = pluralStringResource(R.plurals.word_list_bulk_forward_only_confirm_message, count, count),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = stringResource(R.string.action_continue))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -281,6 +281,9 @@
     <string name="word_list_more_actions">Más acciones</string>
     <string name="word_list_more_actions_selection">Acciones de selección</string>
     <string name="word_list_bulk_delete_confirm_title">Eliminar palabras seleccionadas</string>
+    <string name="word_list_bulk_bidirectional_enable">@string/add_word_bidirectional_toggle</string>
+    <string name="word_list_bulk_bidirectional_disable">Practicar solo hacia adelante</string>
+    <string name="word_list_bulk_forward_only_confirm_title">@string/word_list_bulk_bidirectional_disable</string>
     <string name="word_list_search_label">Buscar</string>
     <string name="word_list_search_placeholder">Buscar palabras</string>
     <string name="word_list_search_no_results">No se encontraron resultados</string>
@@ -316,5 +319,10 @@
         <item quantity="one">¿Eliminar %1$d palabra seleccionada de tu lista?</item>
         <item quantity="many">¿Eliminar %1$d palabras seleccionadas de tu lista?</item>
         <item quantity="other">¿Eliminar %1$d palabras seleccionadas de tu lista?</item>
+    </plurals>
+    <plurals name="word_list_bulk_forward_only_confirm_message">
+        <item quantity="one">¿Dejar de practicar %1$d palabra en sentido inverso? El progreso inverso se conserva y se restaura si vuelves a activarlo.</item>
+        <item quantity="many">¿Dejar de practicar %1$d palabras en sentido inverso? El progreso inverso se conserva y se restaura si vuelves a activarlo.</item>
+        <item quantity="other">¿Dejar de practicar %1$d palabras en sentido inverso? El progreso inverso se conserva y se restaura si vuelves a activarlo.</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -281,6 +281,9 @@
     <string name="word_list_more_actions">Plus d’actions</string>
     <string name="word_list_more_actions_selection">Actions de sélection</string>
     <string name="word_list_bulk_delete_confirm_title">Supprimer les mots sélectionnés</string>
+    <string name="word_list_bulk_bidirectional_enable">@string/add_word_bidirectional_toggle</string>
+    <string name="word_list_bulk_bidirectional_disable">Tester dans un seul sens</string>
+    <string name="word_list_bulk_forward_only_confirm_title">@string/word_list_bulk_bidirectional_disable</string>
     <string name="word_list_search_label">Rechercher</string>
     <string name="word_list_search_placeholder">Rechercher des mots</string>
     <string name="word_list_search_no_results">Aucun résultat trouvé</string>
@@ -316,5 +319,10 @@
         <item quantity="one">Supprimer %1$d mot de votre liste ?</item>
         <item quantity="many">Supprimer %1$d mots de votre liste ?</item>
         <item quantity="other">Supprimer %1$d mots de votre liste ?</item>
+    </plurals>
+    <plurals name="word_list_bulk_forward_only_confirm_message">
+        <item quantity="one">Arrêter de tester %1$d mot dans le sens inverse ? La progression inverse est conservée et restaurée si vous la réactivez.</item>
+        <item quantity="many">Arrêter de tester %1$d mots dans le sens inverse ? La progression inverse est conservée et restaurée si vous la réactivez.</item>
+        <item quantity="other">Arrêter de tester %1$d mots dans le sens inverse ? La progression inverse est conservée et restaurée si vous la réactivez.</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -281,6 +281,9 @@
     <string name="word_list_more_actions">Altre azioni</string>
     <string name="word_list_more_actions_selection">Azioni di selezione</string>
     <string name="word_list_bulk_delete_confirm_title">Elimina parole selezionate</string>
+    <string name="word_list_bulk_bidirectional_enable">@string/add_word_bidirectional_toggle</string>
+    <string name="word_list_bulk_bidirectional_disable">Verifica solo in avanti</string>
+    <string name="word_list_bulk_forward_only_confirm_title">@string/word_list_bulk_bidirectional_disable</string>
     <string name="word_list_search_label">Cerca</string>
     <string name="word_list_search_placeholder">Cerca parole</string>
     <string name="word_list_search_no_results">Nessun risultato trovato</string>
@@ -316,5 +319,10 @@
         <item quantity="one">Eliminare %1$d parola selezionata dal tuo elenco?</item>
         <item quantity="many">Eliminare %1$d parole selezionate dal tuo elenco?</item>
         <item quantity="other">Eliminare %1$d parole selezionate dal tuo elenco?</item>
+    </plurals>
+    <plurals name="word_list_bulk_forward_only_confirm_message">
+        <item quantity="one">Interrompere il test di %1$d parola al contrario? Il progresso inverso viene mantenuto e ripristinato se lo riattivi.</item>
+        <item quantity="many">Interrompere il test di %1$d parole al contrario? Il progresso inverso viene mantenuto e ripristinato se lo riattivi.</item>
+        <item quantity="other">Interrompere il test di %1$d parole al contrario? Il progresso inverso viene mantenuto e ripristinato se lo riattivi.</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -246,6 +246,9 @@
         <string name="word_list_more_actions">Дополнительные действия</string>
         <string name="word_list_more_actions_selection">Действия с выбранными</string>
         <string name="word_list_bulk_delete_confirm_title">Удалить выбранные слова</string>
+        <string name="word_list_bulk_bidirectional_enable">@string/add_word_bidirectional_toggle</string>
+        <string name="word_list_bulk_bidirectional_disable">Проверять только в прямом направлении</string>
+        <string name="word_list_bulk_forward_only_confirm_title">@string/word_list_bulk_bidirectional_disable</string>
         <string name="word_list_search_label">Поиск</string>
         <string name="word_list_search_placeholder">Поиск слов</string>
         <string name="word_list_search_no_results">Совпадений не найдено</string>
@@ -304,6 +307,12 @@
             <item quantity="few">Удалить %1$d слова из списка?</item>
             <item quantity="many">Удалить %1$d слов из списка?</item>
             <item quantity="other">Удалить %1$d слова из списка?</item>
+        </plurals>
+        <plurals name="word_list_bulk_forward_only_confirm_message">
+            <item quantity="one">Перестать проверять %1$d слово в обратном направлении? Прогресс в обратном направлении сохранится и восстановится, если вы включите это снова.</item>
+            <item quantity="few">Перестать проверять %1$d слова в обратном направлении? Прогресс в обратном направлении сохранится и восстановится, если вы включите это снова.</item>
+            <item quantity="many">Перестать проверять %1$d слов в обратном направлении? Прогресс в обратном направлении сохранится и восстановится, если вы включите это снова.</item>
+            <item quantity="other">Перестать проверять %1$d слова в обратном направлении? Прогресс в обратном направлении сохранится и восстановится, если вы включите это снова.</item>
         </plurals>
 
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -281,6 +281,9 @@
     <string name="word_list_more_actions">Додаткові дії</string>
     <string name="word_list_more_actions_selection">Дії з вибраними</string>
     <string name="word_list_bulk_delete_confirm_title">Видалити вибрані слова</string>
+    <string name="word_list_bulk_bidirectional_enable">@string/add_word_bidirectional_toggle</string>
+    <string name="word_list_bulk_bidirectional_disable">Перевіряти лише в прямому напрямку</string>
+    <string name="word_list_bulk_forward_only_confirm_title">@string/word_list_bulk_bidirectional_disable</string>
     <string name="word_list_search_label">Пошук</string>
     <string name="word_list_search_placeholder">Пошук слів</string>
     <string name="word_list_search_no_results">Збігів не знайдено</string>
@@ -321,5 +324,11 @@
         <item quantity="few">Видалити %1$d слова зі списку?</item>
         <item quantity="many">Видалити %1$d слів зі списку?</item>
         <item quantity="other">Видалити %1$d слова зі списку?</item>
+    </plurals>
+    <plurals name="word_list_bulk_forward_only_confirm_message">
+        <item quantity="one">Припинити перевіряти %1$d слово у зворотному напрямку? Прогрес у зворотному напрямку зберігається і відновлюється, якщо ви увімкнете це знову.</item>
+        <item quantity="few">Припинити перевіряти %1$d слова у зворотному напрямку? Прогрес у зворотному напрямку зберігається і відновлюється, якщо ви увімкнете це знову.</item>
+        <item quantity="many">Припинити перевіряти %1$d слів у зворотному напрямку? Прогрес у зворотному напрямку зберігається і відновлюється, якщо ви увімкнете це знову.</item>
+        <item quantity="other">Припинити перевіряти %1$d слова у зворотному напрямку? Прогрес у зворотному напрямку зберігається і відновлюється, якщо ви увімкнете це знову.</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -250,6 +250,9 @@
     <string name="word_list_more_actions">更多操作</string>
     <string name="word_list_more_actions_selection">选择操作</string>
     <string name="word_list_bulk_delete_confirm_title">删除所选单词</string>
+    <string name="word_list_bulk_bidirectional_enable">@string/add_word_bidirectional_toggle</string>
+    <string name="word_list_bulk_bidirectional_disable">仅正向测试</string>
+    <string name="word_list_bulk_forward_only_confirm_title">@string/word_list_bulk_bidirectional_disable</string>
     <string name="word_list_search_label">搜索</string>
     <string name="word_list_search_placeholder">搜索单词</string>
     <string name="word_list_search_no_results">未找到匹配结果</string>
@@ -275,5 +278,8 @@
     </plurals>
     <plurals name="word_list_bulk_delete_confirm_message">
         <item quantity="other">确定要从列表中删除已选择的 %1$d 个单词吗？</item>
+    </plurals>
+    <plurals name="word_list_bulk_forward_only_confirm_message">
+        <item quantity="other">停止反向测试已选择的 %1$d 个单词？反向进度会被保留，重新开启后即可恢复。</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,9 @@
     <string name="word_list_more_actions">More actions</string>
     <string name="word_list_more_actions_selection">Selection actions</string>
     <string name="word_list_bulk_delete_confirm_title">Delete selected words</string>
+    <string name="word_list_bulk_bidirectional_enable">@string/add_word_bidirectional_toggle</string>
+    <string name="word_list_bulk_bidirectional_disable">Test forward only</string>
+    <string name="word_list_bulk_forward_only_confirm_title">@string/word_list_bulk_bidirectional_disable</string>
     <string name="word_list_search_label">Search</string>
     <string name="word_list_search_placeholder">Search words</string>
     <string name="word_list_search_no_results">No matches found</string>
@@ -311,5 +314,9 @@
     <plurals name="word_list_bulk_delete_confirm_message">
         <item quantity="one">Delete %1$d word from your list?</item>
         <item quantity="other">Delete %1$d words from your list?</item>
+    </plurals>
+    <plurals name="word_list_bulk_forward_only_confirm_message">
+        <item quantity="one">Stop testing %1$d word in reverse? Reverse progress is kept and restored if you turn it back on.</item>
+        <item quantity="other">Stop testing %1$d words in reverse? Reverse progress is kept and restored if you turn it back on.</item>
     </plurals>
 </resources>

--- a/app/src/test/java/com/procrastilearn/app/data/local/dao/VocabularyDaoTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/dao/VocabularyDaoTest.kt
@@ -1,0 +1,230 @@
+package com.procrastilearn.app.data.local.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.database.AppDatabase
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class VocabularyDaoTest {
+    private lateinit var database: AppDatabase
+    private lateinit var dao: VocabularyDao
+
+    @Before
+    fun setup() {
+        database =
+            Room
+                .inMemoryDatabaseBuilder(
+                    ApplicationProvider.getApplicationContext(),
+                    AppDatabase::class.java,
+                ).allowMainThreadQueries()
+                .build()
+        dao = database.vocabularyDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private suspend fun insert(
+        word: String,
+        bidirectional: Boolean = false,
+        fsrsDueAt: Long = 0L,
+        backwardFsrsDueAt: Long = 0L,
+        translation: String = word,
+        backwardPromptOverride: String? = null,
+        backwardAnswerOverride: String? = null,
+        fsrsCardJson: String = "forward-json",
+        backwardFsrsCardJson: String = "backward-json",
+        correctCount: Int = 0,
+        incorrectCount: Int = 0,
+        backwardCorrectCount: Int = 0,
+        backwardIncorrectCount: Int = 0,
+    ): Long =
+        dao.insertVocabulary(
+            VocabularyEntity(
+                word = word,
+                translation = translation,
+                bidirectional = bidirectional,
+                fsrsDueAt = fsrsDueAt,
+                backwardFsrsDueAt = backwardFsrsDueAt,
+                backwardPromptOverride = backwardPromptOverride,
+                backwardAnswerOverride = backwardAnswerOverride,
+                fsrsCardJson = fsrsCardJson,
+                backwardFsrsCardJson = backwardFsrsCardJson,
+                correctCount = correctCount,
+                incorrectCount = incorrectCount,
+                backwardCorrectCount = backwardCorrectCount,
+                backwardIncorrectCount = backwardIncorrectCount,
+            ),
+        )
+
+    private suspend fun entityById(id: Long): VocabularyEntity = requireNotNull(dao.getVocabularyById(id))
+
+    @Test
+    fun `setBidirectional enables the flag for every id in the list`() =
+        runTest {
+            val first = insert("Haus")
+            val second = insert("Baum")
+
+            dao.setBidirectional(listOf(first, second), bidirectional = true, seedDueAt = 100L)
+
+            assertThat(entityById(first).bidirectional).isTrue()
+            assertThat(entityById(second).bidirectional).isTrue()
+        }
+
+    @Test
+    fun `setBidirectional disables the flag for every id in the list`() =
+        runTest {
+            val first = insert("Haus", bidirectional = true)
+            val second = insert("Baum", bidirectional = true)
+
+            dao.setBidirectional(listOf(first, second), bidirectional = false, seedDueAt = 100L)
+
+            assertThat(entityById(first).bidirectional).isFalse()
+            assertThat(entityById(second).bidirectional).isFalse()
+        }
+
+    @Test
+    fun `setBidirectional leaves rows outside the id list untouched`() =
+        runTest {
+            val included = insert("Haus")
+            val excluded = insert("Baum")
+
+            dao.setBidirectional(listOf(included), bidirectional = true, seedDueAt = 100L)
+
+            assertThat(entityById(included).bidirectional).isTrue()
+            assertThat(entityById(excluded).bidirectional).isFalse()
+        }
+
+    @Test
+    fun `setBidirectional seeds backwardFsrsDueAt when the row was already reviewed forward`() =
+        runTest {
+            val id = insert("Haus", fsrsDueAt = 500L, backwardFsrsDueAt = 0L)
+
+            dao.setBidirectional(listOf(id), bidirectional = true, seedDueAt = 999L)
+
+            assertThat(entityById(id).backwardFsrsDueAt).isEqualTo(999L)
+        }
+
+    @Test
+    fun `setBidirectional does not seed a row that has never been reviewed`() =
+        runTest {
+            val id = insert("Haus", fsrsDueAt = 0L, backwardFsrsDueAt = 0L)
+
+            dao.setBidirectional(listOf(id), bidirectional = true, seedDueAt = 999L)
+
+            assertThat(entityById(id).backwardFsrsDueAt).isEqualTo(0L)
+        }
+
+    @Test
+    fun `setBidirectional does not overwrite an existing backwardFsrsDueAt`() =
+        runTest {
+            val id = insert("Haus", fsrsDueAt = 500L, backwardFsrsDueAt = 250L)
+
+            dao.setBidirectional(listOf(id), bidirectional = true, seedDueAt = 999L)
+
+            assertThat(entityById(id).backwardFsrsDueAt).isEqualTo(250L)
+        }
+
+    @Test
+    fun `setBidirectional never seeds when disabling`() =
+        runTest {
+            val id = insert("Haus", fsrsDueAt = 500L, backwardFsrsDueAt = 0L)
+
+            dao.setBidirectional(listOf(id), bidirectional = false, seedDueAt = 999L)
+
+            assertThat(entityById(id).backwardFsrsDueAt).isEqualTo(0L)
+            assertThat(entityById(id).bidirectional).isFalse()
+        }
+
+    @Test
+    fun `setBidirectional leaves word translation and both override columns unchanged`() =
+        runTest {
+            val id =
+                insert(
+                    "Haus",
+                    translation = "house",
+                    backwardPromptOverride = "custom prompt",
+                    backwardAnswerOverride = "custom answer",
+                )
+
+            dao.setBidirectional(listOf(id), bidirectional = true, seedDueAt = 100L)
+
+            val entity = entityById(id)
+            assertThat(entity.word).isEqualTo("Haus")
+            assertThat(entity.translation).isEqualTo("house")
+            assertThat(entity.backwardPromptOverride).isEqualTo("custom prompt")
+            assertThat(entity.backwardAnswerOverride).isEqualTo("custom answer")
+        }
+
+    @Test
+    fun `setBidirectional leaves both fsrs card json blobs and all four counters unchanged`() =
+        runTest {
+            val id =
+                insert(
+                    "Haus",
+                    fsrsDueAt = 500L,
+                    fsrsCardJson = "fwd-json",
+                    backwardFsrsCardJson = "bwd-json",
+                    correctCount = 3,
+                    incorrectCount = 1,
+                    backwardCorrectCount = 2,
+                    backwardIncorrectCount = 4,
+                )
+
+            dao.setBidirectional(listOf(id), bidirectional = true, seedDueAt = 100L)
+
+            val entity = entityById(id)
+            assertThat(entity.fsrsCardJson).isEqualTo("fwd-json")
+            assertThat(entity.backwardFsrsCardJson).isEqualTo("bwd-json")
+            assertThat(entity.correctCount).isEqualTo(3)
+            assertThat(entity.incorrectCount).isEqualTo(1)
+            assertThat(entity.backwardCorrectCount).isEqualTo(2)
+            assertThat(entity.backwardIncorrectCount).isEqualTo(4)
+        }
+
+    @Test
+    fun `setBidirectional is a no-op for ids that do not exist`() =
+        runTest {
+            val id = insert("Haus")
+
+            dao.setBidirectional(listOf(999L), bidirectional = true, seedDueAt = 100L)
+
+            assertThat(entityById(id).bidirectional).isFalse()
+        }
+
+    @Test
+    fun `setBidirectional enabling an already bidirectional row changes nothing`() =
+        runTest {
+            val id = insert("Haus", bidirectional = true, fsrsDueAt = 500L, backwardFsrsDueAt = 250L)
+
+            dao.setBidirectional(listOf(id), bidirectional = true, seedDueAt = 999L)
+
+            val entity = entityById(id)
+            assertThat(entity.bidirectional).isTrue()
+            assertThat(entity.backwardFsrsDueAt).isEqualTo(250L)
+        }
+
+    @Test
+    fun `setBidirectional disabling an already forward-only row changes nothing`() =
+        runTest {
+            val id = insert("Haus", bidirectional = false, fsrsDueAt = 500L, backwardFsrsDueAt = 0L)
+
+            dao.setBidirectional(listOf(id), bidirectional = false, seedDueAt = 999L)
+
+            val entity = entityById(id)
+            assertThat(entity.bidirectional).isFalse()
+            assertThat(entity.backwardFsrsDueAt).isEqualTo(0L)
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImplTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImplTest.kt
@@ -262,6 +262,176 @@ class VocabularyRepositoryImplTest {
             assertThat(remaining).isEmpty()
         }
 
+    private suspend fun insertFullVocabulary(
+        word: String,
+        bidirectional: Boolean = false,
+        fsrsDueAt: Long = 0L,
+        backwardFsrsDueAt: Long = 0L,
+        translation: String = word,
+        backwardPromptOverride: String? = null,
+        backwardAnswerOverride: String? = null,
+        fsrsCardJson: String = "forward-json",
+        backwardFsrsCardJson: String = "backward-json",
+        correctCount: Int = 0,
+        incorrectCount: Int = 0,
+        backwardCorrectCount: Int = 0,
+        backwardIncorrectCount: Int = 0,
+    ): Long =
+        vocabularyDao.insertVocabulary(
+            VocabularyEntity(
+                word = word,
+                translation = translation,
+                bidirectional = bidirectional,
+                fsrsDueAt = fsrsDueAt,
+                backwardFsrsDueAt = backwardFsrsDueAt,
+                backwardPromptOverride = backwardPromptOverride,
+                backwardAnswerOverride = backwardAnswerOverride,
+                fsrsCardJson = fsrsCardJson,
+                backwardFsrsCardJson = backwardFsrsCardJson,
+                correctCount = correctCount,
+                incorrectCount = incorrectCount,
+                backwardCorrectCount = backwardCorrectCount,
+                backwardIncorrectCount = backwardIncorrectCount,
+            ),
+        )
+
+    @Test
+    fun `setBidirectional enables a mixed selection leaving already bidirectional rows unchanged`() =
+        runTest {
+            val toEnable = insertFullVocabulary("Haus", bidirectional = false)
+            val alreadyEnabled = insertFullVocabulary("Baum", bidirectional = true, backwardFsrsDueAt = 42L)
+
+            repository.setBidirectional(setOf(toEnable, alreadyEnabled), bidirectional = true)
+
+            assertThat(vocabularyDao.getVocabularyById(toEnable)?.bidirectional).isTrue()
+            val untouched = vocabularyDao.getVocabularyById(alreadyEnabled)
+            assertThat(untouched?.bidirectional).isTrue()
+            assertThat(untouched?.backwardFsrsDueAt).isEqualTo(42L)
+        }
+
+    @Test
+    fun `setBidirectional disables a mixed selection leaving already forward-only rows unchanged`() =
+        runTest {
+            val toDisable = insertFullVocabulary("Haus", bidirectional = true)
+            val alreadyForward = insertFullVocabulary("Baum", bidirectional = false)
+
+            repository.setBidirectional(setOf(toDisable, alreadyForward), bidirectional = false)
+
+            assertThat(vocabularyDao.getVocabularyById(toDisable)?.bidirectional).isFalse()
+            assertThat(vocabularyDao.getVocabularyById(alreadyForward)?.bidirectional).isFalse()
+        }
+
+    @Test
+    fun `setBidirectional with an empty id set performs no writes`() =
+        runTest {
+            val id = insertFullVocabulary("Haus", bidirectional = false)
+            undoSnapshotDao.insert(testSnapshot(id))
+
+            repository.setBidirectional(emptySet(), bidirectional = true)
+
+            assertThat(vocabularyDao.getVocabularyById(id)?.bidirectional).isFalse()
+            assertThat(undoSnapshotDao.count()).isEqualTo(1)
+        }
+
+    @Test
+    fun `setBidirectional purges undo snapshots for the affected rows`() =
+        runTest {
+            val id = insertFullVocabulary("Haus", bidirectional = false)
+            undoSnapshotDao.insert(testSnapshot(id))
+
+            repository.setBidirectional(setOf(id), bidirectional = true)
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(0)
+        }
+
+    @Test
+    fun `setBidirectional leaves undo snapshots of unaffected rows intact`() =
+        runTest {
+            val changed = insertFullVocabulary("Haus", bidirectional = false)
+            val unaffected = insertFullVocabulary("Baum", bidirectional = false)
+            undoSnapshotDao.insert(testSnapshot(changed))
+            undoSnapshotDao.insert(testSnapshot(unaffected))
+
+            repository.setBidirectional(setOf(changed), bidirectional = true)
+
+            assertThat(undoSnapshotDao.count()).isEqualTo(1)
+        }
+
+    @Test
+    fun `setBidirectional seeds all rows in one batch to the same instant`() =
+        runTest {
+            val first = insertFullVocabulary("Haus", fsrsDueAt = 100L, backwardFsrsDueAt = 0L)
+            val second = insertFullVocabulary("Baum", fsrsDueAt = 200L, backwardFsrsDueAt = 0L)
+
+            repository.setBidirectional(setOf(first, second), bidirectional = true)
+
+            val firstDue = vocabularyDao.getVocabularyById(first)?.backwardFsrsDueAt
+            val secondDue = vocabularyDao.getVocabularyById(second)?.backwardFsrsDueAt
+            assertThat(firstDue).isGreaterThan(0L)
+            assertThat(firstDue).isEqualTo(secondDue)
+        }
+
+    @Test
+    fun `setBidirectional chunks id sets larger than the sqlite bind limit`() =
+        runTest {
+            val ids = (1..1000).map { insertFullVocabulary("word$it", bidirectional = false) }.toSet()
+
+            repository.setBidirectional(ids, bidirectional = true)
+
+            ids.forEach { id ->
+                assertThat(vocabularyDao.getVocabularyById(id)?.bidirectional).isTrue()
+            }
+        }
+
+    @Test
+    fun `setBidirectional preserves backward prompt and answer overrides when disabling`() =
+        runTest {
+            val id =
+                insertFullVocabulary(
+                    "Haus",
+                    bidirectional = true,
+                    backwardPromptOverride = "custom prompt",
+                    backwardAnswerOverride = "custom answer",
+                )
+
+            repository.setBidirectional(setOf(id), bidirectional = false)
+
+            val entity = vocabularyDao.getVocabularyById(id)
+            assertThat(entity?.backwardPromptOverride).isEqualTo("custom prompt")
+            assertThat(entity?.backwardAnswerOverride).isEqualTo("custom answer")
+        }
+
+    @Test
+    fun `setBidirectional preserves backward fsrs card json and counters when disabling`() =
+        runTest {
+            val id =
+                insertFullVocabulary(
+                    "Haus",
+                    bidirectional = true,
+                    backwardFsrsCardJson = "bwd-json",
+                    backwardCorrectCount = 5,
+                    backwardIncorrectCount = 2,
+                )
+
+            repository.setBidirectional(setOf(id), bidirectional = false)
+
+            val entity = vocabularyDao.getVocabularyById(id)
+            assertThat(entity?.backwardFsrsCardJson).isEqualTo("bwd-json")
+            assertThat(entity?.backwardCorrectCount).isEqualTo(5)
+            assertThat(entity?.backwardIncorrectCount).isEqualTo(2)
+        }
+
+    @Test
+    fun `re-enabling after disabling restores the previous backward due date rather than reseeding`() =
+        runTest {
+            val id = insertFullVocabulary("Haus", bidirectional = true, fsrsDueAt = 500L, backwardFsrsDueAt = 250L)
+
+            repository.setBidirectional(setOf(id), bidirectional = false)
+            repository.setBidirectional(setOf(id), bidirectional = true)
+
+            assertThat(vocabularyDao.getVocabularyById(id)?.backwardFsrsDueAt).isEqualTo(250L)
+        }
+
     @Test
     fun `resetVocabularyProgress clears scheduling state and counters`() =
         runTest {

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositorySetBidirectionalSchedulingTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositorySetBidirectionalSchedulingTest.kt
@@ -1,0 +1,113 @@
+package com.procrastilearn.app.data.repository
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.dao.VocabularyDao
+import com.procrastilearn.app.data.local.dao.VocabularyReviewDao
+import com.procrastilearn.app.data.local.dao.VocabularyStatsDao
+import com.procrastilearn.app.data.local.database.AppDatabase
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import com.procrastilearn.app.data.local.prefs.DayCountersStore
+import io.github.openspacedrepetition.Scheduler
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class VocabularyRepositorySetBidirectionalSchedulingTest {
+    private lateinit var database: AppDatabase
+    private lateinit var vocabularyDao: VocabularyDao
+    private lateinit var vocabularyReviewDao: VocabularyReviewDao
+    private lateinit var vocabularyStatsDao: VocabularyStatsDao
+    private lateinit var dayCountersStore: DayCountersStore
+    private lateinit var scheduler: Scheduler
+    private lateinit var repository: VocabularyRepositoryImpl
+
+    @Before
+    fun setup() {
+        database =
+            Room
+                .inMemoryDatabaseBuilder(
+                    ApplicationProvider.getApplicationContext(),
+                    AppDatabase::class.java,
+                ).allowMainThreadQueries()
+                .build()
+        vocabularyDao = database.vocabularyDao()
+        vocabularyReviewDao = database.vocabularyReviewDao()
+        vocabularyStatsDao = database.vocabularyStatsDao()
+        dayCountersStore = mockk(relaxed = true)
+        scheduler = Scheduler.builder().build()
+        repository =
+            VocabularyRepositoryImpl(
+                appDatabase = database,
+                scheduler = scheduler,
+                prefs = dayCountersStore,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private suspend fun insertVocabulary(
+        word: String,
+        bidirectional: Boolean = false,
+        fsrsDueAt: Long = 0L,
+        backwardFsrsDueAt: Long = 0L,
+    ): Long =
+        vocabularyDao.insertVocabulary(
+            VocabularyEntity(
+                word = word,
+                translation = word,
+                bidirectional = bidirectional,
+                fsrsDueAt = fsrsDueAt,
+                backwardFsrsDueAt = backwardFsrsDueAt,
+            ),
+        )
+
+    @Test
+    fun `setBidirectional disabling removes the row from backward review candidates`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = true, fsrsDueAt = 500L, backwardFsrsDueAt = 250L)
+
+            repository.setBidirectional(setOf(id), bidirectional = false)
+
+            assertThat(vocabularyReviewDao.pickNextBackwardReviewCandidate(1_000L)).isNull()
+        }
+
+    @Test
+    fun `setBidirectional re-enabling restores the row as a backward review candidate`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = true, fsrsDueAt = 500L, backwardFsrsDueAt = 250L)
+            repository.setBidirectional(setOf(id), bidirectional = false)
+
+            repository.setBidirectional(setOf(id), bidirectional = true)
+
+            assertThat(vocabularyReviewDao.pickNextBackwardReviewCandidate(1_000L)?.id).isEqualTo(id)
+        }
+
+    @Test
+    fun `setBidirectional enabling makes a reviewed row count as backward-due`() =
+        runTest {
+            val id = insertVocabulary("run", bidirectional = false, fsrsDueAt = 500L, backwardFsrsDueAt = 0L)
+
+            repository.setBidirectional(setOf(id), bidirectional = true)
+
+            val entity = vocabularyDao.getVocabularyById(id)!!
+            val dueCount =
+                vocabularyStatsDao.countReviewsDue(
+                    now = entity.backwardFsrsDueAt + 1,
+                    includeForward = false,
+                    includeBackward = true,
+                )
+            assertThat(dueCount).isEqualTo(1)
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/AddWordViewModelTest.kt
@@ -1637,7 +1637,7 @@ class AddWordViewModelTest {
         }
 
     @Test
-    fun `onBidirectionalToggle false collapses and clears the customize section`() =
+    fun `onBidirectionalToggle false keeps the customize section state and overrides`() =
         runTest(mainDispatcherRule.testDispatcher) {
             val viewModel = buildViewModel()
             advanceUntilIdle()
@@ -1650,9 +1650,9 @@ class AddWordViewModelTest {
 
             val state = viewModel.uiState.value
             assertThat(state.bidirectional).isFalse()
-            assertThat(state.isCustomizingBackward).isFalse()
-            assertThat(state.backwardPromptOverride).isEmpty()
-            assertThat(state.backwardAnswerOverride).isEmpty()
+            assertThat(state.isCustomizingBackward).isTrue()
+            assertThat(state.backwardPromptOverride).isEqualTo("prompt")
+            assertThat(state.backwardAnswerOverride).isEqualTo("answer")
         }
 
     @Test

--- a/app/src/test/java/com/procrastilearn/app/ui/BidirectionalFieldsTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/BidirectionalFieldsTest.kt
@@ -23,7 +23,7 @@ class BidirectionalFieldsTest {
     }
 
     @Test
-    fun `toggled false clears bidirectional customize flag and both overrides`() {
+    fun `toggled false keeps both overrides`() {
         val fields =
             BidirectionalFields(
                 bidirectional = true,
@@ -35,13 +35,27 @@ class BidirectionalFieldsTest {
         val result = fields.toggled(false)
 
         assertThat(result.bidirectional).isFalse()
-        assertThat(result.isCustomizingBackward).isFalse()
-        assertThat(result.backwardPromptOverride).isEmpty()
-        assertThat(result.backwardAnswerOverride).isEmpty()
+        assertThat(result.backwardPromptOverride).isEqualTo("prompt")
+        assertThat(result.backwardAnswerOverride).isEqualTo("answer")
     }
 
     @Test
-    fun `toggled true after a prior toggled false does not restore previously cleared overrides`() {
+    fun `toggled false keeps the customize flag`() {
+        val fields =
+            BidirectionalFields(
+                bidirectional = true,
+                isCustomizingBackward = true,
+                backwardPromptOverride = "prompt",
+                backwardAnswerOverride = "answer",
+            )
+
+        val result = fields.toggled(false)
+
+        assertThat(result.isCustomizingBackward).isTrue()
+    }
+
+    @Test
+    fun `toggled false then true round-trips back to the original fields`() {
         val fields =
             BidirectionalFields(
                 bidirectional = true,
@@ -52,10 +66,7 @@ class BidirectionalFieldsTest {
 
         val result = fields.toggled(false).toggled(true)
 
-        assertThat(result.bidirectional).isTrue()
-        assertThat(result.isCustomizingBackward).isFalse()
-        assertThat(result.backwardPromptOverride).isEmpty()
-        assertThat(result.backwardAnswerOverride).isEmpty()
+        assertThat(result).isEqualTo(fields)
     }
 
     @Test
@@ -98,5 +109,20 @@ class BidirectionalFieldsTest {
         val options = fields.toCardOptions()
 
         assertThat(options.bidirectional).isFalse()
+    }
+
+    @Test
+    fun `toCardOptions emits overrides even when bidirectional is false`() {
+        val fields =
+            BidirectionalFields(
+                bidirectional = false,
+                backwardPromptOverride = "prompt",
+                backwardAnswerOverride = "answer",
+            )
+
+        val options = fields.toCardOptions()
+
+        assertThat(options.backwardPromptOverride).isEqualTo("prompt")
+        assertThat(options.backwardAnswerOverride).isEqualTo("answer")
     }
 }

--- a/app/src/test/java/com/procrastilearn/app/ui/WordListViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/WordListViewModelTest.kt
@@ -300,4 +300,167 @@ class WordListViewModelTest {
 
             coVerify(exactly = 1) { repository.deleteVocabularyItems(listOf(first)) }
         }
+
+    private suspend fun WordListViewModel.awaitWords(items: List<VocabularyItem>) {
+        words.test {
+            awaitItem()
+            vocabularyFlow.tryEmit(items)
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setSelectedWordsBidirectional true enables only the selected words that are not yet bidirectional`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val forward = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true)
+            val alreadyBidi = forward.copy(id = 2, word = "Baum", translation = "Tree", bidirectional = true)
+            val notSelected = forward.copy(id = 3, word = "Auto", translation = "Car")
+            val viewModel = buildViewModel()
+            coEvery { repository.setBidirectional(any(), any()) } returns Unit
+            viewModel.awaitWords(listOf(forward, alreadyBidi, notSelected))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.toggleSelection(2L)
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { repository.setBidirectional(setOf(1L), true) }
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional false disables only the selected words that are bidirectional`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val bidi = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true, bidirectional = true)
+            val forwardOnly = bidi.copy(id = 2, word = "Baum", translation = "Tree", bidirectional = false)
+            val viewModel = buildViewModel()
+            coEvery { repository.setBidirectional(any(), any()) } returns Unit
+            viewModel.awaitWords(listOf(bidi, forwardOnly))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.toggleSelection(2L)
+            viewModel.setSelectedWordsBidirectional(false)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { repository.setBidirectional(setOf(1L), false) }
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional exits selection mode after the repository call`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true)
+            val viewModel = buildViewModel()
+            coEvery { repository.setBidirectional(any(), any()) } returns Unit
+            viewModel.awaitWords(listOf(item))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            assertThat(viewModel.selectionState.value).isEqualTo(WordListViewModel.SelectionState())
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional does nothing when nothing is selected`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            viewModel.enterSelectionMode(1L)
+            viewModel.toggleSelection(1L)
+
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { repository.setBidirectional(any(), any()) }
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional does nothing when every selected word is already bidirectional`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true, bidirectional = true)
+            val viewModel = buildViewModel()
+            viewModel.awaitWords(listOf(item))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { repository.setBidirectional(any(), any()) }
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional does nothing when every selected word is already forward only`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true, bidirectional = false)
+            val viewModel = buildViewModel()
+            viewModel.awaitWords(listOf(item))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.setSelectedWordsBidirectional(false)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { repository.setBidirectional(any(), any()) }
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional keeps selection mode active when it is a no-op`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true, bidirectional = true)
+            val viewModel = buildViewModel()
+            viewModel.awaitWords(listOf(item))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            assertThat(viewModel.selectionState.value)
+                .isEqualTo(WordListViewModel.SelectionState(isActive = true, selectedIds = setOf(1L)))
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional ignores selected ids that are no longer present in words`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true)
+            val viewModel = buildViewModel()
+            coEvery { repository.setBidirectional(any(), any()) } returns Unit
+            viewModel.awaitWords(listOf(item))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.toggleSelection(999L)
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { repository.setBidirectional(setOf(1L), true) }
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional includes selected words regardless of any search filter`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val first = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true)
+            val second = first.copy(id = 2, word = "Baum", translation = "Tree")
+            val viewModel = buildViewModel()
+            coEvery { repository.setBidirectional(any(), any()) } returns Unit
+            viewModel.awaitWords(listOf(first, second))
+
+            viewModel.enterSelectionMode(1L)
+            viewModel.toggleSelection(2L)
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { repository.setBidirectional(setOf(1L, 2L), true) }
+        }
+
+    @Test
+    fun `setSelectedWordsBidirectional with a single selected word delegates with that one id`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val item = VocabularyItem(id = 7, word = "lesen", translation = "read", isNew = false)
+            val viewModel = buildViewModel()
+            coEvery { repository.setBidirectional(any(), any()) } returns Unit
+            viewModel.awaitWords(listOf(item))
+
+            viewModel.enterSelectionMode(7L)
+            viewModel.setSelectedWordsBidirectional(true)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { repository.setBidirectional(setOf(7L), true) }
+        }
 }

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/EditWordDialogTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/EditWordDialogTest.kt
@@ -247,7 +247,7 @@ class EditWordDialogTest {
     }
 
     @Test
-    fun `confirming edit dialog after unchecking bidirectional clears previously saved overrides`() {
+    fun `confirming edit dialog after unchecking bidirectional keeps previously saved overrides`() {
         setContent(words = listOf(bidirectionalWordWithOverrides))
         openMenuFor()
         composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
@@ -256,13 +256,7 @@ class EditWordDialogTest {
         composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
 
         verify(exactly = 1) {
-            onEdit(
-                bidirectionalWordWithOverrides.copy(
-                    bidirectional = false,
-                    backwardPromptOverride = null,
-                    backwardAnswerOverride = null,
-                ),
-            )
+            onEdit(bidirectionalWordWithOverrides.copy(bidirectional = false))
         }
     }
 
@@ -289,7 +283,7 @@ class EditWordDialogTest {
     }
 
     @Test
-    fun `re-checking bidirectional in edit dialog after unchecking does not restore previously entered overrides`() {
+    fun `re-checking bidirectional in edit dialog after unchecking restores the previously entered overrides`() {
         setContent(words = words.take(1))
         openMenuFor()
         composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
@@ -308,7 +302,7 @@ class EditWordDialogTest {
         composeTestRule.onNodeWithText(string(R.string.action_save)).performClick()
 
         verify(exactly = 1) {
-            onEdit(words[0].copy(bidirectional = true))
+            onEdit(words[0].copy(bidirectional = true, backwardPromptOverride = "temp"))
         }
     }
 

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
@@ -3,6 +3,8 @@ package com.procrastilearn.app.ui.screens
 import android.content.Context
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -52,6 +54,7 @@ class WordListScreenTest {
     private lateinit var onDeselectAll: () -> Unit
     private lateinit var onExitSelectionMode: () -> Unit
     private lateinit var onDeleteSelected: () -> Unit
+    private lateinit var onSetSelectedBidirectional: (Boolean) -> Unit
 
     private val words =
         listOf(
@@ -73,6 +76,7 @@ class WordListScreenTest {
         onDeselectAll = mockk(relaxed = true)
         onExitSelectionMode = mockk(relaxed = true)
         onDeleteSelected = mockk(relaxed = true)
+        onSetSelectedBidirectional = mockk(relaxed = true)
     }
 
     private fun string(resId: Int) = context.getString(resId)
@@ -226,6 +230,7 @@ class WordListScreenTest {
                 onDeselectAll = onDeselectAll,
                 onExitSelectionMode = onExitSelectionMode,
                 onDeleteSelected = onDeleteSelected,
+                onSetSelectedBidirectional = onSetSelectedBidirectional,
             )
         }
     }
@@ -511,6 +516,131 @@ class WordListScreenTest {
         composeTestRule.onNodeWithText(string(R.string.word_list_search_label)).performTextInput("Ser")
 
         assertThat(query).isEqualTo("Ser")
+    }
+
+    @Test
+    fun `selection kebab shows both direction actions in selection mode`() {
+        setContent(words = words, selectionState = WordListViewModel.SelectionState(isActive = true))
+
+        openSelectionMenu()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `selection kebab is absent outside selection mode`() {
+        setContent(words = words)
+
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_more_actions_selection))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping test both directions applies immediately without a dialog`() {
+        setContent(
+            words = words,
+            selectionState = WordListViewModel.SelectionState(isActive = true, selectedIds = setOf(words[0].id)),
+        )
+        openSelectionMenu()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).performClick()
+
+        verify(exactly = 1) { onSetSelectedBidirectional(true) }
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_forward_only_confirm_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping test forward only opens the confirmation dialog instead of applying`() {
+        val bidiWords = words.map { it.copy(bidirectional = true) }
+        setContent(
+            words = bidiWords,
+            selectionState = WordListViewModel.SelectionState(isActive = true, selectedIds = setOf(bidiWords[0].id)),
+        )
+        openSelectionMenu()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_forward_only_confirm_title)).assertIsDisplayed()
+        verify { onSetSelectedBidirectional wasNot called }
+    }
+
+    @Test
+    fun `confirming the forward only dialog invokes onSetSelectedBidirectional with false`() {
+        val bidiWords = words.map { it.copy(bidirectional = true) }
+        setContent(
+            words = bidiWords,
+            selectionState = WordListViewModel.SelectionState(isActive = true, selectedIds = setOf(bidiWords[0].id)),
+        )
+        openSelectionMenu()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_continue)).performClick()
+
+        verify(exactly = 1) { onSetSelectedBidirectional(false) }
+    }
+
+    @Test
+    fun `cancelling the forward only dialog leaves the words unchanged`() {
+        val bidiWords = words.map { it.copy(bidirectional = true) }
+        setContent(
+            words = bidiWords,
+            selectionState = WordListViewModel.SelectionState(isActive = true, selectedIds = setOf(bidiWords[0].id)),
+        )
+        openSelectionMenu()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        verify { onSetSelectedBidirectional wasNot called }
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_forward_only_confirm_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `forward only dialog message counts only the selected words that are bidirectional`() {
+        val mixed =
+            listOf(
+                words[0].copy(bidirectional = true),
+                words[1].copy(bidirectional = false),
+            )
+        setContent(
+            words = mixed,
+            selectionState =
+                WordListViewModel.SelectionState(isActive = true, selectedIds = setOf(mixed[0].id, mixed[1].id)),
+        )
+        openSelectionMenu()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).performClick()
+
+        composeTestRule
+            .onNodeWithText(
+                "Stop testing 1 word in reverse? Reverse progress is kept and restored if you turn it back on.",
+            ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `direction actions reflect selected words hidden by the active search filter`() {
+        val bidiWords = words.map { it.copy(bidirectional = true) }
+        setContent(
+            words = bidiWords,
+            searchQuery = "xyz",
+            selectionState = WordListViewModel.SelectionState(isActive = true, selectedIds = setOf(bidiWords[0].id)),
+        )
+
+        openSelectionMenu()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).assertIsEnabled()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `delete menu item is greyed out when the selection is empty`() {
+        setContent(words = words, selectionState = WordListViewModel.SelectionState(isActive = true))
+
+        openSelectionMenu()
+
+        composeTestRule.onNodeWithText(string(R.string.action_delete)).assertIsNotEnabled()
     }
 
     private fun openSelectionMenu() {

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/WordListSelectionMenuTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/WordListSelectionMenuTest.kt
@@ -1,0 +1,175 @@
+package com.procrastilearn.app.ui.screens
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.procrastilearn.app.R
+import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
+import io.mockk.called
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WordListSelectionMenuTest {
+    private val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val rules: TestRule =
+        RuleChain
+            .outerRule(ComponentActivityRegistrationRule())
+            .around(composeTestRule)
+
+    private lateinit var context: Context
+    private lateinit var onDismissRequest: () -> Unit
+    private lateinit var onToggleSelectAll: () -> Unit
+    private lateinit var onEnableBidirectional: () -> Unit
+    private lateinit var onDisableBidirectional: () -> Unit
+    private lateinit var onDelete: () -> Unit
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        onDismissRequest = mockk(relaxed = true)
+        onToggleSelectAll = mockk(relaxed = true)
+        onEnableBidirectional = mockk(relaxed = true)
+        onDisableBidirectional = mockk(relaxed = true)
+        onDelete = mockk(relaxed = true)
+    }
+
+    private fun string(resId: Int) = context.getString(resId)
+
+    private fun setContent(
+        expanded: Boolean = true,
+        allDisplayedSelected: Boolean = false,
+        canSelectAll: Boolean = true,
+        canEnableBidirectional: Boolean = true,
+        canDisableBidirectional: Boolean = true,
+        canDelete: Boolean = true,
+    ) {
+        composeTestRule.setContent {
+            WordListSelectionMenu(
+                expanded = expanded,
+                allDisplayedSelected = allDisplayedSelected,
+                canSelectAll = canSelectAll,
+                canEnableBidirectional = canEnableBidirectional,
+                canDisableBidirectional = canDisableBidirectional,
+                canDelete = canDelete,
+                onDismissRequest = onDismissRequest,
+                onToggleSelectAll = onToggleSelectAll,
+                onEnableBidirectional = onEnableBidirectional,
+                onDisableBidirectional = onDisableBidirectional,
+                onDelete = onDelete,
+            )
+        }
+    }
+
+    @Test
+    fun `all four actions are listed when expanded`() {
+        setContent()
+
+        composeTestRule.onNodeWithText(string(R.string.action_select_all)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(string(R.string.action_delete)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `test both directions is enabled when at least one selected word is forward only`() {
+        setContent(canEnableBidirectional = true)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).assertIsEnabled()
+    }
+
+    @Test
+    fun `test both directions is disabled when every selected word is already bidirectional`() {
+        setContent(canEnableBidirectional = false)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `test forward only is enabled when at least one selected word is bidirectional`() {
+        setContent(canDisableBidirectional = true)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).assertIsEnabled()
+    }
+
+    @Test
+    fun `test forward only is disabled when every selected word is already forward only`() {
+        setContent(canDisableBidirectional = false)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `both direction actions are disabled when the selection is empty`() {
+        setContent(canEnableBidirectional = false, canDisableBidirectional = false)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).assertIsNotEnabled()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `delete is disabled when the selection is empty`() {
+        setContent(canDelete = false)
+
+        composeTestRule.onNodeWithText(string(R.string.action_delete)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `delete is enabled when at least one word is selected`() {
+        setContent(canDelete = true)
+
+        composeTestRule.onNodeWithText(string(R.string.action_delete)).assertIsEnabled()
+    }
+
+    @Test
+    fun `select all is disabled when no words are displayed`() {
+        setContent(canSelectAll = false)
+
+        composeTestRule.onNodeWithText(string(R.string.action_select_all)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `tapping test both directions invokes the enable callback and dismisses the menu`() {
+        setContent(canEnableBidirectional = true)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).performClick()
+
+        verify(exactly = 1) { onEnableBidirectional() }
+    }
+
+    @Test
+    fun `tapping test forward only invokes the disable callback and dismisses the menu`() {
+        setContent(canDisableBidirectional = true)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).performClick()
+
+        verify(exactly = 1) { onDisableBidirectional() }
+    }
+
+    @Test
+    fun `a disabled item does not invoke its callback when tapped`() {
+        setContent(canEnableBidirectional = false, canDisableBidirectional = false, canDelete = false)
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_enable)).performClick()
+        composeTestRule.onNodeWithText(string(R.string.word_list_bulk_bidirectional_disable)).performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_delete)).performClick()
+
+        verify { onEnableBidirectional wasNot called }
+        verify { onDisableBidirectional wasNot called }
+        verify { onDelete wasNot called }
+    }
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -9,7 +9,7 @@ complexity:
         ignoreDefaultParameters: true
         ignoreAnnotated: ['Composable']
     TooManyFunctions:
-        thresholdInClasses: 20
+        thresholdInClasses: 21
 
 naming:
     FunctionNaming:

--- a/detekt.yml
+++ b/detekt.yml
@@ -9,7 +9,7 @@ complexity:
         ignoreDefaultParameters: true
         ignoreAnnotated: ['Composable']
     TooManyFunctions:
-        thresholdInClasses: 21
+        thresholdInClasses: 20
 
 naming:
     FunctionNaming:


### PR DESCRIPTION
## Summary
- Add "Test both directions" and "Test forward only" to the word list's selection-mode kebab so a multi-selected group of words can have their bidirectional flag flipped in one action, reusing the existing seed-on-enable rule from the single-word edit flow.
- Menu items grey out when they would be a no-op (including the existing Delete item on an empty selection). Disabling asks for confirmation and preserves reverse overrides and backward FSRS progress; re-enabling restores it.
- Fix `BidirectionalFields.toggled(false)` to stop wiping the reverse prompt/answer overrides and customize-section state, applied to both the new bulk path and the existing single-word edit dialog.
- Add translated strings across all locales (en, es, fr, it, ru, uk, zh).

## Test plan
- [x] `./gradlew check` (ktlint, detekt, Android lint, unit tests — 917 test cases) passes
- [x] `./gradlew assembleDebug` builds successfully
- [x] 40 new unit tests covering DAO seeding rules, repository chunking/undo-snapshot purging, ViewModel no-op guards, and Compose menu enabled-state combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTd6JnV8UzRn4oYL1SiZhY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTd6JnV8UzRn4oYL1SiZhY)_