### PR TITLE
test: add e2e coverage for word edit dialog

### DIFF
--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordEditE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordEditE2eTest.kt
@@ -1,0 +1,278 @@
+package com.procrastilearn.app.e2e
+
+import android.content.Context
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.procrastilearn.app.MainActivity
+import com.procrastilearn.app.R
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import com.procrastilearn.app.di.DatabaseEntryPoint
+import com.procrastilearn.app.di.PreferencesEntryPoint
+import com.procrastilearn.app.domain.model.StudyDirectionMode
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WordEditE2eTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private lateinit var targetContext: Context
+
+    @Before
+    fun beforeEach() {
+        targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        resetAppState()
+        composeTestRule.dismissOnboardingIfPresent(targetContext)
+    }
+
+    @After
+    fun afterEach() {
+        resetAppState()
+    }
+
+    @Test
+    fun editingWordAndTranslationPersistsChangesToDatabase() {
+        val originalWord = "flarnbicket"
+        val originalTranslation = "gloomventra"
+        seedWord(word = originalWord, translation = originalTranslation)
+
+        navigateToWordList()
+        openEditDialogFor(originalWord)
+        replaceFieldText(originalWord, "flarnbicket-updated")
+        replaceFieldText(originalTranslation, "gloomventra-updated")
+        clickAction(R.string.action_save)
+
+        assertNull(vocabularyByWord(originalWord))
+        val updated = vocabularyByWord("flarnbicket-updated")!!
+        assertEquals("gloomventra-updated", updated.translation)
+    }
+
+    @Test
+    fun cancellingEditDialogDiscardsChanges() {
+        val word = "prendolack"
+        val translation = "ostrivane"
+        seedWord(word = word, translation = translation)
+
+        navigateToWordList()
+        openEditDialogFor(word)
+        replaceFieldText(word, "prendolack-changed")
+        clickAction(R.string.action_cancel)
+
+        assertNull(vocabularyByWord("prendolack-changed"))
+        assertEquals(translation, vocabularyByWord(word)!!.translation)
+    }
+
+    @Test
+    fun enablingBidirectionalInEditDialogSetsFlagAndSeedsBackwardDueDateWhenAlreadyReviewed() {
+        val word = "quindaloop"
+        val translation = "brastanix"
+        val forwardDueAt = System.currentTimeMillis() + ONE_DAY_MS
+        seedWord(word = word, translation = translation, correctCount = 1, fsrsDueAt = forwardDueAt)
+
+        navigateToWordList()
+        openEditDialogFor(word)
+        composeTestRule.onNode(isToggleable(), useUnmergedTree = true).performClick()
+        clickAction(R.string.action_save)
+
+        val updated = vocabularyByWord(word)!!
+        assertTrue(updated.bidirectional)
+        assertTrue(updated.backwardFsrsDueAt > 0L)
+    }
+
+    @Test
+    fun disablingBidirectionalInEditDialogClearsFlag() {
+        val word = "trevoskin"
+        val translation = "mundacrest"
+        seedWord(word = word, translation = translation, bidirectional = true)
+
+        navigateToWordList()
+        openEditDialogFor(word)
+        composeTestRule.onNode(isToggleable(), useUnmergedTree = true).performClick()
+        clickAction(R.string.action_save)
+
+        assertFalse(vocabularyByWord(word)!!.bidirectional)
+    }
+
+    @Test
+    fun customizingReverseOverridesPersistsPromptAndAnswerText() {
+        val word = "shalimquor"
+        val translation = "ventrabole"
+        seedWord(word = word, translation = translation)
+
+        navigateToWordList()
+        openEditDialogFor(word)
+        composeTestRule.onNode(isToggleable(), useUnmergedTree = true).performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_customize_backward_show))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextInput("What runs?")
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_answer_label))
+            .performScrollTo()
+            .performTextInput(word)
+        clickAction(R.string.action_save)
+
+        val updated = vocabularyByWord(word)!!
+        assertTrue(updated.bidirectional)
+        assertEquals("What runs?", updated.backwardPromptOverride)
+        assertEquals(word, updated.backwardAnswerOverride)
+    }
+
+    @Test
+    fun clearingReverseOverridesOnSaveResetsThemToNull() {
+        val word = "nostrivell"
+        val translation = "quenthalor"
+        seedWord(
+            word = word,
+            translation = translation,
+            bidirectional = true,
+            backwardPromptOverride = "Old prompt",
+            backwardAnswerOverride = "Old answer",
+        )
+
+        navigateToWordList()
+        openEditDialogFor(word)
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_prompt_label))
+            .performScrollTo()
+            .performTextClearance()
+        composeTestRule
+            .onNodeWithText(string(R.string.add_word_backward_answer_label))
+            .performScrollTo()
+            .performTextClearance()
+        clickAction(R.string.action_save)
+
+        val updated = vocabularyByWord(word)!!
+        assertTrue(updated.bidirectional)
+        assertNull(updated.backwardPromptOverride)
+        assertNull(updated.backwardAnswerOverride)
+    }
+
+    private fun string(resId: Int) = targetContext.getString(resId)
+
+    private fun navigateToWordList() {
+        val addWordLabel = string(R.string.nav_add_word)
+        composeTestRule.waitUntilNodeExists(hasText(addWordLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule
+            .onNodeWithContentDescription(addWordLabel, useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        val viewListLabel = string(R.string.action_view_list)
+        composeTestRule.waitUntilNodeExists(hasContentDescription(viewListLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithContentDescription(viewListLabel).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun openEditDialogFor(word: String) {
+        composeTestRule.waitUntilNodeExists(hasText(word), DEFAULT_TIMEOUT_MS)
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_more_actions), useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(string(R.string.action_edit)).performClick()
+        composeTestRule.waitUntilNodeExists(hasText(string(R.string.edit_word_title)), DEFAULT_TIMEOUT_MS)
+    }
+
+    private fun replaceFieldText(
+        currentValue: String,
+        newValue: String,
+    ) {
+        val field = composeTestRule.onNode(hasText(currentValue).and(hasSetTextAction()), useUnmergedTree = true)
+        field.performTextClearance()
+        field.performTextInput(newValue)
+    }
+
+    private fun clickAction(actionResId: Int) {
+        composeTestRule.onNodeWithText(string(actionResId)).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun seedWord(
+        word: String,
+        translation: String,
+        bidirectional: Boolean = false,
+        correctCount: Int = 0,
+        fsrsDueAt: Long = 0L,
+        backwardPromptOverride: String? = null,
+        backwardAnswerOverride: String? = null,
+    ): Long =
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                entryPoint().appDatabase().vocabularyDao().insertVocabulary(
+                    VocabularyEntity(
+                        word = word,
+                        translation = translation,
+                        bidirectional = bidirectional,
+                        correctCount = correctCount,
+                        fsrsCardJson = "",
+                        fsrsDueAt = fsrsDueAt,
+                        backwardPromptOverride = backwardPromptOverride,
+                        backwardAnswerOverride = backwardAnswerOverride,
+                    ),
+                )
+            }
+        }
+
+    private fun vocabularyByWord(word: String): VocabularyEntity? =
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                entryPoint().appDatabase().vocabularyDao().getVocabularyByWord(word)
+            }
+        }
+
+    private fun resetAppState() {
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                val db = entryPoint().appDatabase()
+                db.vocabularyDao().deleteAllVocabulary()
+                db.undoSnapshotDao().deleteAll()
+                preferencesEntryPoint().dayCountersStore().setStudyDirectionMode(StudyDirectionMode.BIDIRECTIONAL)
+            }
+        }
+    }
+
+    private fun entryPoint(): DatabaseEntryPoint =
+        EntryPointAccessors.fromApplication(
+            targetContext.applicationContext,
+            DatabaseEntryPoint::class.java,
+        )
+
+    private fun preferencesEntryPoint(): PreferencesEntryPoint =
+        EntryPointAccessors.fromApplication(
+            targetContext.applicationContext,
+            PreferencesEntryPoint::class.java,
+        )
+
+    private companion object {
+        const val DEFAULT_TIMEOUT_MS = 15_000L
+        const val ONE_DAY_MS = 24 * 60 * 60 * 1000L
+    }
+}

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordEditE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordEditE2eTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.procrastilearn.app.MainActivity
@@ -61,8 +62,8 @@ class WordEditE2eTest {
 
         navigateToWordList()
         openEditDialogFor(originalWord)
-        replaceFieldText(originalWord, "flarnbicket-updated")
-        replaceFieldText(originalTranslation, "gloomventra-updated")
+        replaceFieldText(R.string.add_word_label_word, "flarnbicket-updated")
+        replaceFieldText(R.string.add_word_label_translation, "gloomventra-updated")
         clickAction(R.string.action_save)
 
         assertNull(vocabularyByWord(originalWord))
@@ -78,7 +79,7 @@ class WordEditE2eTest {
 
         navigateToWordList()
         openEditDialogFor(word)
-        replaceFieldText(word, "prendolack-changed")
+        replaceFieldText(R.string.add_word_label_word, "prendolack-changed")
         clickAction(R.string.action_cancel)
 
         assertNull(vocabularyByWord("prendolack-changed"))
@@ -202,12 +203,12 @@ class WordEditE2eTest {
     }
 
     private fun replaceFieldText(
-        currentValue: String,
+        labelResId: Int,
         newValue: String,
     ) {
-        val field = composeTestRule.onNode(hasText(currentValue).and(hasSetTextAction()), useUnmergedTree = true)
-        field.performTextClearance()
-        field.performTextInput(newValue)
+        composeTestRule
+            .onNode(hasText(string(labelResId)).and(hasSetTextAction()), useUnmergedTree = true)
+            .performTextReplacement(newValue)
     }
 
     private fun clickAction(actionResId: Int) {

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordEditE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordEditE2eTest.kt
@@ -207,7 +207,7 @@ class WordEditE2eTest {
         newValue: String,
     ) {
         composeTestRule
-            .onNode(hasText(string(labelResId)).and(hasSetTextAction()), useUnmergedTree = true)
+            .onNode(hasText(string(labelResId)).and(hasSetTextAction()))
             .performTextReplacement(newValue)
     }
 


### PR DESCRIPTION
## Description

Adds instrumented e2e coverage for the word edit dialog (`WordListScreen`'s pencil-icon `EditWordDialog`). Previously this flow had no e2e coverage: `WordListBidirectionalToggleE2eTest` only exercised the bulk selection-menu bidirectional toggle, and the existing `EditWordDialogTest` is a component-level Robolectric unit test with mocked callbacks, not a full-stack e2e test wired through real navigation, Hilt DI, and Room.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

_(Test coverage only — no production code changed.)_

## Changes Made

- Added `app/src/androidTest/java/com/procrastilearn/app/e2e/WordEditE2eTest.kt` covering, through the real app UI and DB:
  - Editing word/translation text persists the change.
  - Cancelling the dialog discards changes.
  - Enabling bidirectional from the edit dialog sets the flag and seeds the backward due date when the word was already reviewed.
  - Disabling bidirectional from the edit dialog clears the flag.
  - Customizing the reverse prompt/answer overrides persists the entered text.
  - Clearing reverse prompt/answer overrides on save resets them to `null`.

## How to Test

1. `./gradlew connectedDebugAndroidTest --tests "com.procrastilearn.app.e2e.WordEditE2eTest"` on the `Medium_Phone` API 36.1 emulator.
2. All six tests should pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable, including edge cases
- [ ] Existing tests pass locally <!-- no emulator available in this sandbox; verified via ktlintCheck, detekt, and compileDebugAndroidTestSources locally, will watch CI -->
- [ ] Updated documentation if needed
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_011HR9rQc3LSUhLWWR9ZUiKa)_