### PR TITLE
ci: cache AVD snapshot for instrumented tests + Gradle cache retention sweep

### DIFF
--- a/.github/workflows/cache-sweep.yml
+++ b/.github/workflows/cache-sweep.yml
@@ -1,0 +1,58 @@
+name: Cache retention sweep
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune superseded Gradle caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          KEEP: "2"
+        run: |
+          set -euo pipefail
+          # gh cache list caps at --limit 100; if any single prefix ever exceeds
+          # that count this under-deletes silently — fine at current scale (94 total).
+          prefixes=(
+            'gradle-home-v1|Linux-X64|verify'
+            'gradle-home-v1|Linux-X64|instrumented-tests'
+            'gradle-dependencies-v1-'
+            'gradle-transforms-v1-'
+            'gradle-generated-gradle-jars-v1-'
+            'gradle-wrapper-zips-v1-'
+            'gradle-kotlin-dsl-v1-'
+            'gradle-groovy-dsl-v1-'
+            'gradle-instrumented-jars-v1-'
+          )
+          failed=0
+          for p in "${prefixes[@]}"; do
+            echo "::group::$p"
+            # Defensive: gh < 2.61.0 printed "No caches found" instead of []
+            # for --json on an empty match, which would abort here under set -e.
+            # Runners are expected to be well past that (fixed Nov 2024), but the
+            # fallback is free and doesn't mask real deletion failures below.
+            ids=$(gh cache list -R "$REPO" --key "$p" --limit 100 \
+                    --sort created_at --order desc \
+                    --json id --jq ".[${KEEP}:] | .[].id" 2>/dev/null) || ids=""
+            for id in $ids; do
+              if gh cache delete "$id" -R "$REPO"; then
+                echo "deleted $id"
+              else
+                echo "::warning::failed to delete cache id=$id"
+                failed=$((failed + 1))
+              fi
+            done
+            echo "::endgroup::"
+          done
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed cache deletions failed — check token permissions"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: AVD cache
-        uses: actions/cache@v4
+      - name: Restore AVD cache
+        uses: actions/cache/restore@v4
         id: avd-cache
         with:
           path: |
@@ -114,6 +114,15 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
+
+      - name: Save AVD cache
+        if: steps.avd-cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ runner.os }}-30-pixel_6-x86_64-v1
 
       - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,28 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ runner.os }}-30-pixel_6-x86_64-v1
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: default
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -101,7 +123,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           force-avd-creation: false
-          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
             adb logcat -c


### PR DESCRIPTION
## Description

`instrumented-tests` reinstalls the Android SDK, emulator binary, and system image, and cold-boots a fresh AVD on every single CI run — confirmed by inspecting run #293's logs (`sdkmanager --install`, `avdmanager create avd` fired every time). `force-avd-creation: false` was already set but had nothing to skip, since no AVD was ever cached, and `-no-snapshot` in `emulator-options` prevented snapshot boot even if one existed.

This adds AVD snapshot caching following [`reactivecircus/android-emulator-runner`'s documented two-step pattern](https://github.com/ReactiveCircus/android-emulator-runner#faq): a warm-up step boots once and lets the runner snapshot the AVD on a cache miss, and the real test step boots from that snapshot (`-no-snapshot-save` instead of `-no-snapshot`, so it doesn't overwrite the clean warm-up snapshot with post-test state on every run).

**Branch-scoped cache writes.** `gradle/actions/setup-gradle` is read-only on non-default branches by default — PR runs never write to the Gradle cache, only `master` does. `actions/cache` has no such restriction, so a naive combined `actions/cache` step would have every open PR save its own multi-GB AVD copy scoped to its own merge ref, multiplying cache usage instead of sharing one entry. The AVD cache is therefore split into `actions/cache/restore` + `actions/cache/save`, with the save gated to `github.ref == 'refs/heads/master'` — matching `setup-gradle`'s own write policy. PR branches always restore `master`'s cache and never write their own.

**Gradle cache retention sweep.** Separately, the repo is at 94 entries / 9.39 GB of a 10 GB cap. `setup-gradle`'s `cache-cleanup` feature already runs by default (`on-success`) but only prunes stale files inside the Gradle User Home before a save — it never deletes superseded GitHub Actions cache *entries* from earlier commits, which is what's actually driving the entry count. Caches unaccessed for 7 days auto-delete independently of the 10 GB cap, so the current pile is close to this repo's steady state at current push volume, not a one-time backlog — a manual purge alone only resets the clock. Added `.github/workflows/cache-sweep.yml`, scheduled daily (and manually dispatchable), which keeps the newest 2 entries per known Gradle cache-name prefix and deletes the rest.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [x] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Split the AVD cache step into `Restore AVD cache` (`actions/cache/restore@v4`) and `Save AVD cache` (`actions/cache/save@v4`, gated on cache-miss **and** `github.ref == 'refs/heads/master'`)
- Add a `Create AVD and generate snapshot for caching` warm-up step, gated on `steps.avd-cache.outputs.cache-hit != 'true'`, that boots the emulator once and lets it snapshot on shutdown
- Change the existing `Run instrumented tests` step's `emulator-options` from `-no-snapshot` to `-no-snapshot-save`, so it boots from the cached snapshot but doesn't re-save it after tests run
- Add `.github/workflows/cache-sweep.yml`: daily-scheduled + manually dispatchable job that lists caches per known Gradle prefix (`gradle-dependencies-v1-`, `gradle-transforms-v1-`, `gradle-home-v1|...`, etc.), keeps the newest 2 of each, and deletes the rest via `gh cache delete`. Deletion failures are tracked and fail the job loudly rather than being silently swallowed.
- No changes to the `verify` job

**Cache key is frozen once saved** (`avd-${{ runner.os }}-30-pixel_6-x86_64-v1`) — it never refreshes on its own, while `sdkmanager --install emulator --channel=0` installs the latest emulator build every run. If a future emulator build can't load the old snapshot, the usual failure mode is a silent fallback to cold boot (no error, just no speedup). The escape hatch is bumping the key's `-v1` suffix to `-v2` by hand.

## How to Test

1. On this PR's own run: AVD cache miss (first time) or restore from `master` (once populated) → warm-up step creates/skips accordingly → real test step reuses that AVD and should not cold-boot within the same job. The `Save AVD cache` step should show as **skipped** in the log (this isn't `master`), not silently succeeding.
2. After merge, on the first `master` push: confirm `Save AVD cache` actually runs and succeeds, populating the shared cache.
3. On a subsequent PR run: confirm it restores `master`'s AVD cache and skips the warm-up step entirely.
4. After merge: manually dispatch `cache-sweep.yml` once, confirm the run succeeds and the repo's Caches page shows a reduced entry count/size (up to 18 entries across the 9 tracked prefixes at keep-2, well under the 94 currently there).
5. Confirm `connectedDebugAndroidTest` still passes throughout.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (not applicable — CI config change only)
- [ ] Existing tests pass (pending CI on this PR)
- [ ] Documentation updated if needed (not applicable)
- [x] No duplicate/redundant code
- [x] No new warnings or suppressions introduced without maintainer approval

## Related Issues

N/A