### PR TITLE
test: add PendingWordMapper coverage and a cross-midnight undo case

### DIFF
--- a/app/src/test/java/com/procrastilearn/app/data/local/mapper/PendingWordMapperTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/mapper/PendingWordMapperTest.kt
@@ -1,0 +1,95 @@
+package com.procrastilearn.app.data.local.mapper
+
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.entity.PendingWordEntity
+import com.procrastilearn.app.domain.model.AiTranslationDirection
+import com.procrastilearn.app.domain.model.PendingWord
+import org.junit.Test
+
+class PendingWordMapperTest {
+    @Test
+    fun `toDomain maps id, word and createdAt through unchanged`() {
+        val entity =
+            PendingWordEntity(
+                id = 7,
+                word = "lernen",
+                direction = AiTranslationDirection.TARGET_TO_NATIVE.name,
+                createdAt = 12_345L,
+            )
+
+        val result = entity.toDomain()
+
+        assertThat(result.id).isEqualTo(7)
+        assertThat(result.word).isEqualTo("lernen")
+        assertThat(result.createdAt).isEqualTo(12_345L)
+    }
+
+    @Test
+    fun `toDomain parses TARGET_TO_NATIVE direction`() {
+        val entity = PendingWordEntity(word = "lernen", direction = "TARGET_TO_NATIVE")
+
+        assertThat(entity.toDomain().direction).isEqualTo(AiTranslationDirection.TARGET_TO_NATIVE)
+    }
+
+    @Test
+    fun `toDomain parses NATIVE_TO_TARGET direction`() {
+        val entity = PendingWordEntity(word = "lernen", direction = "NATIVE_TO_TARGET")
+
+        assertThat(entity.toDomain().direction).isEqualTo(AiTranslationDirection.NATIVE_TO_TARGET)
+    }
+
+    @Test
+    fun `toDomain falls back to TARGET_TO_NATIVE for an unrecognized direction string`() {
+        val entity = PendingWordEntity(word = "lernen", direction = "SOME_UNKNOWN_ENUM_VALUE")
+
+        assertThat(entity.toDomain().direction).isEqualTo(AiTranslationDirection.TARGET_TO_NATIVE)
+    }
+
+    @Test
+    fun `toDomain falls back to TARGET_TO_NATIVE for a blank direction string`() {
+        val entity = PendingWordEntity(word = "lernen", direction = "")
+
+        assertThat(entity.toDomain().direction).isEqualTo(AiTranslationDirection.TARGET_TO_NATIVE)
+    }
+
+    @Test
+    fun `toEntity maps id, word and createdAt through unchanged`() {
+        val word =
+            PendingWord(
+                id = 9,
+                word = "sprechen",
+                direction = AiTranslationDirection.NATIVE_TO_TARGET,
+                createdAt = 99_999L,
+            )
+
+        val result = word.toEntity()
+
+        assertThat(result.id).isEqualTo(9)
+        assertThat(result.word).isEqualTo("sprechen")
+        assertThat(result.createdAt).isEqualTo(99_999L)
+    }
+
+    @Test
+    fun `toEntity serializes direction using its enum name`() {
+        val targetToNative = PendingWord(word = "a", direction = AiTranslationDirection.TARGET_TO_NATIVE)
+        val nativeToTarget = PendingWord(word = "b", direction = AiTranslationDirection.NATIVE_TO_TARGET)
+
+        assertThat(targetToNative.toEntity().direction).isEqualTo("TARGET_TO_NATIVE")
+        assertThat(nativeToTarget.toEntity().direction).isEqualTo("NATIVE_TO_TARGET")
+    }
+
+    @Test
+    fun `round trip through entity preserves every field`() {
+        val original =
+            PendingWord(
+                id = 3,
+                word = "gehen",
+                direction = AiTranslationDirection.NATIVE_TO_TARGET,
+                createdAt = 42L,
+            )
+
+        val roundTripped = original.toEntity().toDomain()
+
+        assertThat(roundTripped).isEqualTo(original)
+    }
+}

--- a/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/repository/VocabularyRepositoryUndoTest.kt
@@ -269,6 +269,64 @@ class VocabularyRepositoryUndoTest {
         }
 
     @Test
