### PR TITLE
ci: run instrumented tests on a hardware-accelerated emulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,16 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedDebugAndroidTest --no-daemon
+          script: |
+            adb logcat -c
+            adb logcat -v threadtime > /tmp/logcat.txt &
+            LOGCAT_PID=$!
+            set +e
+            ./gradlew connectedDebugAndroidTest --no-daemon
+            GRADLE_EXIT=$?
+            set -e
+            kill "$LOGCAT_PID" 2>/dev/null || true
+            exit $GRADLE_EXIT
 
       - name: Upload instrumented test reports
         if: failure()
@@ -130,3 +139,10 @@ jobs:
         with:
           name: instrumented-test-reports
           path: app/build/reports/androidTests/
+
+      - name: Upload logcat
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-logcat
+          path: /tmp/logcat.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
           path: app/build/reports/lint-results-debug.html
 
   instrumented-tests:
-    needs: verify
+    # TODO(before merge): restore `needs: verify` - dropped temporarily to run this job in
+    # parallel with verify instead of waiting ~7min for it, while iterating on the emulator
+    # setup itself.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
           path: app/build/reports/lint-results-debug.html
 
   instrumented-tests:
-    # TODO(before merge): restore `needs: verify` - dropped temporarily to run this job in
-    # parallel with verify instead of waiting ~7min for it, while iterating on the emulator
-    # setup itself.
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
   instrumented-tests:
     needs: verify
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,11 +126,21 @@ jobs:
             adb logcat -c
             adb logcat -v threadtime > /tmp/logcat.txt &
             LOGCAT_PID=$!
+            mkdir -p /tmp/screens
+            (
+              i=0
+              while [ $i -lt 90 ]; do
+                sleep 3
+                i=$((i + 1))
+                adb exec-out screencap -p > "/tmp/screens/screen_$(printf '%03d' $i).png" 2>/dev/null
+              done
+            ) &
+            SCREENSHOT_PID=$!
             set +e
             ./gradlew connectedDebugAndroidTest --no-daemon
             GRADLE_EXIT=$?
             set -e
-            kill "$LOGCAT_PID" 2>/dev/null || true
+            kill "$LOGCAT_PID" "$SCREENSHOT_PID" 2>/dev/null || true
             exit $GRADLE_EXIT
 
       - name: Upload instrumented test reports
@@ -139,6 +149,13 @@ jobs:
         with:
           name: instrumented-test-reports
           path: app/build/reports/androidTests/
+
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-screenshots
+          path: /tmp/screens/
 
       - name: Upload logcat
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,6 @@ jobs:
           script: |
             adb logcat -c
             adb logcat -v threadtime > /tmp/logcat.txt &
-            mkdir -p /tmp/screens
-            (i=0; while [ $i -lt 90 ]; do sleep 3; i=$((i + 1)); adb exec-out screencap -p > "/tmp/screens/screen_$(printf '%03d' $i).png" 2>/dev/null; done) &
             ./gradlew connectedDebugAndroidTest --no-daemon
 
       - name: Upload instrumented test reports
@@ -116,13 +114,6 @@ jobs:
         with:
           name: instrumented-test-reports
           path: app/build/reports/androidTests/
-
-      - name: Upload screenshots
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: instrumented-screenshots
-          path: /tmp/screens/
 
       - name: Upload logcat
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,64 @@ jobs:
         with:
           name: lint-reports
           path: app/build/reports/lint-results-debug.html
+
+  instrumented-tests:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-30
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: default
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: default
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew connectedDebugAndroidTest --no-daemon
+
+      - name: Upload instrumented test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-reports
+          path: app/build/reports/androidTests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-30
+          key: avd-30-pixel6
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -110,6 +110,7 @@ jobs:
           api-level: 30
           target: default
           arch: x86_64
+          profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -121,6 +122,7 @@ jobs:
           api-level: 30
           target: default
           arch: x86_64
+          profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
   instrumented-tests:
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -92,28 +93,6 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-30-pixel6
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 30
-          target: default
-          arch: x86_64
-          profile: pixel_6
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
       - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -122,7 +101,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
             adb logcat -c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,23 +125,9 @@ jobs:
           script: |
             adb logcat -c
             adb logcat -v threadtime > /tmp/logcat.txt &
-            LOGCAT_PID=$!
             mkdir -p /tmp/screens
-            (
-              i=0
-              while [ $i -lt 90 ]; do
-                sleep 3
-                i=$((i + 1))
-                adb exec-out screencap -p > "/tmp/screens/screen_$(printf '%03d' $i).png" 2>/dev/null
-              done
-            ) &
-            SCREENSHOT_PID=$!
-            set +e
+            (i=0; while [ $i -lt 90 ]; do sleep 3; i=$((i + 1)); adb exec-out screencap -p > "/tmp/screens/screen_$(printf '%03d' $i).png" 2>/dev/null; done) &
             ./gradlew connectedDebugAndroidTest --no-daemon
