### PR TITLE
ci: enable Gradle caching and consolidate verify steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: ktlint
-        run: ./gradlew ktlintCheck --no-daemon
-
-      - name: detekt
-        run: ./gradlew detekt --no-daemon
-
-      - name: Android Lint
-        run: ./gradlew lint --no-daemon
-
-      - name: Unit tests
-        run: ./gradlew testDebugUnitTest --no-daemon
+      - name: Verify (ktlint, detekt, lint, unit tests)
+        run: ./gradlew ktlintCheck detekt lint testDebugUnitTest
 
       - name: Upload test reports
         if: failure()
@@ -137,7 +128,7 @@ jobs:
           script: |
             adb logcat -c
             adb logcat -v threadtime > /tmp/logcat.txt &
-            ./gradlew connectedDebugAndroidTest --no-daemon
+            ./gradlew connectedDebugAndroidTest
 
       - name: Upload instrumented test reports
         if: failure()

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Description

CI paid full cost on every run: `gradle.properties` had no build-cache or configuration-cache settings, so task outputs (ktlint, detekt, lint, compile) were redone from scratch even when inputs hadn't changed. The `verify` job also invoked `./gradlew` four separate times with `--no-daemon`, so each of the four paid a full JVM cold start and full project (re-)configuration. This enables Gradle's own caching and removes the self-inflicted per-step overhead, with no change to what's checked or its pass/fail behavior.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Infrastructure / CI/CD
- [x] Performance improvement

## Changes Made

- Added `org.gradle.caching=true` and `org.gradle.configuration-cache=true` to `gradle.properties`. `gradle/actions/setup-gradle@v4` (already used in both CI jobs) automatically persists the build cache directory, so no workflow change is needed for this to take effect.
- Collapsed the `verify` job's four separate steps (`ktlintCheck`, `detekt`, `lint`, `testDebugUnitTest`) into a single `./gradlew ktlintCheck detekt lint testDebugUnitTest` step, and dropped `--no-daemon` so the daemon started for the run stays warm across tasks (each GH-hosted runner is a fresh VM per job, so there's no stale-daemon risk).
- Dropped `--no-daemon` from the `instrumented-tests` job's single Gradle invocation for consistency (same reasoning, no functional difference since it's already one call).

## How to Test

1. Verified locally that `org.gradle.configuration-cache=true` doesn't break the build: ran `./gradlew ktlintCheck --dry-run` twice and confirmed a "Configuration cache entry stored." the first time and "Configuration cache entry reused." the second (1m56s → 817ms).
2. Watch the CI run on this PR — `verify` job should still run ktlint, detekt, lint, and unit tests and fail/report the same way as before if any of them fail.
3. On a subsequent run, check the Gradle step logs for configuration-cache reuse and build-cache task outcomes (`FROM-CACHE`).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [ ] Added or updated tests where applicable, including edge cases
- [x] Existing tests pass locally
- [ ] Updated documentation if needed
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [x] No new warnings or supressions introduced. If something like this has to be introduced - get approve from maintainer first

## Related Issues

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wcjdm4FTtUukr1oXKQLazQ)_