### PR TITLE
docs: replace word with hello in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ProcrastiLearn
 
-There's Anki on your phone, there's Duolingo, and you do mean to get around to them. Then you pick the phone up, and twenty minutes later you're somewhere in TikTok, not really sure how you got there. ProcrastiLearn steps in right at that moment and asks you for one word first.
+There's Anki on your phone, there's Duolingo, and you do mean to get around to them. Then you pick the phone up, and twenty minutes later you're somewhere in TikTok, not really sure how you got there. ProcrastiLearn steps in right at that moment and asks you for one hello first.
 
 ProcrastiLearn is an Android (Kotlin + Jetpack Compose) app that turns distracting moments into spaced‑repetition reps. Pick the apps you tend to open mindlessly; whenever you launch them, a full‑screen overlay blocks access until you learn/review a word. Optional OpenAI-powered translations (API key required) make adding new words fast.
 


### PR DESCRIPTION
## Description

Changed a word in README.md from "word" to "hello" for testing purposes.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Changed "word" to "hello" in the first paragraph of README.md

## How to Test

1. Review the change in README.md line 3
2. Verify the text now reads "asks you for one hello first"

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable, including edge cases
- [x] Existing tests pass locally
- [x] Updated documentation if needed
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeZRbvTNkJDzJV4zhYnwxo)_