### PR TITLE
Add configurable search scope (word/translation) to word list

### DIFF
--- a/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListSearchScopeE2eTest.kt
+++ b/app/src/androidTest/java/com/procrastilearn/app/e2e/WordListSearchScopeE2eTest.kt
@@ -1,0 +1,282 @@
+package com.procrastilearn.app.e2e
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.procrastilearn.app.MainActivity
+import com.procrastilearn.app.R
+import com.procrastilearn.app.data.local.entity.VocabularyEntity
+import com.procrastilearn.app.di.DatabaseEntryPoint
+import com.procrastilearn.app.di.PreferencesEntryPoint
+import com.procrastilearn.app.domain.model.SearchScope
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WordListSearchScopeE2eTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    private lateinit var targetContext: Context
+
+    private var nextPosition = 1L
+
+    @Before
+    fun beforeEach() {
+        targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        resetAppState()
+        composeTestRule.dismissOnboardingIfPresent(targetContext)
+    }
+
+    @After
+    fun afterEach() {
+        resetAppState()
+    }
+
+    @Test
+    fun defaultScopeMatchesBothWordAndTranslationOnFreshInstall() {
+        val wordMatchId = seedWord(word = "glimmerquat", translation = "shiny-thing")
+        val translationMatchId = seedWord(word = "sunderpike", translation = "arcanewhisper")
+
+        navigateToWordList()
+        typeInSearchField("glimmer")
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(wordMatchId)), DEFAULT_TIMEOUT_MS)
+
+        composeTestRule.onNodeWithTag("word_list_search_field").performClick()
+        clearSearchField()
+        typeInSearchField("arcanewhisper")
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(translationMatchId)), DEFAULT_TIMEOUT_MS)
+    }
+
+    @Test
+    fun openingTheScopeDialogShowsSearchInTitleAndBothOptions() {
+        navigateToWordList()
+
+        openScopeDialog()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_title)).assertExists()
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_option_word)).assertExists()
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_option_translation)).assertExists()
+    }
+
+    @Test
+    fun applyingWordOnlyScopeExcludesTranslationMatchesFromSearchResults() {
+        val translationOnlyMatchId = seedWord(word = "brellathorn", translation = "wildberrynectar")
+        navigateToWordList()
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        typeInSearchField("wildberrynectar")
+
+        composeTestRule.onNodeWithTag(itemTag(translationOnlyMatchId)).assertDoesNotExist()
+    }
+
+    @Test
+    fun applyingTranslationOnlyScopeExcludesWordMatchesFromSearchResults() {
+        val wordOnlyMatchId = seedWord(word = "molvantree", translation = "unrelated-meaning")
+        navigateToWordList()
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        typeInSearchField("molvantree")
+
+        composeTestRule.onNodeWithTag(itemTag(wordOnlyMatchId)).assertDoesNotExist()
+    }
+
+    @Test
+    fun cancellingTheScopeDialogDoesNotChangeActiveSearchResults() {
+        val translationOnlyMatchId = seedWord(word = "pikewander", translation = "duskember")
+        navigateToWordList()
+        typeInSearchField("duskember")
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(translationOnlyMatchId)), DEFAULT_TIMEOUT_MS)
+
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        composeTestRule.onNodeWithTag(itemTag(translationOnlyMatchId)).assertExists()
+    }
+
+    @Test
+    fun reopeningTheDialogAfterCancelShowsTheLastAppliedScopeNotTheDiscardedDraft() {
+        navigateToWordList()
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        openScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").assertIsOn()
+    }
+
+    @Test
+    fun dismissingTheDialogViaBackPressBehavesTheSameAsCancel() {
+        navigateToWordList()
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+
+        Espresso.pressBack()
+        composeTestRule.waitForIdle()
+
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
+    }
+
+    @Test
+    fun wordListSearchScopePersistsAcrossActivityRecreation() {
+        val translationOnlyMatchId = seedWord(word = "corvantiel", translation = "emberfallecho")
+        navigateToWordList()
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        recreateActivity()
+        composeTestRule.dismissOnboardingIfPresent(targetContext)
+        navigateToWordList()
+        typeInSearchField("emberfallecho")
+
+        composeTestRule.onNodeWithTag(itemTag(translationOnlyMatchId)).assertDoesNotExist()
+    }
+
+    @Test
+    fun applyingBothScopeAgainRestoresDefaultBehavior() {
+        val translationOnlyMatchId = seedWord(word = "sableharrow", translation = "windlornsong")
+        navigateToWordList()
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        openScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        typeInSearchField("windlornsong")
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(translationOnlyMatchId)), DEFAULT_TIMEOUT_MS)
+    }
+
+    @Test
+    fun existingWordMatchingSearchFlowsAreUnaffectedByTheNewScopeFeature() {
+        val matchingId = seedWord(word = "quorlinfast", translation = "translation-a")
+        val otherId = seedWord(word = "thornapple", translation = "translation-b")
+
+        navigateToWordList()
+        composeTestRule.waitUntilNodeExists(hasTestTag(itemTag(matchingId)), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithTag(itemTag(otherId)).assertExists()
+
+        typeInSearchField("quorlin")
+
+        composeTestRule.onNodeWithTag(itemTag(matchingId)).assertExists()
+        composeTestRule.waitUntilNodeGone(hasTestTag(itemTag(otherId)), DEFAULT_TIMEOUT_MS)
+    }
+
+    private fun string(resId: Int) = targetContext.getString(resId)
+
+    private fun navigateToWordList() {
+        val addWordLabel = string(R.string.nav_add_word)
+        composeTestRule.waitUntilNodeExists(hasText(addWordLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule
+            .onNodeWithContentDescription(addWordLabel, useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        val viewListLabel = string(R.string.action_view_list)
+        composeTestRule.waitUntilNodeExists(hasContentDescription(viewListLabel), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithContentDescription(viewListLabel).performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun typeInSearchField(query: String) {
+        composeTestRule.waitUntilNodeExists(hasTestTag("word_list_search_field"), DEFAULT_TIMEOUT_MS)
+        composeTestRule.onNodeWithTag("word_list_search_field").performTextInput(query)
+        composeTestRule.waitForIdle()
+    }
+
+    private fun clearSearchField() {
+        composeTestRule.onNodeWithTag("word_list_search_field").performTextClearance()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun openScopeDialog() {
+        composeTestRule.waitUntilNodeExists(
+            hasContentDescription(string(R.string.word_list_search_scope_content_description)),
+            DEFAULT_TIMEOUT_MS,
+        )
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun recreateActivity() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            composeTestRule.activity.recreate()
+        }
+    }
+
+    private fun itemTag(id: Long) = "word_list_item_$id"
+
+    private fun seedWord(
+        word: String,
+        translation: String,
+    ): Long =
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                entryPoint().appDatabase().vocabularyDao().insertVocabulary(
+                    VocabularyEntity(
+                        word = word,
+                        translation = translation,
+                        fsrsCardJson = "",
+                        position = nextPosition++,
+                    ),
+                )
+            }
+        }
+
+    private fun resetAppState() {
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                val db = entryPoint().appDatabase()
+                db.vocabularyDao().deleteAllVocabulary()
+                db.undoSnapshotDao().deleteAll()
+                preferencesEntryPoint().wordListSearchPreferencesStore().setScope(SearchScope())
+            }
+        }
+    }
+
+    private fun entryPoint(): DatabaseEntryPoint =
+        EntryPointAccessors.fromApplication(
+            targetContext.applicationContext,
+            DatabaseEntryPoint::class.java,
+        )
+
+    private fun preferencesEntryPoint(): PreferencesEntryPoint =
+        EntryPointAccessors.fromApplication(
+            targetContext.applicationContext,
+            PreferencesEntryPoint::class.java,
+        )
+
+    private companion object {
+        const val DEFAULT_TIMEOUT_MS = 15_000L
+    }
+}

--- a/app/src/main/java/com/procrastilearn/app/data/local/prefs/WordListSearchPreferencesStore.kt
+++ b/app/src/main/java/com/procrastilearn/app/data/local/prefs/WordListSearchPreferencesStore.kt
@@ -1,0 +1,38 @@
+package com.procrastilearn.app.data.local.prefs
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.procrastilearn.app.domain.model.SearchScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WordListSearchPreferencesStore
+    @Inject
+    constructor(
+        studyPreferences: StudyPreferencesDataStore,
+    ) {
+        private val ds = studyPreferences.ds
+
+        private object K {
+            val MATCH_WORD = booleanPreferencesKey("word_list_search_match_word")
+            val MATCH_TRANSLATION = booleanPreferencesKey("word_list_search_match_translation")
+        }
+
+        fun readScope(): Flow<SearchScope> =
+            ds.data.map { preferences ->
+                SearchScope(
+                    matchWord = preferences[K.MATCH_WORD] ?: true,
+                    matchTranslation = preferences[K.MATCH_TRANSLATION] ?: true,
+                )
+            }
+
+        suspend fun setScope(scope: SearchScope) {
+            ds.edit { preferences ->
+                preferences[K.MATCH_WORD] = scope.matchWord
+                preferences[K.MATCH_TRANSLATION] = scope.matchTranslation
+            }
+        }
+    }

--- a/app/src/main/java/com/procrastilearn/app/di/PreferencesEntryPoint.kt
+++ b/app/src/main/java/com/procrastilearn/app/di/PreferencesEntryPoint.kt
@@ -2,6 +2,7 @@ package com.procrastilearn.app.di
 
 import com.procrastilearn.app.data.local.prefs.DayCountersStore
 import com.procrastilearn.app.data.local.prefs.TranslationPreferences
+import com.procrastilearn.app.data.local.prefs.WordListSearchPreferencesStore
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
@@ -12,4 +13,6 @@ interface PreferencesEntryPoint {
     fun dayCountersStore(): DayCountersStore
 
     fun translationPreferences(): TranslationPreferences
+
+    fun wordListSearchPreferencesStore(): WordListSearchPreferencesStore
 }

--- a/app/src/main/java/com/procrastilearn/app/domain/model/SearchScope.kt
+++ b/app/src/main/java/com/procrastilearn/app/domain/model/SearchScope.kt
@@ -1,0 +1,8 @@
+package com.procrastilearn.app.domain.model
+
+data class SearchScope(
+    val matchWord: Boolean = true,
+    val matchTranslation: Boolean = true,
+) {
+    val isValid: Boolean get() = matchWord || matchTranslation
+}

--- a/app/src/main/java/com/procrastilearn/app/ui/WordListViewModel.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/WordListViewModel.kt
@@ -2,6 +2,8 @@ package com.procrastilearn.app.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.procrastilearn.app.data.local.prefs.WordListSearchPreferencesStore
+import com.procrastilearn.app.domain.model.SearchScope
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.repository.VocabularyCatalogRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,6 +22,7 @@ class WordListViewModel
     @Inject
     constructor(
         private val repository: VocabularyCatalogRepository,
+        private val searchPreferencesStore: WordListSearchPreferencesStore,
     ) : ViewModel() {
         data class SelectionState(
             val isActive: Boolean = false,
@@ -35,8 +38,24 @@ class WordListViewModel
                     initialValue = emptyList(),
                 )
 
+        val searchScope: StateFlow<SearchScope> =
+            searchPreferencesStore
+                .readScope()
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5000),
+                    initialValue = SearchScope(),
+                )
+
         private val _selectionState = MutableStateFlow(SelectionState())
         val selectionState: StateFlow<SelectionState> = _selectionState.asStateFlow()
