### PR TITLE
fix: order word list by DB position, not query-planner order

### DIFF
--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListOrderE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListOrderE2eTest.kt
@@ -1,0 +1,176 @@
+package com.procrastilearn.app.e2e
+
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.procrastilearn.app.MainActivity
+import com.procrastilearn.app.R
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import com.procrastilearn.app.di.DatabaseEntryPoint
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private val WORD_LIST_ITEM_MATCHER =
+    SemanticsMatcher("has a test tag starting with word_list_item_") { node ->
+        node.config.getOrNull(SemanticsProperties.TestTag)?.startsWith("word_list_item_") == true
+    }
+
+@RunWith(AndroidJUnit4::class)
+class WordListOrderE2eTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private lateinit var targetContext: Context
+
+    @Before
+    fun beforeEach() {
+        targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        resetAppState()
+        composeTestRule.dismissOnboardingIfPresent(targetContext)
+    }
+
+    @After
+    fun afterEach() {
+        resetAppState()
+    }
+
+    @Test
+    fun wordListDisplaysWordsOrderedByPositionNotInsertionOrder() {
+        // Seeded (and thus id-assigned) in the order zeta, alpha, mu, but with position values
+        // that put alpha first, mu second, zeta last - neither insertion/id order nor
+        // alphabetical order matches the expected position order.
+        val zetaId = seedWord(word = "zeta-quorvin", translation = "translation-zeta", position = 3L)
+        val alphaId = seedWord(word = "alpha-quorvin", translation = "translation-alpha", position = 1L)
+        val muId = seedWord(word = "mu-quorvin", translation = "translation-mu", position = 2L)
+
+        navigateToWordList()
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(zetaId)), DEFAULT_TIMEOUT_MS)
+
+        assertEquals(listOf(alphaId, muId, zetaId), displayedWordIdsInOrder())
+    }
+
+    @Test
+    fun wordListKeepsRemainingWordsInPositionOrderAfterDeletingTheFirstOne() {
+        val zetaId = seedWord(word = "zeta-brenlock", translation = "translation-zeta", position = 3L)
+        val alphaId = seedWord(word = "alpha-brenlock", translation = "translation-alpha", position = 1L)
+        val muId = seedWord(word = "mu-brenlock", translation = "translation-mu", position = 2L)
+
+        navigateToWordList()
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(zetaId)), DEFAULT_TIMEOUT_MS)
+
+        longPressItem(alphaId)
+        openSelectionMenuAndTap(R.string.action_delete)
+        confirmBulkDeleteDialog()
+
+        composeTestRule.waitUntilNodeGone(hasTestTag(itemTag(alphaId)), DEFAULT_TIMEOUT_MS)
+        assertEquals(listOf(muId, zetaId), displayedWordIdsInOrder())
+    }
+
+    private fun string(resId: Int) = targetContext.getString(resId)
+
+    private fun navigateToWordList() {
+        val addWordLabel = string(R.string.nav_add_word)
+        composeTestRule.waitUntilNodeExists(hasText(addWordLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule
+            .onNodeWithContentDescription(addWordLabel, useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        val viewListLabel = string(R.string.action_view_list)
+        composeTestRule.waitUntilNodeExists(hasContentDescription(viewListLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithContentDescription(viewListLabel).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun longPressItem(id: Long) {
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(id)), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithTag(itemTag(id)).performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun openSelectionMenuAndTap(actionResId: Int) {
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_more_actions_selection))
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(string(actionResId)).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun confirmBulkDeleteDialog() {
+        composeTestRule.waitUntilNodeExists(
+            hasText(string(R.string.word_list_bulk_delete_confirm_title)),
+            DEFAULT_TIMEOUT_MS,
+        )
+        composeTestRule.onNodeWithText(string(R.string.action_delete)).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun itemTag(id: Long) = "word_list_item_$id"
+
+    private fun displayedWordIdsInOrder(): List<Long> =
+        composeTestRule
+            .onAllNodes(WORD_LIST_ITEM_MATCHER, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .mapNotNull { node -> node.config.getOrNull(SemanticsProperties.TestTag) }
+            .map { tag -> tag.removePrefix("word_list_item_").toLong() }
+
+    private fun seedWord(
+        word: String,
+        translation: String,
+        position: Long,
+    ): Long =
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                entryPoint().appDatabase().vocabularyDao().insertVocabulary(
+                    VocabularyEntity(
+                        word = word,
+                        translation = translation,
+                        fsrsCardJson = "",
+                        position = position,
+                    ),
+                )
+            }
+        }
+
+    private fun resetAppState() {
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                val db = entryPoint().appDatabase()
+                db.vocabularyDao().deleteAllVocabulary()
+                db.undoSnapshotDao().deleteAll()
+            }
+        }
+    }
+
+    private fun entryPoint(): DatabaseEntryPoint =
+        EntryPointAccessors.fromApplication(
+            targetContext.applicationContext,
+            DatabaseEntryPoint::class.java,
+        )
+
+    private companion object {
+        const val DEFAULT_TIMEOUT_MS = 15_000L
+    }
+}

--- a/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/dao/VocabularyDao.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface VocabularyDao {
     // Existing
-    @Query("SELECT * FROM vocabulary")
+    @Query("SELECT * FROM vocabulary ORDER BY position ASC, id ASC")
     fun getAllVocabulary(): Flow<List<VocabularyEntity>>
 
     @Query("SELECT * FROM vocabulary WHERE id = :id")

--- a/app/src/test/java/com/procrastilearn/app/data/local/dao/VocabularyDaoTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/dao/VocabularyDaoTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.procrastilearn.app.data.local.database.AppDatabase
 import com.procrastilearn.app.data.local.entity.VocabularyEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -413,5 +414,79 @@ class VocabularyDaoTest {
             // also be rolled back, since it shared the same @Transaction as the failing one.
             assertThat(dao.getVocabularyByWord("Baum")).isNull()
             assertThat(dao.getVocabularyByWord("Haus")?.translation).isEqualTo("existing")
+        }
+
+    @Test
+    fun `getAllVocabulary returns rows ordered by position ascending, not insertion order`() =
+        runTest {
+            insert("first-inserted", position = 30L)
+            insert("second-inserted", position = 10L)
+            insert("third-inserted", position = 20L)
+
+            val words = dao.getAllVocabulary().first().map { it.word }
+
+            assertThat(words).containsExactly("second-inserted", "third-inserted", "first-inserted").inOrder()
+        }
+
+    @Test
+    fun `getAllVocabulary on an empty table emits an empty list`() =
+        runTest {
+            assertThat(dao.getAllVocabulary().first()).isEmpty()
+        }
+
+    @Test
+    fun `getAllVocabulary with a single row emits a single-element list`() =
+        runTest {
+            insert("Haus", position = 1L)
+
+            assertThat(dao.getAllVocabulary().first().map { it.word }).containsExactly("Haus")
+        }
+
+    @Test
+    fun `getAllVocabulary reflects a position update on the next collection`() =
+        runTest {
+            val movedId = insert("moved", position = 1L)
+            insert("anchor", position = 2L)
+
+            assertThat(dao.getAllVocabulary().first().map { it.word })
+                .containsExactly("moved", "anchor")
+                .inOrder()
+
+            dao.updateVocabulary(entityById(movedId).copy(position = 3L))
+
+            assertThat(dao.getAllVocabulary().first().map { it.word })
+                .containsExactly("anchor", "moved")
+                .inOrder()
+        }
+
+    @Test
+    fun `getAllVocabulary keeps remaining rows in position order after a middle row is deleted`() =
+        runTest {
+            insert("low", position = 1L)
+            val middleId = insert("middle", position = 2L)
+            insert("high", position = 3L)
+
+            dao.deleteVocabulary(entityById(middleId))
+
+            assertThat(dao.getAllVocabulary().first().map { it.word })
+                .containsExactly("low", "high")
+                .inOrder()
+        }
+
+    @Test
+    fun `getAllVocabulary orders by position even when that disagrees with both id and alphabetical order`() =
+        runTest {
+            // Insertion order (and thus id order) is z, a, m; alphabetical order is a, m, z;
+            // position order is m, z, a - all three orderings disagree, so only a genuine
+            // position-based ORDER BY can make this assertion pass.
+            insert("zzz-first-inserted", position = 30L)
+            insert("aaa-second-inserted", position = 10L)
+            insert("mmm-third-inserted", position = 5L)
+
+            val words = dao.getAllVocabulary().first().map { it.word }
+
+            assertThat(words)
+                .containsExactly("mmm-third-inserted", "aaa-second-inserted", "zzz-first-inserted")
+                .inOrder()
         }
 }

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImplTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryImplTest.kt
@@ -96,6 +96,7 @@ class VocabularyRepositoryImplTest {
         correctCount: Int = 0,
         incorrectCount: Int = 0,
         lastShownAt: Long = 0L,
+        position: Long = nextTestPosition++,
     ): Long =
         vocabularyDao.insertVocabulary(
             VocabularyEntity(
@@ -107,7 +108,7 @@ class VocabularyRepositoryImplTest {
                 correctCount = correctCount,
                 incorrectCount = incorrectCount,
                 lastShownAt = lastShownAt,
-                position = nextTestPosition++,
+                position = position,
             ),
         )
 
@@ -487,6 +488,19 @@ class VocabularyRepositoryImplTest {
                 val reviewedItem = emission.first { it.word == "alt" }
                 assertThat(newItem.isNew).isTrue()
                 assertThat(reviewedItem.isNew).isFalse()
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `getAllVocabulary emits domain items ordered by position, not insertion order`() =
+        runTest {
+            insertTestVocabulary("inserted-first", "a", position = 20L)
+            insertTestVocabulary("inserted-second", "b", position = 10L)
+
+            repository.getAllVocabulary().test {
+                val words = awaitItem().map { it.word }
+                assertThat(words).containsExactly("inserted-second", "inserted-first").inOrder()
                 cancelAndConsumeRemainingEvents()
             }
         }

--- a/app/src/test/java/com/procrastilearn/app/ui/WordListViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/WordListViewModelTest.kt
@@ -62,6 +62,23 @@ class WordListViewModelTest {
         }
 
     @Test
+    fun `words preserves the repository's emitted order even when it does not match ascending id`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            val higherId = VocabularyItem(id = 2, word = "Baum", translation = "Tree", isNew = false)
+            val lowerId = VocabularyItem(id = 1, word = "Haus", translation = "House", isNew = true)
+
+            viewModel.words.test {
+                assertThat(awaitItem()).isEmpty()
+
+                vocabularyFlow.tryEmit(listOf(higherId, lowerId))
+
+                assertThat(awaitItem()).containsExactly(higherId, lowerId).inOrder()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `deleteWord delegates to repository`() =
         runTest(mainDispatcherRule.testDispatcher) {
             val item = VocabularyItem(id = 10, word = "lesen", translation = "read", isNew = false)


### PR DESCRIPTION
## Description

The word list screen was rendering words in whatever order SQLite's query planner happened to return, not in the DB's `position` order.

`VocabularyEntity.position` is a uniquely-indexed column correctly maintained on every write path (`getMaxPosition() + 1` on insert, sequential assignment on import), and is already used by `VocabularyReviewDao.pickNewIdByPositionAsc` for sequential-new-card study order. But `VocabularyDao.getAllVocabulary()` — the query backing the word list — was a bare `SELECT * FROM vocabulary` with no `ORDER BY`. Every layer above it (`VocabularyRepositoryImpl`, `WordListViewModel`, `WordListScreen`) just passes that order straight through, so the bug surfaced directly in the UI. It went unnoticed because `position` and `id` order happen to coincide today (the migration that added `position` backfilled it from `id`), but nothing guarantees they stay in sync, and the order is not guaranteed to match either without the `ORDER BY`.

Existing tests already had to work around this by manually re-sorting the DAO's raw output before asserting (`AnkiImportOrderIntegrationTest`, `ExportImportRoomIntegrationTest`).

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- `VocabularyDao.getAllVocabulary()` now runs `SELECT * FROM vocabulary ORDER BY position ASC, id ASC`, matching the ordering pattern already used by `pickNewIdByPositionAsc`.
- Added `VocabularyDaoTest` coverage for `getAllVocabulary()` ordering: position order diverging from insertion/id order, empty table, single row, reacting to a position update, surviving a mid-list delete, and position order disagreeing with both id order and alphabetical order simultaneously.
- Added a `VocabularyRepositoryImplTest` test confirming the domain-mapped list preserves DB position order.
- Added a `WordListViewModelTest` test pinning down that the ViewModel never re-sorts what the repository flow emits.
- Added a new instrumented e2e test, `WordListOrderE2eTest`, verifying the rendered word list order matches `position` (not insertion order) and that order is preserved after deleting an item.

## How to Test

1. Seed vocabulary rows with `position` values in an order different from insertion/id order (e.g. via `VocabularyDao.insertVocabulary`).
2. Open the word list screen.
3. Confirm words appear in ascending `position` order.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable, including edge cases
- [x] Existing tests pass locally (`./gradlew testDebugUnitTest`, `ktlintCheck`, `detekt`, `lintDebug`)
- [ ] Updated documentation if needed
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01TyAz2Myxn3PLx5icDgHWn9)_