### PR TITLE
fix: correct typo 'dack' to 'deck' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All data (blocked apps, vocabulary, progress, and preferences) is stored locally
 - Add a kebab menu to the overlay to delete/edit the current word.
 - Track progress properties and show analytics charts.
 - Use AI to analyze existing words, estimate level and suggest new vocabulary based on that info.
-- On export, ask to keep progress for transfer or reset it for sharing the dack.
+- On export, ask to keep progress for transfer or reset it for sharing the deck.
 - Possibility to "buy" time beforehand in dojo.
 
 ### Long Term Roadmap


### PR DESCRIPTION
## Description

Corrected a typo in the README.md file where "dack" was incorrectly used instead of "deck" in the roadmap section.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Fixed typo on line 40: changed "dack" to "deck" in the roadmap description about exporting decks

## How to Test

1. Review the README.md file
2. Verify that line 40 now correctly reads "...reset it for sharing the deck."

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] No duplication introduced
- [x] No new warnings or suppressions introduced

## Related Issues

No related issues

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXG7jpH93iivTwp5RbYJbS)_