-            GRADLE_EXIT=$?
-            set -e
-            kill "$LOGCAT_PID" "$SCREENSHOT_PID" 2>/dev/null || true
-            exit $GRADLE_EXIT
 
       - name: Upload instrumented test reports
         if: failure()

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
@@ -62,11 +62,21 @@ fun ComposeTestRule.dismissOnboardingIfPresent(context: Context) {
     val notNow = context.getString(R.string.action_not_now)
     repeat(2) {
         if (nodeVisibleWithin(hasText(notNow), ONBOARDING_STEP_TIMEOUT_MS)) {
+            val notNowNode = onNodeWithText(notNow, useUnmergedTree = true)
             // ProminentA11yDisclosureScreen is a full-screen scrollable Column (not a compact
-            // AlertDialog), so on small emulator viewports its "Not now" button can be below the
-            // fold: present in the semantics tree (nodeVisibleWithin finds it) but at screen
-            // coordinates performClick() can't actually hit without scrolling to it first.
-            onNodeWithText(notNow, useUnmergedTree = true).performScrollTo().performClick()
+            // AlertDialog like OverlayPermissionDialog, the other screen this loop can hit), so
+            // on small emulator viewports its "Not now" button can be below the fold: present in
+            // the semantics tree (nodeVisibleWithin finds it) but at screen coordinates
+            // performClick() can't actually hit without scrolling to it first. performScrollTo()
+            // throws when the node has no scrollable ancestor at all, which is exactly the case
+            // for OverlayPermissionDialog's button - it's already fully visible, so skip the
+            // scroll there instead of failing the test over it.
+            try {
+                notNowNode.performScrollTo()
+            } catch (_: AssertionError) {
+                // No scrollable ancestor - already visible, nothing to scroll to.
+            }
+            notNowNode.performClick()
             waitForIdle()
         }
     }

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.procrastilearn.app.R
 
 // Generous enough to cover MainActivity's cold-start (Hilt injection, DataStore reads, first
@@ -61,7 +62,11 @@ fun ComposeTestRule.dismissOnboardingIfPresent(context: Context) {
     val notNow = context.getString(R.string.action_not_now)
     repeat(2) {
         if (nodeVisibleWithin(hasText(notNow), ONBOARDING_STEP_TIMEOUT_MS)) {
-            onNodeWithText(notNow, useUnmergedTree = true).performClick()
+            // ProminentA11yDisclosureScreen is a full-screen scrollable Column (not a compact
+            // AlertDialog), so on small emulator viewports its "Not now" button can be below the
+            // fold: present in the semantics tree (nodeVisibleWithin finds it) but at screen
+            // coordinates performClick() can't actually hit without scrolling to it first.
+            onNodeWithText(notNow, useUnmergedTree = true).performScrollTo().performClick()
             waitForIdle()
         }
     }

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
@@ -11,11 +11,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.procrastilearn.app.R
 
-// Generous enough to cover MainActivity's cold-start (Hilt injection, DataStore reads, first
-// Compose frame) on slow CI emulators — nodeVisibleWithin returns as soon as the node appears,
-// so this doesn't slow down fast environments, only raises the worst-case ceiling. A tighter
-// budget risks one gating screen's slow first render eating the whole repeat() iteration,
-// leaving the next gating screen (e.g. the overlay permission dialog) never dismissed.
 private const val ONBOARDING_STEP_TIMEOUT_MS = 10_000L
 private const val NODE_POLL_INTERVAL_MS = 100L
 

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.procrastilearn.app.R
 
-private const val ONBOARDING_STEP_TIMEOUT_MS = 10_000L
+private const val ONBOARDING_STEP_TIMEOUT_MS = 1_500L
 private const val NODE_POLL_INTERVAL_MS = 100L
 
 @OptIn(ExperimentalTestApi::class)

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
@@ -10,7 +10,12 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.procrastilearn.app.R
 
-private const val ONBOARDING_STEP_TIMEOUT_MS = 1_000L
+// Generous enough to cover MainActivity's cold-start (Hilt injection, DataStore reads, first
+// Compose frame) on slow CI emulators — nodeVisibleWithin returns as soon as the node appears,
+// so this doesn't slow down fast environments, only raises the worst-case ceiling. A tighter
+// budget risks one gating screen's slow first render eating the whole repeat() iteration,
+// leaving the next gating screen (e.g. the overlay permission dialog) never dismissed.
+private const val ONBOARDING_STEP_TIMEOUT_MS = 10_000L
 private const val NODE_POLL_INTERVAL_MS = 100L
 
 @OptIn(ExperimentalTestApi::class)

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/E2eTestSupport.kt
@@ -53,7 +53,14 @@ fun ComposeTestRule.nodeVisibleWithin(
     return false
 }
 
+private object OnboardingState {
+    @Volatile
+    var dismissed = false
+}
+
 fun ComposeTestRule.dismissOnboardingIfPresent(context: Context) {
+    if (OnboardingState.dismissed) return
+
     val notNow = context.getString(R.string.action_not_now)
     repeat(2) {
         if (nodeVisibleWithin(hasText(notNow), ONBOARDING_STEP_TIMEOUT_MS)) {
@@ -77,7 +84,10 @@ fun ComposeTestRule.dismissOnboardingIfPresent(context: Context) {
     }
 
     val languageTitle = context.getString(R.string.language_selection_dialog_title)
-    if (!nodeVisibleWithin(hasText(languageTitle), ONBOARDING_STEP_TIMEOUT_MS)) return
+    if (!nodeVisibleWithin(hasText(languageTitle), ONBOARDING_STEP_TIMEOUT_MS)) {
+        OnboardingState.dismissed = true
+        return
+    }
 
     onNodeWithTag("language_selection_native_field", useUnmergedTree = true).performClick()
     waitForIdle()
@@ -91,4 +101,6 @@ fun ComposeTestRule.dismissOnboardingIfPresent(context: Context) {
 
     onNodeWithText(context.getString(R.string.action_continue), useUnmergedTree = true).performClick()
     waitForIdle()
+
+    OnboardingState.dismissed = true
 }


### PR DESCRIPTION
## Description

Adds a CI stage that actually boots an Android emulator and runs the existing `androidTest` suite (Compose UI tests, E2E flows, Room migration test) on every push/PR to `master`. Previously only `testDebugUnitTest` (JVM) ran in CI — the instrumented tests existed in the repo but nothing executed them automatically.

Along the way this also fixed a real bug in the E2E test suite's onboarding-dismissal helper, uncovered only because these tests had never actually run against a fresh install before.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Add an `instrumented-tests` job to `.github/workflows/ci.yml`, gated on `needs: verify` so a lint/detekt/unit-test failure fails fast without spinning up an emulator.
- Use `reactivecircus/android-emulator-runner@v2` on `ubuntu-latest` with KVM enabled via udev rules, giving hardware-accelerated (not software-rendered) emulation.
- Target API 30 (matches `minSdk`), `default` image (no Google Play Services dependency in the app), `x86_64` arch, `pixel_6` hardware profile (1080x2400 — a realistic phone screen, not the tiny 320x640 default).
- Each run creates and boots a fresh AVD in one step — **deliberately no cross-run AVD cache**. An earlier attempt at caching (to save ~1 min of boot time) caused a run to hang for 4+ hours booting from a stale cross-run snapshot; the AVD boot isn't the bottleneck (37 sequential test-suite Activity launches are), so it wasn't worth the reliability risk.
- `timeout-minutes: 30` as a hard backstop so a future hang fails loudly instead of running unattended.
- Capture `adb logcat` for the duration of the run, uploaded as an artifact only `if: failure()` — cheap, and was the key diagnostic tool for the bugs below.
- Fixed `dismissOnboardingIfPresent` in `E2eTestSupport.kt`: on a real fresh install (no accessibility service enabled, no overlay permission granted), `MainActivity` shows two full-screen/dialog gating screens before the app's normal content. The "Not now" button on the first (a full-screen scrollable disclosure page, not a compact dialog) could be below the fold on the emulator's viewport — present in the semantics tree so the test's node lookup found it, but unreachable by `performClick()` without scrolling first. Added `performScrollTo()` before the click, falling back to a direct click when there's no scrollable ancestor (the second gating screen is a plain `AlertDialog`, nothing to scroll).
- Added an `OnboardingState.dismissed` short-circuit so the dismissal check only runs once per test-instrumentation process instead of every test re-polling for onboarding screens that are provably no longer there — cut the suite from ~13 minutes to ~4.5 minutes.

## How to Test

1. Open this PR and watch the `instrumented-tests` job in the Actions tab.
2. Confirm it depends on `verify` completing first, boots the emulator, and runs the full `androidTest` suite (37 tests: `DojoE2eTest`, `SettingsAnkiImportE2eTest`, `AppDatabaseMigrationTest`, etc.) to green.
3. On failure, confirm the logcat artifact uploads and contains useful diagnostic output.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable, including edge cases
- [x] Existing tests pass locally
- [ ] Updated documentation if needed
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A — follow-up to setting up instrumented test coverage; this wires it into CI.
