### PR TITLE
chore: disable Claude Code attribution footer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commits": false,
+    "pullRequests": false
+  }
+}


### PR DESCRIPTION
## Description

Adds a `.claude/settings.json` that disables the Claude Code attribution footer, turning off the "Generated by Claude Code" text appended to PR descriptions and the `Co-Authored-By` trailer appended to commit messages.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Added `.claude/settings.json` with `attribution.commits: false` and `attribution.pullRequests: false`

## How to Test

1. Have Claude Code make a commit or open a PR against this repository
2. Confirm the commit message has no `Co-Authored-By` trailer and the PR description has no "Generated by Claude Code" footer

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [ ] Added or updated tests where applicable, including edge cases
- [x] Existing tests pass locally
- [x] Updated documentation if needed
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01EhXMoZEzKSu63JutdLh17R)_