### PR TITLE
fix: use non-mirrored LibraryAdd icon reference

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/AddCardsForTodaySettingsItem.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/components/AddCardsForTodaySettingsItem.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.LibraryAdd
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
+import androidx.compose.material.icons.filled.LibraryAdd
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +25,7 @@ fun AddCardsForTodaySettingsItem(
         headlineContent = { Text(stringResource(R.string.settings_add_cards_for_today_title)) },
         leadingContent = {
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.LibraryAdd,
+                imageVector = Icons.Default.LibraryAdd,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )


### PR DESCRIPTION
## Summary
- PR #58 merged `Icons.AutoMirrored.Filled.LibraryAdd`, which doesn't exist in `material-icons-extended` — `LibraryAdd` is only published under the plain `filled` package (verified by inspecting the jar contents), so `compileDebugKotlin` fails on `master`.
- Switched the leading icon on the "Add Cards For Today" settings row to `Icons.Default.LibraryAdd`.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew detekt` passes
- [x] `./gradlew lint` passes
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWwkCH4ZSV5W6hzyx2srdX)_