### PR TITLE
test: add e2e coverage for word list bulk delete

### DIFF
--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListBulkDeleteE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListBulkDeleteE2eTest.kt
@@ -1,0 +1,201 @@
+package com.procrastilearn.app.e2e
+
+import android.content.Context
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.procrastilearn.app.MainActivity
+import com.procrastilearn.app.R
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import com.procrastilearn.app.di.DatabaseEntryPoint
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WordListBulkDeleteE2eTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private lateinit var targetContext: Context
+
+    @Before
+    fun beforeEach() {
+        targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        resetAppState()
+        composeTestRule.dismissOnboardingIfPresent(targetContext)
+    }
+
+    @After
+    fun afterEach() {
+        resetAppState()
+    }
+
+    @Test
+    fun deletingSingleSelectedWordRemovesItFromListAndDatabase() {
+        val word = "quorvintal"
+        val id = seedWord(word = word, translation = "flembercot")
+
+        navigateToWordList()
+        longPressItem(id)
+        openSelectionMenuAndTap(R.string.action_delete)
+        confirmBulkDeleteDialog()
+
+        composeTestRule.waitUntilNodeGone(hasTestTag(itemTag(id)), DEFAULT_TIMEOUT_MS)
+        assertNull(vocabularyById(id))
+    }
+
+    @Test
+    fun bulkDeleteRemovesOnlySelectedWordsAndExitsSelectionMode() {
+        val wordA = "plindorash"
+        val wordB = "castervine"
+        val wordKept = "molthingear"
+        val idA = seedWord(word = wordA, translation = "translation-a")
+        val idB = seedWord(word = wordB, translation = "translation-b")
+        val idKept = seedWord(word = wordKept, translation = "translation-kept")
+
+        navigateToWordList()
+        longPressItem(idA)
+        clickItem(idB)
+        openSelectionMenuAndTap(R.string.action_delete)
+        confirmBulkDeleteDialog()
+
+        composeTestRule.waitUntilNodeGone(hasTestTag(itemTag(idA)), DEFAULT_TIMEOUT_MS)
+
+        assertNull(vocabularyById(idA))
+        assertNull(vocabularyById(idB))
+        assertNotNull(vocabularyById(idKept))
+
+        composeTestRule
+            .onNodeWithText(string(R.string.word_list_title))
+            .assertExists()
+        composeTestRule.onNodeWithTag(itemTag(idKept)).assertExists()
+    }
+
+    @Test
+    fun cancelingBulkDeleteDialogKeepsSelectedWords() {
+        val word = "haventrolm"
+        val id = seedWord(word = word, translation = "sondrifelt")
+
+        navigateToWordList()
+        longPressItem(id)
+        openSelectionMenuAndTap(R.string.action_delete)
+
+        composeTestRule.waitUntilNodeExists(
+            hasText(string(R.string.word_list_bulk_delete_confirm_title)),
+            DEFAULT_TIMEOUT_MS,
+        )
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(itemTag(id)).assertExists()
+        assertNotNull(vocabularyById(id))
+    }
+
+    private fun string(resId: Int) = targetContext.getString(resId)
+
+    private fun navigateToWordList() {
+        val addWordLabel = string(R.string.nav_add_word)
+        composeTestRule.waitUntilNodeExists(hasText(addWordLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule
+            .onNodeWithContentDescription(addWordLabel, useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        val viewListLabel = string(R.string.action_view_list)
+        composeTestRule.waitUntilNodeExists(hasContentDescription(viewListLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithContentDescription(viewListLabel).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun longPressItem(id: Long) {
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(id)), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithTag(itemTag(id)).performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun clickItem(id: Long) {
+        composeTestRule.onNodeWithTag(itemTag(id)).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun itemTag(id: Long) = "word_list_item_$id"
+
+    private fun openSelectionMenuAndTap(actionResId: Int) {
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_more_actions_selection))
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(string(actionResId)).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun confirmBulkDeleteDialog() {
+        composeTestRule.waitUntilNodeExists(
+            hasText(string(R.string.word_list_bulk_delete_confirm_title)),
+            DEFAULT_TIMEOUT_MS,
+        )
+        composeTestRule.onNodeWithText(string(R.string.action_delete)).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun seedWord(
+        word: String,
+        translation: String,
+    ): Long =
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                entryPoint().appDatabase().vocabularyDao().insertVocabulary(
+                    VocabularyEntity(
+                        word = word,
+                        translation = translation,
+                        fsrsCardJson = "",
+                    ),
+                )
+            }
+        }
+
+    private fun vocabularyById(id: Long): VocabularyEntity? =
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                entryPoint().appDatabase().vocabularyDao().getVocabularyById(id)
+            }
+        }
+
+    private fun resetAppState() {
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                val db = entryPoint().appDatabase()
+                db.vocabularyDao().deleteAllVocabulary()
+                db.undoSnapshotDao().deleteAll()
+            }
+        }
+    }
+
+    private fun entryPoint(): DatabaseEntryPoint =
+        EntryPointAccessors.fromApplication(
+            targetContext.applicationContext,
+            DatabaseEntryPoint::class.java,
+        )
+
+    private companion object {
+        const val DEFAULT_TIMEOUT_MS = 15_000L
+    }
+}


### PR DESCRIPTION
## Description

The word list's bulk delete feature (multi-select words → delete via the selection menu → confirm dialog) had no instrumented/e2e test coverage — only unit tests for the ViewModel/selection logic and an instrumented test that checks selection mode resets on navigation, none of which exercise an actual delete-and-confirm flow end to end.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement
- [x] Test coverage

## Changes Made

- Added `WordListBulkDeleteE2eTest.kt` (instrumented, `e2e` package) covering:
  - Deleting a single selected word removes it from the list and the database.
  - Bulk-deleting multiple selected words removes only those words, keeps unselected words, and exits selection mode afterward.
  - Canceling the bulk delete confirmation dialog leaves selected words untouched.

## How to Test

1. Attach an emulator (`Medium_Phone`, API 36.1).
2. Run `./gradlew connectedDebugAndroidTest --tests "com.procrastilearn.app.e2e.WordListBulkDeleteE2eTest"`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable, including edge cases
- [ ] Existing tests pass locally — `ktlintCheck`, `detekt`, and `compileDebugAndroidTestSources` were run locally and pass; the instrumented test itself requires an emulator I don't have access to in this session, so I'm relying on CI to run it and will fix any failures it surfaces.
- [ ] Updated documentation if needed — N/A
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused — this file mirrors the existing helper pattern used in `WordListBidirectionalToggleE2eTest.kt`, which is the established convention in this test package (no shared base class exists to extract into).
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01794Bc7SdYoHs5yJJGewJzG)_