### PR TITLE
fix: reduce settings page header height

### DIFF
--- a/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/settings/SettingsScreen.kt
@@ -246,7 +246,7 @@ fun SettingsScreen(
 private fun SettingsTopBar() {
     CenterAlignedTopAppBar(
         title = { Text(stringResource(R.string.settings_title)) },
-        expandedHeight = 60.dp,
+        expandedHeight = 48.dp,
     )
 }
 


### PR DESCRIPTION
Shrink the settings top app bar's expanded height from 60dp to 48dp
for a more compact header.