+    fun `undoing across a day boundary in a mixed stack only restores counters for the entry from today`() =
+        runTest {
+            val yesterdayId = insertVocab("gestern")
+            val todayId = insertVocab("heute")
+
+            // Simulate a rating made yesterday that is still on the stack because the app
+            // wasn't reopened when the day rolled over, sitting below a rating made today.
+            undoSnapshotDao.insert(
+                UndoSnapshotEntity(
+                    vocabId = yesterdayId,
+                    createdAt = System.currentTimeMillis() - 86_400_000L,
+                    snapshotDay = todayStamp() - 1,
+                    ratingName = Rating.EASY.name,
+                    direction = StudyDirection.FORWARD.name,
+                    fsrsCardJson = "",
+                    fsrsDueAt = 0L,
+                    lastShownAt = null,
+                    correctCount = 0,
+                    incorrectCount = 0,
+                    backwardFsrsCardJson = "",
+                    backwardFsrsDueAt = 0L,
+                    backwardCorrectCount = 0,
+                    backwardIncorrectCount = 0,
+                    newShown = 0,
+                    reviewShown = 0,
+                    reviewsSinceLastNew = 0,
+                ),
+            )
+            vocabularyReviewDao.applyFsrsReview(
+                id = yesterdayId,
+                cardJson = Card.builder().build().toJson(),
+                dueAt = System.currentTimeMillis() + 1_000L,
+                reviewedAt = System.currentTimeMillis(),
+                wasCorrect = false,
+            )
+
+            repository.reviewVocabularyItem(todayId, Rating.GOOD, StudyDirection.FORWARD)
+            assertThat(dayCountersStore.read().first().newShown).isEqualTo(1)
+
+            // First undo reverts today's rating (LIFO) -> today's counters go back to zero.
+            val firstUndo = repository.undoLastRating()
+            assertThat(firstUndo?.item?.id).isEqualTo(todayId)
+            assertThat(dayCountersStore.read().first().newShown).isEqualTo(0)
+
+            // Second undo reverts yesterday's rating: its FSRS state must still be restored,
+            // but its stale snapshotDay must not perturb today's (already-zero) counters.
+            val secondUndo = repository.undoLastRating()
+            assertThat(secondUndo?.item?.id).isEqualTo(yesterdayId)
+            val restoredYesterday = vocabularyDao.getVocabularyById(yesterdayId)!!
+            assertThat(restoredYesterday.fsrsCardJson).isEmpty()
+            assertThat(restoredYesterday.incorrectCount).isEqualTo(0)
+
+            val finalCounters = dayCountersStore.read().first()
+            assertThat(finalCounters.newShown).isEqualTo(0)
+            assertThat(finalCounters.reviewShown).isEqualTo(0)
+        }
+
+    @Test
     fun `undoLastRating never touches extraNewToday`() =
         runTest {
             val id = insertVocab("kaufen")


### PR DESCRIPTION
## Description

Adds two of the test-coverage gaps identified in a review of the codebase: `PendingWordMapper` had zero dedicated tests (unlike its sibling `VocabularyMapper`), and the undo stack's cross-midnight behavior wasn't exercised in a mixed (yesterday + today) stack.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement
- [x] Test coverage

## Changes Made

- Add `PendingWordMapperTest`: field mapping, direction parsing (`TARGET_TO_NATIVE`/`NATIVE_TO_TARGET`), the `runCatching` fallback to `TARGET_TO_NATIVE` for an unrecognized/blank direction string, and an entity round-trip.
- Extend `VocabularyRepositoryUndoTest` with a mixed-day undo-stack case: a stale (yesterday's) snapshot sitting below a snapshot rated today. Undoing today's rating restores its counters; undoing the older entry afterward restores its FSRS state without perturbing today's already-reset day counters.

## How to Test

1. `./gradlew testDebugUnitTest --tests "com.procrastilearn.app.data.local.mapper.PendingWordMapperTest" --tests "com.procrastilearn.app.data.repository.VocabularyRepositoryUndoTest"`
2. `./gradlew ktlintCheck detekt`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable, including edge cases
- [x] Existing tests pass locally
- [ ] Updated documentation if needed
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_015X4Jt3R8JShd2RCoZWRwgV)_