### PR TITLE
test: add e2e coverage for word list search

### DIFF
--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListSearchE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListSearchE2eTest.kt
@@ -1,0 +1,162 @@
+package com.procrastilearn.app.e2e
+
+import android.content.Context
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.procrastilearn.app.MainActivity
+import com.procrastilearn.app.R
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import com.procrastilearn.app.di.DatabaseEntryPoint
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WordListSearchE2eTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private lateinit var targetContext: Context
+
+    @Before
+    fun beforeEach() {
+        targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        resetAppState()
+        composeTestRule.dismissOnboardingIfPresent(targetContext)
+    }
+
+    @After
+    fun afterEach() {
+        resetAppState()
+    }
+
+    @Test
+    fun typingQueryFiltersListToMatchingWordsOnly() {
+        val matchingId = seedWord(word = "glimmerquat", translation = "shiny-thing")
+        val otherId = seedWord(word = "sunderpike", translation = "broken-spear")
+
+        navigateToWordList()
+        composeTestRule.onNodeWithTag(itemTag(matchingId)).assertExists()
+        composeTestRule.onNodeWithTag(itemTag(otherId)).assertExists()
+
+        typeInSearchField("glimmer")
+
+        composeTestRule.onNodeWithTag(itemTag(matchingId)).assertExists()
+        composeTestRule.waitUntilNodeGone(hasTestTag(itemTag(otherId)), DEFAULT_TIMEOUT_MS)
+    }
+
+    @Test
+    fun searchIsCaseInsensitiveAndMatchesSubstringAnywhereInWord() {
+        val id = seedWord(word = "corvantiel", translation = "translation-a")
+
+        navigateToWordList()
+        typeInSearchField("VANTI")
+
+        composeTestRule.onNodeWithTag(itemTag(id)).assertExists()
+    }
+
+    @Test
+    fun queryWithNoMatchesShowsEmptyStateAndHidesAllWords() {
+        val id = seedWord(word = "brellathorn", translation = "translation-b")
+
+        navigateToWordList()
+        typeInSearchField("xyznotfound")
+
+        composeTestRule.waitUntilNodeExists(
+            hasText(string(R.string.word_list_search_no_results)),
+            DEFAULT_TIMEOUT_MS,
+        )
+        composeTestRule.onNodeWithTag(itemTag(id)).assertDoesNotExist()
+    }
+
+    @Test
+    fun clearingSearchQueryRestoresFullWordList() {
+        val idA = seedWord(word = "molvantree", translation = "translation-a")
+        val idB = seedWord(word = "pikewander", translation = "translation-b")
+
+        navigateToWordList()
+        typeInSearchField("molvan")
+        composeTestRule.waitUntilNodeGone(hasTestTag(itemTag(idB)), DEFAULT_TIMEOUT_MS)
+
+        composeTestRule.onNodeWithTag("word_list_search_field").performTextClearance()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(itemTag(idA)).assertExists()
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(idB)), DEFAULT_TIMEOUT_MS)
+    }
+
+    private fun string(resId: Int) = targetContext.getString(resId)
+
+    private fun navigateToWordList() {
+        val addWordLabel = string(R.string.nav_add_word)
+        composeTestRule.waitUntilNodeExists(hasText(addWordLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule
+            .onNodeWithContentDescription(addWordLabel, useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        val viewListLabel = string(R.string.action_view_list)
+        composeTestRule.waitUntilNodeExists(hasContentDescription(viewListLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithContentDescription(viewListLabel).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun typeInSearchField(query: String) {
+        composeTestRule.waitUntilNodeExists(hasTestTag("word_list_search_field"), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithTag("word_list_search_field").performTextInput(query)
+        composeTestRule.waitForIdle()
+    }
+
+    private fun itemTag(id: Long) = "word_list_item_$id"
+
+    private fun seedWord(
+        word: String,
+        translation: String,
+    ): Long =
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                entryPoint().appDatabase().vocabularyDao().insertVocabulary(
+                    VocabularyEntity(
+                        word = word,
+                        translation = translation,
+                        fsrsCardJson = "",
+                    ),
+                )
+            }
+        }
+
+    private fun resetAppState() {
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                val db = entryPoint().appDatabase()
+                db.vocabularyDao().deleteAllVocabulary()
+                db.undoSnapshotDao().deleteAll()
+            }
+        }
+    }
+
+    private fun entryPoint(): DatabaseEntryPoint =
+        EntryPointAccessors.fromApplication(
+            targetContext.applicationContext,
+            DatabaseEntryPoint::class.java,
+        )
+
+    private companion object {
+        const val DEFAULT_TIMEOUT_MS = 15_000L
+    }
+}

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
@@ -241,7 +241,8 @@ internal fun WordListContent(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 16.dp),
+                    .padding(bottom = 16.dp)
+                    .testTag("word_list_search_field"),
             label = { Text(text = stringResource(R.string.word_list_search_label)) },
             placeholder = { Text(text = stringResource(R.string.word_list_search_placeholder)) },
             leadingIcon = {


### PR DESCRIPTION
## Summary
- The word list screen has a search field (`WordListScreen.kt`) with no e2e coverage — this adds it.
- New `WordListSearchE2eTest` covers: filtering to matching words, case-insensitive substring matching, the no-results empty state, and clearing the query to restore the full list.
- Adds a `testTag("word_list_search_field")` to the search `OutlinedTextField` so it can be targeted reliably from Compose UI tests (it previously had no tag or unique text to select on).

## Test plan
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — compiles cleanly
- [x] `./gradlew ktlintCheck detekt` — passes
- [x] `./gradlew :app:assembleDebug` — builds cleanly
- [ ] `./gradlew connectedDebugAndroidTest` — will run in CI (no local emulator in this environment); will monitor the pipeline and fix forward if it fails

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRGuqrvG1mLS9XYKeMbu4n)_