+
+        fun setSearchScope(scope: SearchScope) {
+            if (!scope.isValid) return
+            viewModelScope.launch {
+                searchPreferencesStore.setScope(scope)
+            }
+        }
 
         fun deleteWord(item: VocabularyItem) {
             viewModelScope.launch {

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -70,6 +71,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.procrastilearn.app.R
+import com.procrastilearn.app.domain.model.SearchScope
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.ui.BidirectionalFields
 import com.procrastilearn.app.ui.WordListViewModel
@@ -99,6 +101,7 @@ fun WordListScreen(
 ) {
     val words by viewModel.words.collectAsState()
     val selectionState by viewModel.selectionState.collectAsState()
+    val searchScope by viewModel.searchScope.collectAsState()
     var searchQuery by rememberSaveable { mutableStateOf("") }
 
     WordListContent(
@@ -106,6 +109,8 @@ fun WordListScreen(
         selectionState = selectionState,
         searchQuery = searchQuery,
         onSearchQueryChange = { searchQuery = it },
+        searchScope = searchScope,
+        onSearchScopeChange = viewModel::setSearchScope,
         onDelete = viewModel::deleteWord,
         onEdit = viewModel::updateWord,
         onReset = viewModel::resetWordProgress,
@@ -134,6 +139,8 @@ internal fun WordListContent(
     onEdit: (VocabularyItem) -> Unit,
     onReset: (VocabularyItem) -> Unit,
     modifier: Modifier = Modifier,
+    searchScope: SearchScope = SearchScope(),
+    onSearchScopeChange: (SearchScope) -> Unit = {},
     selectionState: SelectionState = SelectionState(),
     onEnterSelectionMode: (Long) -> Unit = {},
     onToggleSelection: (Long) -> Unit = {},
@@ -178,12 +185,18 @@ internal fun WordListContent(
         if (normalizedQuery.isBlank()) {
             localOrder
         } else {
-            words.filter { it.word.contains(normalizedQuery, ignoreCase = true) }
+            words.filter { item ->
+                searchScope.matchWord &&
+                    item.word.contains(normalizedQuery, ignoreCase = true) ||
+                    searchScope.matchTranslation &&
+                    item.translation.contains(normalizedQuery, ignoreCase = true)
+            }
         }
 
     var showSelectionMenu by remember { mutableStateOf(false) }
     var showBulkDeleteDialog by remember { mutableStateOf(false) }
     var showForwardOnlyDialog by remember { mutableStateOf(false) }
+    var showSearchScopeDialog by remember { mutableStateOf(false) }
     val allDisplayedSelected =
         displayedWords.isNotEmpty() && displayedWords.all { it.id in selectionState.selectedIds }
     val selectedWords = words.filter { it.id in selectionState.selectedIds }
@@ -291,6 +304,14 @@ internal fun WordListContent(
                     imageVector = Icons.Default.Search,
                     contentDescription = null,
                 )
+            },
+            trailingIcon = {
+                IconButton(onClick = { showSearchScopeDialog = true }) {
+                    Icon(
+                        imageVector = Icons.Default.Tune,
+                        contentDescription = stringResource(R.string.word_list_search_scope_content_description),
+                    )
+                }
             },
             singleLine = true,
             shape = RoundedCornerShape(16.dp),
@@ -426,6 +447,17 @@ internal fun WordListContent(
                 onSetSelectedBidirectional(false)
                 showForwardOnlyDialog = false
             },
+        )
+    }
+
+    if (showSearchScopeDialog) {
+        WordListSearchScopeDialog(
+            currentScope = searchScope,
+            onApply = { newScope ->
+                onSearchScopeChange(newScope)
+                showSearchScopeDialog = false
+            },
+            onDismiss = { showSearchScopeDialog = false },
         )
     }
 }

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListSearchScopeDialog.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListSearchScopeDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -39,6 +40,7 @@ internal fun WordListSearchScopeDialog(
         text = {
             Column {
                 Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                 ) {
                     Checkbox(
@@ -50,6 +52,7 @@ internal fun WordListSearchScopeDialog(
                     Text(stringResource(R.string.word_list_search_scope_option_word))
                 }
                 Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                 ) {
                     Checkbox(

--- a/app/src/main/java/com/procrastilearn/app/ui/screens/WordListSearchScopeDialog.kt
+++ b/app/src/main/java/com/procrastilearn/app/ui/screens/WordListSearchScopeDialog.kt
@@ -1,0 +1,95 @@
+package com.procrastilearn.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.procrastilearn.app.R
+import com.procrastilearn.app.domain.model.SearchScope
+import com.procrastilearn.app.ui.theme.MyApplicationTheme
+
+@Composable
+internal fun WordListSearchScopeDialog(
+    currentScope: SearchScope,
+    onApply: (SearchScope) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var draftScope by remember { mutableStateOf(currentScope) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.word_list_search_scope_title)) },
+        text = {
+            Column {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                ) {
+                    Checkbox(
+                        checked = draftScope.matchWord,
+                        onCheckedChange = { checked -> draftScope = draftScope.copy(matchWord = checked) },
+                        modifier = Modifier.testTag("word_list_search_scope_word_checkbox"),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.word_list_search_scope_option_word))
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                ) {
+                    Checkbox(
+                        checked = draftScope.matchTranslation,
+                        onCheckedChange = { checked -> draftScope = draftScope.copy(matchTranslation = checked) },
+                        modifier = Modifier.testTag("word_list_search_scope_translation_checkbox"),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.word_list_search_scope_option_translation))
+                }
+                if (!draftScope.isValid) {
+                    Text(
+                        text = stringResource(R.string.word_list_search_scope_error),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.testTag("word_list_search_scope_error_text"),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onApply(draftScope) },
+                enabled = draftScope.isValid,
+            ) {
+                Text(stringResource(R.string.action_apply))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WordListSearchScopeDialogPreview() {
+    MyApplicationTheme {
+        WordListSearchScopeDialog(currentScope = SearchScope(), onApply = {}, onDismiss = {})
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Bearbeiten</string>
     <string name="action_reset">Zurücksetzen</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Anwenden</string>
     <string name="action_cancel">Abbrechen</string>
     <string name="action_proceed">Fortfahren</string>
     <string name="action_select_all">Alle auswählen</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Suchen</string>
     <string name="word_list_search_placeholder">Wörter suchen</string>
     <string name="word_list_search_no_results">Keine Treffer gefunden</string>
+    <string name="word_list_search_scope_content_description">Sucheinstellungen</string>
+    <string name="word_list_search_scope_title">Suchen in</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Bitte mindestens eine Option auswählen</string>
     <string name="word_list_drag_handle_content_description"><xliff:g id="word_name">%1$s</xliff:g> verschieben</string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Editar</string>
     <string name="action_reset">Restablecer</string>
     <string name="action_ok">Aceptar</string>
+    <string name="action_apply">Aplicar</string>
     <string name="action_cancel">Cancelar</string>
     <string name="action_proceed">@string/action_continue</string>
     <string name="action_select_all">Seleccionar todo</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Buscar</string>
     <string name="word_list_search_placeholder">Buscar palabras</string>
     <string name="word_list_search_no_results">No se encontraron resultados</string>
+    <string name="word_list_search_scope_content_description">Opciones de búsqueda</string>
+    <string name="word_list_search_scope_title">Buscar en</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Selecciona al menos una opción</string>
     <string name="word_list_drag_handle_content_description">Reordenar <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Modifier</string>
     <string name="action_reset">Réinitialiser</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Appliquer</string>
     <string name="action_cancel">Annuler</string>
     <string name="action_proceed">Poursuivre</string>
     <string name="action_select_all">Tout sélectionner</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Rechercher</string>
     <string name="word_list_search_placeholder">Rechercher des mots</string>
     <string name="word_list_search_no_results">Aucun résultat trouvé</string>
+    <string name="word_list_search_scope_content_description">Options de recherche</string>
+    <string name="word_list_search_scope_title">Rechercher dans</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Sélectionnez au moins une option</string>
     <string name="word_list_drag_handle_content_description">Réorganiser <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">एडिट करें</string>
     <string name="action_reset">रीसेट करें</string>
     <string name="action_ok">ठीक है</string>
+    <string name="action_apply">लागू करें</string>
     <string name="action_cancel">कैंसिल करें</string>
     <string name="action_proceed">आगे बढ़ें</string>
     <string name="action_select_all">सभी चुनें</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">सर्च करें</string>
     <string name="word_list_search_placeholder">शब्द सर्च करें</string>
     <string name="word_list_search_no_results">कोई मैच नहीं मिला</string>
+    <string name="word_list_search_scope_content_description">खोज विकल्प</string>
+    <string name="word_list_search_scope_title">खोजें इसमें</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">कम से कम एक विकल्प चुनें</string>
     <string name="word_list_drag_handle_content_description"><xliff:g id="word_name">%1$s</xliff:g> को फिर से क्रमबद्ध करें</string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Ubah</string>
     <string name="action_reset">Reset</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Terapkan</string>
     <string name="action_cancel">Batal</string>
     <string name="action_proceed">Teruskan</string>
     <string name="action_select_all">Pilih semua</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Cari</string>
     <string name="word_list_search_placeholder">Cari kata</string>
     <string name="word_list_search_no_results">Tidak ada hasil yang cocok</string>
+    <string name="word_list_search_scope_content_description">Opsi pencarian</string>
+    <string name="word_list_search_scope_title">Cari di</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Pilih setidaknya satu opsi</string>
     <string name="word_list_drag_handle_content_description">Atur ulang urutan <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Modifica</string>
     <string name="action_reset">Reimposta</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Applica</string>
     <string name="action_cancel">Annulla</string>
     <string name="action_proceed">Procedi</string>
     <string name="action_select_all">Seleziona tutto</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Cerca</string>
     <string name="word_list_search_placeholder">Cerca parole</string>
     <string name="word_list_search_no_results">Nessun risultato trovato</string>
+    <string name="word_list_search_scope_content_description">Opzioni di ricerca</string>
+    <string name="word_list_search_scope_title">Cerca in</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Seleziona almeno un’opzione</string>
     <string name="word_list_drag_handle_content_description">Riordina <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">編集</string>
     <string name="action_reset">リセット</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">適用</string>
     <string name="action_cancel">キャンセル</string>
     <string name="action_proceed">続行</string>
     <string name="action_select_all">すべて選択</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">検索</string>
     <string name="word_list_search_placeholder">単語を検索</string>
     <string name="word_list_search_no_results">一致する結果がありません</string>
+    <string name="word_list_search_scope_content_description">検索オプション</string>
+    <string name="word_list_search_scope_title">検索対象</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">少なくとも1つ選択してください</string>
     <string name="word_list_drag_handle_content_description"><xliff:g id="word_name">%1$s</xliff:g>を並べ替え</string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">수정</string>
     <string name="action_reset">초기화</string>
     <string name="action_ok">확인</string>
+    <string name="action_apply">적용</string>
     <string name="action_cancel">취소</string>
     <string name="action_proceed">계속 진행</string>
     <string name="action_select_all">전체 선택</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">검색</string>
     <string name="word_list_search_placeholder">단어 검색</string>
     <string name="word_list_search_no_results">일치하는 결과가 없습니다</string>
+    <string name="word_list_search_scope_content_description">검색 옵션</string>
+    <string name="word_list_search_scope_title">검색 대상</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">하나 이상 선택하세요</string>
     <string name="word_list_drag_handle_content_description"><xliff:g id="word_name">%1$s</xliff:g> 순서 변경</string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Edytuj</string>
     <string name="action_reset">Resetuj</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Zastosuj</string>
     <string name="action_cancel">Anuluj</string>
     <string name="action_proceed">Potwierdź</string>
     <string name="action_select_all">Zaznacz wszystkie</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Szukaj</string>
     <string name="word_list_search_placeholder">Szukaj słówek</string>
     <string name="word_list_search_no_results">Brak wyników</string>
+    <string name="word_list_search_scope_content_description">Opcje wyszukiwania</string>
+    <string name="word_list_search_scope_title">Szukaj w</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Wybierz co najmniej jedną opcję</string>
     <string name="word_list_drag_handle_content_description">Zmień kolejność <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Editar</string>
     <string name="action_reset">Redefinir</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Aplicar</string>
     <string name="action_cancel">Cancelar</string>
     <string name="action_proceed">Prosseguir</string>
     <string name="action_select_all">Selecionar tudo</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Pesquisar</string>
     <string name="word_list_search_placeholder">Pesquisar palavras</string>
     <string name="word_list_search_no_results">Nenhum resultado encontrado</string>
+    <string name="word_list_search_scope_content_description">Opções de pesquisa</string>
+    <string name="word_list_search_scope_title">Pesquisar em</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Selecione pelo menos uma opção</string>
     <string name="word_list_drag_handle_content_description">Reordenar <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -13,6 +13,7 @@
         <string name="action_save">Сохранить</string>
         <string name="action_edit">Редактировать</string>
         <string name="action_ok">ОК</string>
+        <string name="action_apply">Применить</string>
         <string name="action_cancel">Отмена</string>
         <string name="action_proceed">@string/action_continue</string>
         <string name="action_select_all">Выбрать все</string>
@@ -277,6 +278,11 @@
         <string name="word_list_search_label">Поиск</string>
         <string name="word_list_search_placeholder">Поиск слов</string>
         <string name="word_list_search_no_results">Совпадений не найдено</string>
+        <string name="word_list_search_scope_content_description">Параметры поиска</string>
+        <string name="word_list_search_scope_title">Искать в</string>
+        <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+        <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+        <string name="word_list_search_scope_error">Выберите хотя бы один вариант</string>
         <string name="word_list_drag_handle_content_description">Изменить порядок <xliff:g id="word_name">%1$s</xliff:g></string>
 
         <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Düzenle</string>
     <string name="action_reset">Sıfırla</string>
     <string name="action_ok">Tamam</string>
+    <string name="action_apply">Uygula</string>
     <string name="action_cancel">İptal</string>
     <string name="action_proceed">Onayla</string>
     <string name="action_select_all">Tümünü seç</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Ara</string>
     <string name="word_list_search_placeholder">Kelime ara</string>
     <string name="word_list_search_no_results">Sonuç bulunamadı</string>
+    <string name="word_list_search_scope_content_description">Arama seçenekleri</string>
+    <string name="word_list_search_scope_title">Şurada ara</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">En az bir seçenek belirleyin</string>
     <string name="word_list_drag_handle_content_description"><xliff:g id="word_name">%1$s</xliff:g> kelimesini yeniden sırala</string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Редагувати</string>
     <string name="action_reset">Скинути</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Застосувати</string>
     <string name="action_cancel">Скасувати</string>
     <string name="action_proceed">@string/action_continue</string>
     <string name="action_select_all">Вибрати всі</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Пошук</string>
     <string name="word_list_search_placeholder">Пошук слів</string>
     <string name="word_list_search_no_results">Збігів не знайдено</string>
+    <string name="word_list_search_scope_content_description">Параметри пошуку</string>
+    <string name="word_list_search_scope_title">Шукати в</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Виберіть принаймні один варіант</string>
     <string name="word_list_drag_handle_content_description">Змінити порядок <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">Chỉnh sửa</string>
     <string name="action_reset">Đặt lại</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Áp dụng</string>
     <string name="action_cancel">Hủy</string>
     <string name="action_proceed">Xác nhận</string>
     <string name="action_select_all">Chọn tất cả</string>
@@ -310,6 +311,11 @@
     <string name="word_list_search_label">Tìm kiếm</string>
     <string name="word_list_search_placeholder">Tìm từ</string>
     <string name="word_list_search_no_results">Không tìm thấy kết quả nào</string>
+    <string name="word_list_search_scope_content_description">Tùy chọn tìm kiếm</string>
+    <string name="word_list_search_scope_title">Tìm trong</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Chọn ít nhất một tùy chọn</string>
     <string name="word_list_drag_handle_content_description">Sắp xếp lại <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -17,6 +17,7 @@
     <string name="action_edit">编辑</string>
     <string name="action_reset">重置</string>
     <string name="action_ok">确定</string>
+    <string name="action_apply">套用</string>
     <string name="action_cancel">取消</string>
     <string name="action_proceed">@string/action_continue</string>
     <string name="action_select_all">全选</string>
@@ -279,6 +280,11 @@
     <string name="word_list_search_label">搜索</string>
     <string name="word_list_search_placeholder">搜索单词</string>
     <string name="word_list_search_no_results">未找到匹配结果</string>
+    <string name="word_list_search_scope_content_description">搜索选项</string>
+    <string name="word_list_search_scope_title">搜索范围</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">请至少选择一项</string>
     <string name="word_list_drag_handle_content_description">重新排序 <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="action_edit">Edit</string>
     <string name="action_reset">Reset</string>
     <string name="action_ok">OK</string>
+    <string name="action_apply">Apply</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_proceed">Proceed</string>
     <string name="action_select_all">Select all</string>
@@ -312,6 +313,11 @@
     <string name="word_list_search_label">Search</string>
     <string name="word_list_search_placeholder">Search words</string>
     <string name="word_list_search_no_results">No matches found</string>
+    <string name="word_list_search_scope_content_description">Search options</string>
+    <string name="word_list_search_scope_title">Search in</string>
+    <string name="word_list_search_scope_option_word">@string/add_word_label_word</string>
+    <string name="word_list_search_scope_option_translation">@string/add_word_label_translation</string>
+    <string name="word_list_search_scope_error">Select at least one option</string>
     <string name="word_list_drag_handle_content_description">Reorder <xliff:g id="word_name">%1$s</xliff:g></string>
 
     <!-- ─── Apps list ──────────────────────────────────────────────────────── -->

--- a/app/src/test/java/com/procrastilearn/app/data/local/prefs/WordListSearchPreferencesStoreTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/data/local/prefs/WordListSearchPreferencesStoreTest.kt
@@ -1,0 +1,104 @@
+package com.procrastilearn.app.data.local.prefs
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.domain.model.SearchScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class WordListSearchPreferencesStoreTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var studyPreferences: StudyPreferencesDataStore
+    private lateinit var store: WordListSearchPreferencesStore
+
+    @Before
+    fun setUp() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val filesRoot = temporaryFolder.newFolder("datastore-root")
+        val dataStoreContext =
+            object : ContextWrapper(baseContext) {
+                override fun getFilesDir(): File = filesRoot
+
+                override fun getApplicationContext(): Context = this
+            }
+        studyPreferences = StudyPreferencesDataStore(dataStoreContext)
+        store = WordListSearchPreferencesStore(studyPreferences)
+    }
+
+    @Test
+    fun readScopeEmitsBothTrueWhenNothingIsStored() =
+        runTest {
+            assertThat(store.readScope().first()).isEqualTo(SearchScope(matchWord = true, matchTranslation = true))
+        }
+
+    @Test
+    fun setScopeWordOnlyPersistsAndReadsBack() =
+        runTest {
+            store.setScope(SearchScope(matchWord = true, matchTranslation = false))
+
+            assertThat(store.readScope().first())
+                .isEqualTo(SearchScope(matchWord = true, matchTranslation = false))
+        }
+
+    @Test
+    fun setScopeTranslationOnlyPersistsAndReadsBack() =
+        runTest {
+            store.setScope(SearchScope(matchWord = false, matchTranslation = true))
+
+            assertThat(store.readScope().first())
+                .isEqualTo(SearchScope(matchWord = false, matchTranslation = true))
+        }
+
+    @Test
+    fun setScopeOverwritesPreviouslyPersistedScope() =
+        runTest {
+            store.setScope(SearchScope(matchWord = true, matchTranslation = false))
+            store.setScope(SearchScope(matchWord = false, matchTranslation = true))
+
+            assertThat(store.readScope().first())
+                .isEqualTo(SearchScope(matchWord = false, matchTranslation = true))
+        }
+
+    @Test
+    fun readScopeReflectsLiveUpdatesToTheUnderlyingDataStore() =
+        runTest {
+            assertThat(store.readScope().first()).isEqualTo(SearchScope(matchWord = true, matchTranslation = true))
+
+            store.setScope(SearchScope(matchWord = true, matchTranslation = false))
+            assertThat(store.readScope().first())
+                .isEqualTo(SearchScope(matchWord = true, matchTranslation = false))
+        }
+
+    @Test
+    fun readScopeSurvivesRecreationOfTheStoreWrapper() =
+        runTest {
+            store.setScope(SearchScope(matchWord = false, matchTranslation = true))
+
+            val recreatedStore = WordListSearchPreferencesStore(studyPreferences)
+            assertThat(recreatedStore.readScope().first())
+                .isEqualTo(SearchScope(matchWord = false, matchTranslation = true))
+        }
+
+    @Test
+    fun setScopeWithBothFlagsFalseStillWritesWhatItIsGiven() =
+        runTest {
+            store.setScope(SearchScope(matchWord = false, matchTranslation = false))
+
+            assertThat(store.readScope().first())
+                .isEqualTo(SearchScope(matchWord = false, matchTranslation = false))
+        }
+}

--- a/app/src/test/java/com/procrastilearn/app/ui/WordListViewModelTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/WordListViewModelTest.kt
@@ -2,6 +2,8 @@ package com.procrastilearn.app.ui
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.data.local.prefs.WordListSearchPreferencesStore
+import com.procrastilearn.app.domain.model.SearchScope
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.domain.repository.VocabularyCatalogRepository
 import com.procrastilearn.app.utils.MainDispatcherRule
@@ -26,6 +28,8 @@ class WordListViewModelTest {
 
     private lateinit var repository: VocabularyCatalogRepository
     private lateinit var vocabularyFlow: MutableSharedFlow<List<VocabularyItem>>
+    private lateinit var searchPreferencesStore: WordListSearchPreferencesStore
+    private lateinit var searchScopeFlow: MutableSharedFlow<SearchScope>
 
     @Before
     fun setUp() {
@@ -33,6 +37,11 @@ class WordListViewModelTest {
         vocabularyFlow = MutableSharedFlow(replay = 1)
         vocabularyFlow.tryEmit(emptyList())
         every { repository.getAllVocabulary() } returns vocabularyFlow
+
+        searchPreferencesStore = mockk(relaxed = true)
+        searchScopeFlow = MutableSharedFlow(replay = 1)
+        searchScopeFlow.tryEmit(SearchScope())
+        every { searchPreferencesStore.readScope() } returns searchScopeFlow
     }
 
     @After
@@ -40,7 +49,7 @@ class WordListViewModelTest {
         clearAllMocks()
     }
 
-    private fun buildViewModel() = WordListViewModel(repository)
+    private fun buildViewModel() = WordListViewModel(repository, searchPreferencesStore)
 
     @Test
     fun `words emits latest repository items`() =
@@ -594,5 +603,78 @@ class WordListViewModelTest {
             advanceUntilIdle()
 
             coVerify(exactly = 1) { repository.reorderVocabulary(listOf(second.id, first.id)) }
+        }
+
+    @Test
+    fun `searchScope emits the store's current value`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            assertThat(viewModel.searchScope.value).isEqualTo(SearchScope(matchWord = true, matchTranslation = true))
+        }
+
+    @Test
+    fun `searchScope reflects the store re-emitting an updated scope`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+
+            viewModel.searchScope.test {
+                assertThat(awaitItem()).isEqualTo(SearchScope(matchWord = true, matchTranslation = true))
+
+                searchScopeFlow.tryEmit(SearchScope(matchWord = true, matchTranslation = false))
+                assertThat(awaitItem()).isEqualTo(SearchScope(matchWord = true, matchTranslation = false))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `setSearchScope with word-only delegates to the store's setScope`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+
+            viewModel.setSearchScope(SearchScope(matchWord = true, matchTranslation = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                searchPreferencesStore.setScope(SearchScope(matchWord = true, matchTranslation = false))
+            }
+        }
+
+    @Test
+    fun `setSearchScope with translation-only delegates to the store's setScope`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+
+            viewModel.setSearchScope(SearchScope(matchWord = false, matchTranslation = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                searchPreferencesStore.setScope(SearchScope(matchWord = false, matchTranslation = true))
+            }
+        }
+
+    @Test
+    fun `setSearchScope with both flags false does not call the store`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+
+            viewModel.setSearchScope(SearchScope(matchWord = false, matchTranslation = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { searchPreferencesStore.setScope(any()) }
+        }
+
+    @Test
+    fun `setSearchScope with both flags true delegates to the store's setScope`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val viewModel = buildViewModel()
+
+            viewModel.setSearchScope(SearchScope(matchWord = true, matchTranslation = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                searchPreferencesStore.setScope(SearchScope(matchWord = true, matchTranslation = true))
+            }
         }
 }

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -21,6 +22,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.procrastilearn.app.R
+import com.procrastilearn.app.domain.model.SearchScope
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
 import com.procrastilearn.app.ui.WordListViewModel
@@ -37,6 +39,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@Suppress("LargeClass")
 class WordListScreenTest {
     private val composeTestRule = createComposeRule()
     private val dragStepCount = 10
@@ -144,6 +147,209 @@ class WordListScreenTest {
     }
 
     @Test
+    fun `tune icon is visible in the search field`() {
+        setContent(words = words)
+
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `clicking the tune icon opens the search scope dialog`() {
+        setContent(words = words)
+
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `search scope dialog shows both checkboxes checked by default`() {
+        setContent(words = words, searchScope = SearchScope())
+
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").assertIsOn()
+    }
+
+    @Test
+    fun `search scope dialog seeds checkboxes from the currently applied scope, not always-default`() {
+        setContent(words = words, searchScope = SearchScope(matchWord = true, matchTranslation = false))
+
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").assertIsOff()
+    }
+
+    @Test
+    fun `unchecking one checkbox leaves Apply enabled and hides the error text`() {
+        setContent(words = words)
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsEnabled()
+        composeTestRule.onNodeWithTag("word_list_search_scope_error_text").assertDoesNotExist()
+    }
+
+    @Test
+    fun `unchecking both checkboxes disables Apply and shows the error text`() {
+        setContent(words = words)
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsNotEnabled()
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_error)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `re-checking a box after reaching zero re-enables Apply`() {
+        setContent(words = words)
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsEnabled()
+        composeTestRule.onNodeWithTag("word_list_search_scope_error_text").assertDoesNotExist()
+    }
+
+    @Test
+    fun `clicking Apply with a modified scope invokes onSearchScopeChange with the new scope and closes the dialog`() {
+        var applied: SearchScope? = null
+        setContent(words = words, onSearchScopeChangeOverride = { applied = it })
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        assertThat(applied).isEqualTo(SearchScope(matchWord = true, matchTranslation = false))
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `dismissing the dialog via Cancel does not invoke onSearchScopeChange and reverts unapplied changes`() {
+        var invoked = false
+        setContent(words = words, onSearchScopeChangeOverride = { invoked = true })
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        assertThat(invoked).isFalse()
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
+    }
+
+    @Test
+    fun `Apply button being disabled prevents onSearchScopeChange from being invoked`() {
+        var invoked = false
+        setContent(words = words, onSearchScopeChangeOverride = { invoked = true })
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        assertThat(invoked).isFalse()
+    }
+
+    @Test
+    fun `filtering with default both-checked scope matches by word (parity with pre-feature behavior)`() {
+        setContent(words = words, searchScope = SearchScope(), searchQuery = "PE")
+
+        composeTestRule.onNodeWithText("Peregrinate").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Serendipity").assertCountEquals(0)
+        composeTestRule.onAllNodesWithText("Ephemeral").assertCountEquals(0)
+    }
+
+    @Test
+    fun `filtering with word-only scope excludes matches that are only in the translation field`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchScope = SearchScope(matchWord = true, matchTranslation = false),
+            searchQuery = "wildly",
+        )
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
+    }
+
+    @Test
+    fun `filtering with translation-only scope excludes matches that are only in the word field`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchScope = SearchScope(matchWord = false, matchTranslation = true),
+            searchQuery = "quixo",
+        )
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
+    }
+
+    @Test
+    fun `filtering with translation-only scope still matches items whose translation contains the query`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchScope = SearchScope(matchWord = false, matchTranslation = true),
+            searchQuery = "wildly",
+        )
+
+        composeTestRule.onNodeWithText("Quixotic").assertIsDisplayed()
+    }
+
+    @Test
+    fun `filtering with both scopes enabled shows an item only once when it matches in both fields`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Quixotic-like folly", isNew = false)
+        setContent(words = words + extra, searchScope = SearchScope(), searchQuery = "quixo")
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(1)
+    }
+
+    @Test
+    fun `changing scope while a query is already active immediately re-filters the displayed list`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchQuery = "wildly",
+            searchScope = SearchScope(matchWord = true, matchTranslation = false),
+        )
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
+    }
+
+    @Test
+    fun `search field label is unchanged by the search scope`() {
+        setContent(words = words, searchScope = SearchScope(matchWord = false, matchTranslation = true))
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_label)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `no visual indicator differs on the tune icon regardless of active scope`() {
+        setContent(words = words, searchScope = SearchScope(matchWord = true, matchTranslation = false))
+
+        composeTestRule
+            .onAllNodesWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .assertCountEquals(1)
+    }
+
+    private fun openSearchScopeDialog() {
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .performClick()
+    }
+
+    @Test
     fun `clicking back button invokes onNavigateBack`() {
         setContent(words = words)
 
@@ -219,6 +425,8 @@ class WordListScreenTest {
         words: List<VocabularyItem>,
         searchQuery: String = "",
         onSearchQueryChangeOverride: ((String) -> Unit)? = null,
+        searchScope: SearchScope = SearchScope(),
+        onSearchScopeChangeOverride: ((SearchScope) -> Unit)? = null,
         selectionState: WordListViewModel.SelectionState = WordListViewModel.SelectionState(),
     ) {
         composeTestRule.setContent {
@@ -226,6 +434,8 @@ class WordListScreenTest {
                 words = words.toImmutableList(),
                 searchQuery = searchQuery,
                 onSearchQueryChange = onSearchQueryChangeOverride ?: {},
+                searchScope = searchScope,
+                onSearchScopeChange = onSearchScopeChangeOverride ?: {},
                 onDelete = onDelete,
                 onEdit = onEdit,
                 onReset = onReset,

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/WordListScreenTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
-import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -22,7 +21,6 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.procrastilearn.app.R
-import com.procrastilearn.app.domain.model.SearchScope
 import com.procrastilearn.app.domain.model.VocabularyItem
 import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
 import com.procrastilearn.app.ui.WordListViewModel
@@ -39,7 +37,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-@Suppress("LargeClass")
 class WordListScreenTest {
     private val composeTestRule = createComposeRule()
     private val dragStepCount = 10
@@ -96,257 +93,6 @@ class WordListScreenTest {
         setContent(words = emptyList())
 
         composeTestRule.onNodeWithText(string(R.string.word_list_empty)).assertIsDisplayed()
-    }
-
-    @Test
-    fun `shows all words when search query is empty`() {
-        setContent(words = words)
-
-        words.forEach { composeTestRule.onNodeWithText(it.word).assertIsDisplayed() }
-    }
-
-    @Test
-    fun `filters words by case-insensitive substring match`() {
-        setContent(words = words, searchQuery = "PE")
-
-        composeTestRule.onNodeWithText("Peregrinate").assertIsDisplayed()
-        composeTestRule.onAllNodesWithText("Serendipity").assertCountEquals(0)
-        composeTestRule.onAllNodesWithText("Ephemeral").assertCountEquals(0)
-    }
-
-    @Test
-    fun `trims whitespace from search query before filtering`() {
-        setContent(words = words, searchQuery = "  ephemeral  ")
-
-        composeTestRule.onNodeWithText("Ephemeral").assertIsDisplayed()
-        composeTestRule.onAllNodesWithText("Serendipity").assertCountEquals(0)
-    }
-
-    @Test
-    fun `shows no matches message when search has no results`() {
-        setContent(words = words, searchQuery = "xyz")
-
-        composeTestRule.onNodeWithText(string(R.string.word_list_search_no_results)).assertIsDisplayed()
-    }
-
-    @Test
-    fun `blank search query behaves as if it were empty`() {
-        setContent(words = words, searchQuery = "   ")
-
-        words.forEach { composeTestRule.onNodeWithText(it.word).assertIsDisplayed() }
-    }
-
-    @Test
-    fun `typing in search field invokes onSearchQueryChange`() {
-        var query: String? = null
-        setContent(words = words, onSearchQueryChangeOverride = { query = it })
-
-        composeTestRule.onNodeWithText(string(R.string.word_list_search_label)).performTextInput("Ser")
-
-        assertThat(query).isEqualTo("Ser")
-    }
-
-    @Test
-    fun `tune icon is visible in the search field`() {
-        setContent(words = words)
-
-        composeTestRule
-            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun `clicking the tune icon opens the search scope dialog`() {
-        setContent(words = words)
-
-        composeTestRule
-            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
-            .performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_title)).assertIsDisplayed()
-    }
-
-    @Test
-    fun `search scope dialog shows both checkboxes checked by default`() {
-        setContent(words = words, searchScope = SearchScope())
-
-        openSearchScopeDialog()
-
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
-        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").assertIsOn()
-    }
-
-    @Test
-    fun `search scope dialog seeds checkboxes from the currently applied scope, not always-default`() {
-        setContent(words = words, searchScope = SearchScope(matchWord = true, matchTranslation = false))
-
-        openSearchScopeDialog()
-
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
-        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").assertIsOff()
-    }
-
-    @Test
-    fun `unchecking one checkbox leaves Apply enabled and hides the error text`() {
-        setContent(words = words)
-        openSearchScopeDialog()
-
-        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsEnabled()
-        composeTestRule.onNodeWithTag("word_list_search_scope_error_text").assertDoesNotExist()
-    }
-
-    @Test
-    fun `unchecking both checkboxes disables Apply and shows the error text`() {
-        setContent(words = words)
-        openSearchScopeDialog()
-
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
-        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsNotEnabled()
-        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_error)).assertIsDisplayed()
-    }
-
-    @Test
-    fun `re-checking a box after reaching zero re-enables Apply`() {
-        setContent(words = words)
-        openSearchScopeDialog()
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
-        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
-
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsEnabled()
-        composeTestRule.onNodeWithTag("word_list_search_scope_error_text").assertDoesNotExist()
-    }
-
-    @Test
-    fun `clicking Apply with a modified scope invokes onSearchScopeChange with the new scope and closes the dialog`() {
-        var applied: SearchScope? = null
-        setContent(words = words, onSearchScopeChangeOverride = { applied = it })
-        openSearchScopeDialog()
-        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
-
-        assertThat(applied).isEqualTo(SearchScope(matchWord = true, matchTranslation = false))
-        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_title)).assertDoesNotExist()
-    }
-
-    @Test
-    fun `dismissing the dialog via Cancel does not invoke onSearchScopeChange and reverts unapplied changes`() {
-        var invoked = false
-        setContent(words = words, onSearchScopeChangeOverride = { invoked = true })
-        openSearchScopeDialog()
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
-
-        assertThat(invoked).isFalse()
-        openSearchScopeDialog()
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
-    }
-
-    @Test
-    fun `Apply button being disabled prevents onSearchScopeChange from being invoked`() {
-        var invoked = false
-        setContent(words = words, onSearchScopeChangeOverride = { invoked = true })
-        openSearchScopeDialog()
-        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
-        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
-
-        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
-
-        assertThat(invoked).isFalse()
-    }
-
-    @Test
-    fun `filtering with default both-checked scope matches by word (parity with pre-feature behavior)`() {
-        setContent(words = words, searchScope = SearchScope(), searchQuery = "PE")
-
-        composeTestRule.onNodeWithText("Peregrinate").assertIsDisplayed()
-        composeTestRule.onAllNodesWithText("Serendipity").assertCountEquals(0)
-        composeTestRule.onAllNodesWithText("Ephemeral").assertCountEquals(0)
-    }
-
-    @Test
-    fun `filtering with word-only scope excludes matches that are only in the translation field`() {
-        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
-        setContent(
-            words = words + extra,
-            searchScope = SearchScope(matchWord = true, matchTranslation = false),
-            searchQuery = "wildly",
-        )
-
-        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
-    }
-
-    @Test
-    fun `filtering with translation-only scope excludes matches that are only in the word field`() {
-        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
-        setContent(
-            words = words + extra,
-            searchScope = SearchScope(matchWord = false, matchTranslation = true),
-            searchQuery = "quixo",
-        )
-
-        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
-    }
-
-    @Test
-    fun `filtering with translation-only scope still matches items whose translation contains the query`() {
-        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
-        setContent(
-            words = words + extra,
-            searchScope = SearchScope(matchWord = false, matchTranslation = true),
-            searchQuery = "wildly",
-        )
-
-        composeTestRule.onNodeWithText("Quixotic").assertIsDisplayed()
-    }
-
-    @Test
-    fun `filtering with both scopes enabled shows an item only once when it matches in both fields`() {
-        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Quixotic-like folly", isNew = false)
-        setContent(words = words + extra, searchScope = SearchScope(), searchQuery = "quixo")
-
-        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(1)
-    }
-
-    @Test
-    fun `changing scope while a query is already active immediately re-filters the displayed list`() {
-        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
-        setContent(
-            words = words + extra,
-            searchQuery = "wildly",
-            searchScope = SearchScope(matchWord = true, matchTranslation = false),
-        )
-
-        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
-    }
-
-    @Test
-    fun `search field label is unchanged by the search scope`() {
-        setContent(words = words, searchScope = SearchScope(matchWord = false, matchTranslation = true))
-
-        composeTestRule.onNodeWithText(string(R.string.word_list_search_label)).assertIsDisplayed()
-    }
-
-    @Test
-    fun `no visual indicator differs on the tune icon regardless of active scope`() {
-        setContent(words = words, searchScope = SearchScope(matchWord = true, matchTranslation = false))
-
-        composeTestRule
-            .onAllNodesWithContentDescription(string(R.string.word_list_search_scope_content_description))
-            .assertCountEquals(1)
-    }
-
-    private fun openSearchScopeDialog() {
-        composeTestRule
-            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
-            .performClick()
     }
 
     @Test
@@ -425,8 +171,6 @@ class WordListScreenTest {
         words: List<VocabularyItem>,
         searchQuery: String = "",
         onSearchQueryChangeOverride: ((String) -> Unit)? = null,
-        searchScope: SearchScope = SearchScope(),
-        onSearchScopeChangeOverride: ((SearchScope) -> Unit)? = null,
         selectionState: WordListViewModel.SelectionState = WordListViewModel.SelectionState(),
     ) {
         composeTestRule.setContent {
@@ -434,8 +178,6 @@ class WordListScreenTest {
                 words = words.toImmutableList(),
                 searchQuery = searchQuery,
                 onSearchQueryChange = onSearchQueryChangeOverride ?: {},
-                searchScope = searchScope,
-                onSearchScopeChange = onSearchScopeChangeOverride ?: {},
                 onDelete = onDelete,
                 onEdit = onEdit,
                 onReset = onReset,

--- a/app/src/test/java/com/procrastilearn/app/ui/screens/WordListSearchTest.kt
+++ b/app/src/test/java/com/procrastilearn/app/ui/screens/WordListSearchTest.kt
@@ -1,0 +1,330 @@
+package com.procrastilearn.app.ui.screens
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.procrastilearn.app.R
+import com.procrastilearn.app.domain.model.SearchScope
+import com.procrastilearn.app.domain.model.VocabularyItem
+import com.procrastilearn.app.testing.ComponentActivityRegistrationRule
+import kotlinx.collections.immutable.toImmutableList
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WordListSearchTest {
+    private val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val rules: TestRule =
+        RuleChain
+            .outerRule(ComponentActivityRegistrationRule())
+            .around(composeTestRule)
+
+    private lateinit var context: Context
+
+    private val words =
+        listOf(
+            VocabularyItem(id = 1, word = "Serendipity", translation = "Happy accident", isNew = true),
+            VocabularyItem(id = 2, word = "Ephemeral", translation = "Short lived", isNew = false),
+            VocabularyItem(id = 3, word = "Peregrinate", translation = "To wander", isNew = false),
+        )
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    private fun string(resId: Int) = context.getString(resId)
+
+    @Test
+    fun `shows all words when search query is empty`() {
+        setContent(words = words)
+
+        words.forEach { composeTestRule.onNodeWithText(it.word).assertIsDisplayed() }
+    }
+
+    @Test
+    fun `filters words by case-insensitive substring match`() {
+        setContent(words = words, searchQuery = "PE")
+
+        composeTestRule.onNodeWithText("Peregrinate").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Serendipity").assertCountEquals(0)
+        composeTestRule.onAllNodesWithText("Ephemeral").assertCountEquals(0)
+    }
+
+    @Test
+    fun `trims whitespace from search query before filtering`() {
+        setContent(words = words, searchQuery = "  ephemeral  ")
+
+        composeTestRule.onNodeWithText("Ephemeral").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Serendipity").assertCountEquals(0)
+    }
+
+    @Test
+    fun `shows no matches message when search has no results`() {
+        setContent(words = words, searchQuery = "xyz")
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_no_results)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `blank search query behaves as if it were empty`() {
+        setContent(words = words, searchQuery = "   ")
+
+        words.forEach { composeTestRule.onNodeWithText(it.word).assertIsDisplayed() }
+    }
+
+    @Test
+    fun `typing in search field invokes onSearchQueryChange`() {
+        var query: String? = null
+        setContent(words = words, onSearchQueryChangeOverride = { query = it })
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_label)).performTextInput("Ser")
+
+        assertThat(query).isEqualTo("Ser")
+    }
+
+    @Test
+    fun `tune icon is visible in the search field`() {
+        setContent(words = words)
+
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `clicking the tune icon opens the search scope dialog`() {
+        setContent(words = words)
+
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `search scope dialog shows both checkboxes checked by default`() {
+        setContent(words = words, searchScope = SearchScope())
+
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").assertIsOn()
+    }
+
+    @Test
+    fun `search scope dialog seeds checkboxes from the currently applied scope, not always-default`() {
+        setContent(words = words, searchScope = SearchScope(matchWord = true, matchTranslation = false))
+
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").assertIsOff()
+    }
+
+    @Test
+    fun `unchecking one checkbox leaves Apply enabled and hides the error text`() {
+        setContent(words = words)
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsEnabled()
+        composeTestRule.onNodeWithTag("word_list_search_scope_error_text").assertDoesNotExist()
+    }
+
+    @Test
+    fun `unchecking both checkboxes disables Apply and shows the error text`() {
+        setContent(words = words)
+        openSearchScopeDialog()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsNotEnabled()
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_error)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `re-checking a box after reaching zero re-enables Apply`() {
+        setContent(words = words)
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).assertIsEnabled()
+        composeTestRule.onNodeWithTag("word_list_search_scope_error_text").assertDoesNotExist()
+    }
+
+    @Test
+    fun `clicking Apply with a modified scope invokes onSearchScopeChange with the new scope and closes the dialog`() {
+        var applied: SearchScope? = null
+        setContent(words = words, onSearchScopeChangeOverride = { applied = it })
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        assertThat(applied).isEqualTo(SearchScope(matchWord = true, matchTranslation = false))
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_scope_title)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `dismissing the dialog via Cancel does not invoke onSearchScopeChange and reverts unapplied changes`() {
+        var invoked = false
+        setContent(words = words, onSearchScopeChangeOverride = { invoked = true })
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_cancel)).performClick()
+
+        assertThat(invoked).isFalse()
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").assertIsOn()
+    }
+
+    @Test
+    fun `Apply button being disabled prevents onSearchScopeChange from being invoked`() {
+        var invoked = false
+        setContent(words = words, onSearchScopeChangeOverride = { invoked = true })
+        openSearchScopeDialog()
+        composeTestRule.onNodeWithTag("word_list_search_scope_word_checkbox").performClick()
+        composeTestRule.onNodeWithTag("word_list_search_scope_translation_checkbox").performClick()
+
+        composeTestRule.onNodeWithText(string(R.string.action_apply)).performClick()
+
+        assertThat(invoked).isFalse()
+    }
+
+    @Test
+    fun `filtering with default both-checked scope matches by word (parity with pre-feature behavior)`() {
+        setContent(words = words, searchScope = SearchScope(), searchQuery = "PE")
+
+        composeTestRule.onNodeWithText("Peregrinate").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Serendipity").assertCountEquals(0)
+        composeTestRule.onAllNodesWithText("Ephemeral").assertCountEquals(0)
+    }
+
+    @Test
+    fun `filtering with word-only scope excludes matches that are only in the translation field`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchScope = SearchScope(matchWord = true, matchTranslation = false),
+            searchQuery = "wildly",
+        )
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
+    }
+
+    @Test
+    fun `filtering with translation-only scope excludes matches that are only in the word field`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchScope = SearchScope(matchWord = false, matchTranslation = true),
+            searchQuery = "quixo",
+        )
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
+    }
+
+    @Test
+    fun `filtering with translation-only scope still matches items whose translation contains the query`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchScope = SearchScope(matchWord = false, matchTranslation = true),
+            searchQuery = "wildly",
+        )
+
+        composeTestRule.onNodeWithText("Quixotic").assertIsDisplayed()
+    }
+
+    @Test
+    fun `filtering with both scopes enabled shows an item only once when it matches in both fields`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Quixotic-like folly", isNew = false)
+        setContent(words = words + extra, searchScope = SearchScope(), searchQuery = "quixo")
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(1)
+    }
+
+    @Test
+    fun `changing scope while a query is already active immediately re-filters the displayed list`() {
+        val extra = VocabularyItem(id = 4, word = "Quixotic", translation = "Wildly impractical scheme", isNew = false)
+        setContent(
+            words = words + extra,
+            searchQuery = "wildly",
+            searchScope = SearchScope(matchWord = true, matchTranslation = false),
+        )
+
+        composeTestRule.onAllNodesWithText("Quixotic").assertCountEquals(0)
+    }
+
+    @Test
+    fun `search field label is unchanged by the search scope`() {
+        setContent(words = words, searchScope = SearchScope(matchWord = false, matchTranslation = true))
+
+        composeTestRule.onNodeWithText(string(R.string.word_list_search_label)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `no visual indicator differs on the tune icon regardless of active scope`() {
+        setContent(words = words, searchScope = SearchScope(matchWord = true, matchTranslation = false))
+
+        composeTestRule
+            .onAllNodesWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .assertCountEquals(1)
+    }
+
+    private fun openSearchScopeDialog() {
+        composeTestRule
+            .onNodeWithContentDescription(string(R.string.word_list_search_scope_content_description))
+            .performClick()
+    }
+
+    private fun setContent(
+        words: List<VocabularyItem>,
+        searchQuery: String = "",
+        onSearchQueryChangeOverride: ((String) -> Unit)? = null,
+        searchScope: SearchScope = SearchScope(),
+        onSearchScopeChangeOverride: ((SearchScope) -> Unit)? = null,
+    ) {
+        composeTestRule.setContent {
+            WordListContent(
+                words = words.toImmutableList(),
+                searchQuery = searchQuery,
+                onSearchQueryChange = onSearchQueryChangeOverride ?: {},
+                searchScope = searchScope,
+                onSearchScopeChange = onSearchScopeChangeOverride ?: {},
+                onDelete = {},
+                onEdit = {},
+                onReset = {},
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description

The word list search field only matched the `word` field, so users couldn't find a card by its translation. This adds a tune icon to the search bar that opens a "Search in" dialog letting users choose Word, Translation, or both. At least one option must stay checked (Apply is disabled otherwise, with an inline error). The choice is persisted via DataStore and applied immediately to the active search query.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Added `SearchScope` domain model (`matchWord`, `matchTranslation`, `isValid`).
- Added `WordListSearchPreferencesStore` (DataStore-backed, defaults to both `true`), following the existing `LanguagePreferencesStore` pattern — reuses `StudyPreferencesDataStore`'s underlying store, no new Hilt module needed.
- `WordListViewModel` now exposes `searchScope: StateFlow<SearchScope>` and `setSearchScope(...)`, guarding against ever persisting an all-false scope.
- Added `WordListSearchScopeDialog`: an `AlertDialog` titled "Search in" with Word/Translation checkboxes, Apply (disabled + error text when nothing is checked) and Cancel buttons. Dismissing (Cancel, back, tap-outside) discards unapplied changes.
- Added a trailing `Icons.Default.Tune` icon inside the existing search field that opens the dialog.
- Updated the word-list filter predicate to respect the active scope (word-only / translation-only / both, with no duplicate results when both fields match).
- Added `action_apply` and `word_list_search_scope_*` strings, translated into all 15 supported locales (reusing existing `add_word_label_word`/`add_word_label_translation` values where identical, to avoid `DuplicateStrings` lint errors).
- Exposed `WordListSearchPreferencesStore` via `PreferencesEntryPoint` so instrumented tests can reset/verify persisted scope directly.

## How to Test

1. Open the word list, add a couple of words where the query matches only the word or only the translation.
2. Tap the tune icon next to the search field — a "Search in" dialog appears with Word and Translation both checked.
3. Uncheck one option, confirm Apply stays enabled with one checked, then uncheck the other — Apply disables and an error appears. Re-check one to re-enable Apply.
4. Apply a word-only or translation-only scope and confirm the search results respect it; confirm Cancel/back/outside-tap discards the change.
5. Restart the app and confirm the applied scope persisted.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable, including edge cases (unit tests for the new DataStore, ViewModel, and dialog/filter UI behavior, plus new instrumented e2e tests)
- [x] Existing tests pass locally (`ktlintCheck`, `detekt`, `lintDebug`, `testDebugUnitTest` all green; instrumented tests can't run in this environment — CI will exercise them)
- [ ] Updated documentation if needed (no user-facing docs exist for this screen)
- [x] No duplication introduced. I searched the existing code for similar behavior and extracted similar parts to be reused
- [ ] No new warnings or suppressions introduced — added `@Suppress("LargeClass")` to `WordListScreenTest` since detekt's LargeClass threshold was crossed by the added tests; this mirrors the existing precedent in `AddWordViewModelTest.kt` and `AppDatabaseMigrationTest.kt`. Flagging for maintainer approval per the checklist above.

## Related Issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_015XGRLhEFhas98XzK474dHc)_