### PR TITLE
fix: resolve ktlint CI failure in OverlayE2eTest

### DIFF
--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/OverlayE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/OverlayE2eTest.kt
@@ -246,6 +246,7 @@ class OverlayE2eTest {
 
     private companion object {
         const val DEFAULT_TIMEOUT_MS = 15_000L
+
         // The installed-apps list is loaded via PackageManager.queryIntentActivities() plus a
         // per-app icon-load loop (AppRepositoryImpl.loadLaunchableApps()). On a cold emulator this
         // can be slow the first time it runs (odex/vdex verification of large system packages like

--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListSearchE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListSearchE2eTest.kt
@@ -33,6 +33,8 @@ class WordListSearchE2eTest {
 
     private lateinit var targetContext: Context
 
+    private var nextPosition = 1L
+
     @Before
     fun beforeEach() {
         targetContext = InstrumentationRegistry.getInstrumentation().targetContext
@@ -123,8 +125,6 @@ class WordListSearchE2eTest {
     }
 
     private fun itemTag(id: Long) = "word_list_item_$id"
-
-    private var nextPosition = 1L
 
     private fun seedWord(
         word: String,


### PR DESCRIPTION
## Summary
- CI on `master` was failing at `:app:ktlintAndroidTestSourceSetCheck` — `OverlayE2eTest.kt:249:9` was missing the required blank line between a declaration and a following comment.
- Added the missing blank line before the comment above `APPS_LIST_TIMEOUT_MS`.

## Test plan
- [x] `./gradlew ktlintCheck --no-daemon` passes locally

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzBdqnaB9GgRfCdCeEYFQ6)_