### PR TITLE
fix: correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All data (blocked apps, vocabulary, progress, and preferences) is stored locally
 - Add a kebab menu to the overlay to delete/edit the current word.
 - Track progress properties and show analytics charts.
 - Use AI to analyze existing words, estimate level and suggest new vocabulary based on that info.
-- On export, ask to keep progress for transfer or reset it for sharing the dack.
+- On export, ask to keep progress for transfer or reset it for sharing the deck.
 - Possibility to "buy" time beforehand in dojo.
 
 ### Long Term Roadmap


### PR DESCRIPTION
## Summary
- Fixed typo in README roadmap section: changed "dack" to "deck" for proper spelling

## Changes
- Updated line 40 in README.md: corrected "sharing the dack" to "sharing the deck"

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9B2xmbfNqb5Sg7CZ3FzQ7)_